### PR TITLE
Rebranding in docs/manual/

### DIFF
--- a/docs/manual/_index.md
+++ b/docs/manual/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Use Redis"
-linkTitle: "Use Redis"
-description: A developer's guide to Redis
+title: "Use Valkey"
+linkTitle: "Use Valkey"
+description: A developer's guide to Valkey
 weight: 50
 ---

--- a/docs/manual/client-side-caching.md
+++ b/docs/manual/client-side-caching.md
@@ -1,9 +1,9 @@
 ---
-title: "Client-side caching in Redis"
+title: "Client-side caching in Valkey"
 linkTitle: "Client-side caching"
 weight: 2
 description: >
-    Server-assisted, client-side caching in Redis
+    Server-assisted, client-side caching in Valkey
 aliases:
     - /topics/client-side-caching
 ---
@@ -69,7 +69,7 @@ may continue to serve the old username for user:1234.
 Sometimes, depending on the exact application we are modeling, this isn't a
 big deal, so the client will just use a fixed maximum "time to live" for the
 cached information. Once a given amount of time has elapsed, the information
-will no longer be considered valid. More complex patterns, when using Redis,
+will no longer be considered valid. More complex patterns, when using Valkey,
 leverage the Pub/Sub system in order to send invalidation messages to
 listening clients. This can be made to work but is tricky and costly from
 the point of view of the bandwidth used, because often such patterns involve
@@ -85,9 +85,9 @@ reason Redis 6 implements direct support for client-side caching, in order
 to make this pattern much simpler to implement, more accessible, reliable,
 and efficient.
 
-## The Redis implementation of client-side caching
+## The Valkey implementation of client-side caching
 
-The Redis client-side caching support is called _Tracking_, and has two modes:
+The Valkey client-side caching support is called _Tracking_, and has two modes:
 
 * In the default mode, the server remembers what keys a given client accessed, and sends invalidation messages when the same keys are modified. This costs memory in the server side, but sends invalidation messages only for the set of keys that the client might have in memory.
 * In the _broadcasting_ mode, the server does not attempt to remember what keys a given client accessed, so this mode costs no memory at all in the server side. Instead clients subscribe to key prefixes such as `object:` or `user:`, and receive a notification message every time a key matching a subscribed prefix is touched.
@@ -111,21 +111,21 @@ This is an example of the protocol:
 
 This looks great superficially, but if you imagine 10k connected clients all
 asking for millions of keys over long living connection, the server ends up
-storing too much information. For this reason Redis uses two key ideas in
+storing too much information. For this reason Valkey uses two key ideas in
 order to limit the amount of memory used server-side and the CPU cost of
 handling the data structures implementing the feature:
 
 * The server remembers the list of clients that may have cached a given key in a single global table. This table is called the **Invalidation Table**. The invalidation table can contain a maximum number of entries. If a new key is inserted, the server may evict an older entry by pretending that such key was modified (even if it was not), and sending an invalidation message to the clients. Doing so, it can reclaim the memory used for this key, even if this will force the clients having a local copy of the key to evict it.
-* Inside the invalidation table we don't really need to store pointers to clients' structures, that would force a garbage collection procedure when the client disconnects: instead what we do is just store client IDs (each Redis client has a unique numerical ID). If a client disconnects, the information will be incrementally garbage collected as caching slots are invalidated.
+* Inside the invalidation table we don't really need to store pointers to clients' structures, that would force a garbage collection procedure when the client disconnects: instead what we do is just store client IDs (each Valkey client has a unique numerical ID). If a client disconnects, the information will be incrementally garbage collected as caching slots are invalidated.
 * There is a single keys namespace, not divided by database numbers. So if a client is caching the key `foo` in database 2, and some other client changes the value of the key `foo` in database 3, an invalidation message will still be sent. This way we can ignore database numbers reducing both the memory usage and the implementation complexity.
 
 ## Two connections mode
 
-Using the new version of the Redis protocol, RESP3, supported by Redis 6, it is possible to run the data queries and receive the invalidation messages in the same connection. However many client implementations may prefer to implement client-side caching using two separated connections: one for data, and one for invalidation messages. For this reason when a client enables tracking, it can specify to redirect the invalidation messages to another connection by specifying the "client ID" of a different connection. Many data connections can redirect invalidation messages to the same connection, this is useful for clients implementing connection pooling. The two connections model is the only one that is also supported for RESP2 (which lacks the ability to multiplex different kind of information in the same connection).
+Using the new version of the Valkey protocol, RESP3, supported by Redis 6, it is possible to run the data queries and receive the invalidation messages in the same connection. However many client implementations may prefer to implement client-side caching using two separated connections: one for data, and one for invalidation messages. For this reason when a client enables tracking, it can specify to redirect the invalidation messages to another connection by specifying the "client ID" of a different connection. Many data connections can redirect invalidation messages to the same connection, this is useful for clients implementing connection pooling. The two connections model is the only one that is also supported for RESP2 (which lacks the ability to multiplex different kind of information in the same connection).
 
-Here's an example of a complete session using the Redis protocol in the old RESP2 mode involving the following steps: enabling tracking redirecting to another connection, asking for a key, and getting an invalidation message once the key gets modified.
+Here's an example of a complete session using the Valkey protocol in the old RESP2 mode involving the following steps: enabling tracking redirecting to another connection, asking for a key, and getting an invalidation message once the key gets modified.
 
-To start, the client opens a first connection that will be used for invalidations, requests the connection ID, and subscribes via Pub/Sub to the special channel that is used to get invalidation messages when in RESP2 modes (remember that RESP2 is the usual Redis protocol, and not the more advanced protocol that you can use, optionally, with Redis 6 using the `HELLO` command):
+To start, the client opens a first connection that will be used for invalidations, requests the connection ID, and subscribes via Pub/Sub to the special channel that is used to get invalidation messages when in RESP2 modes (remember that RESP2 is the usual Valkey protocol, and not the more advanced protocol that you can use, optionally, with Redis 6 using the `HELLO` command):
 
 ```
 (Connection 1 -- used for invalidations)
@@ -178,7 +178,7 @@ foo
 The client will check if there are cached keys in this caching slot, and will evict the information that is no longer valid.
 
 Note that the third element of the Pub/Sub message is not a single key but
-is a Redis array with just a single element. Since we send an array, if there
+is a Valkey array with just a single element. Since we send an array, if there
 are groups of keys to invalidate, we can do that in a single message.
 In case of a flush (`FLUSHALL` or `FLUSHDB`), a `null` message will be sent.
 
@@ -244,7 +244,7 @@ commands executed by the script will be tracked.
 
 ## Broadcasting mode
 
-So far we described the first client-side caching model that Redis implements.
+So far we described the first client-side caching model that Valkey implements.
 There is another one, called broadcasting, that sees the problem from the
 point of view of a different tradeoff, does not consume any memory on the
 server side, but instead sends more invalidation messages to clients.
@@ -329,7 +329,7 @@ keys that were not served recently.
 * Putting a max TTL on every key is a good idea, even if it has no TTL. This protects against bugs or connection issues that would make the client have old data in the local copy.
 * Limiting the amount of memory used by clients is absolutely needed. There must be a way to evict old keys when new ones are added.
 
-## Limiting the amount of memory used by Redis
+## Limiting the amount of memory used by Valkey
 
-Be sure to configure a suitable value for the maximum number of keys remembered by Redis or alternatively use the BCAST mode that consumes no memory at all on the Redis side. Note that the memory consumed by Redis when BCAST is not used, is proportional both to the number of keys tracked and the number of clients requesting such keys.
+Be sure to configure a suitable value for the maximum number of keys remembered by Valkey or alternatively use the BCAST mode that consumes no memory at all on the Valkey side. Note that the memory consumed by Valkey when BCAST is not used, is proportional both to the number of keys tracked and the number of clients requesting such keys.
 

--- a/docs/manual/client-side-caching.md
+++ b/docs/manual/client-side-caching.md
@@ -81,7 +81,7 @@ command, costing the database more CPU time to process this command.
 Regardless of what schema is used, there is a simple fact: many very large
 applications implement some form of client-side caching, because it is the
 next logical step to having a fast store or a fast cache server. For this
-reason Redis 6 implements direct support for client-side caching, in order
+reason Valkey implements direct support for client-side caching, in order
 to make this pattern much simpler to implement, more accessible, reliable,
 and efficient.
 
@@ -121,11 +121,11 @@ handling the data structures implementing the feature:
 
 ## Two connections mode
 
-Using the new version of the Valkey protocol, RESP3, supported by Redis 6, it is possible to run the data queries and receive the invalidation messages in the same connection. However many client implementations may prefer to implement client-side caching using two separated connections: one for data, and one for invalidation messages. For this reason when a client enables tracking, it can specify to redirect the invalidation messages to another connection by specifying the "client ID" of a different connection. Many data connections can redirect invalidation messages to the same connection, this is useful for clients implementing connection pooling. The two connections model is the only one that is also supported for RESP2 (which lacks the ability to multiplex different kind of information in the same connection).
+Using the new version of the Valkey protocol, RESP3, it is possible to run the data queries and receive the invalidation messages in the same connection. However many client implementations may prefer to implement client-side caching using two separated connections: one for data, and one for invalidation messages. For this reason when a client enables tracking, it can specify to redirect the invalidation messages to another connection by specifying the "client ID" of a different connection. Many data connections can redirect invalidation messages to the same connection, this is useful for clients implementing connection pooling. The two connections model is the only one that is also supported for RESP2 (which lacks the ability to multiplex different kind of information in the same connection).
 
 Here's an example of a complete session using the Valkey protocol in the old RESP2 mode involving the following steps: enabling tracking redirecting to another connection, asking for a key, and getting an invalidation message once the key gets modified.
 
-To start, the client opens a first connection that will be used for invalidations, requests the connection ID, and subscribes via Pub/Sub to the special channel that is used to get invalidation messages when in RESP2 modes (remember that RESP2 is the usual Valkey protocol, and not the more advanced protocol that you can use, optionally, with Redis 6 using the `HELLO` command):
+To start, the client opens a first connection that will be used for invalidations, requests the connection ID, and subscribes via Pub/Sub to the special channel that is used to get invalidation messages when in RESP2 modes (remember that RESP2 is the usual Valkey protocol, and not the more advanced protocol that you can use, optionally, using the `HELLO` command):
 
 ```
 (Connection 1 -- used for invalidations)

--- a/docs/manual/keyspace.md
+++ b/docs/manual/keyspace.md
@@ -3,12 +3,12 @@ title: "Keyspace"
 linkTitle: "Keyspace"
 weight: 1
 description: >
-    Managing keys in Redis: Key expiration, scanning, altering and querying the key space
+    Managing keys in Valkey: Key expiration, scanning, altering and querying the key space
 aliases:
   - /docs/manual/the-redis-keyspace    
 ---
 
-Redis keys are binary safe; this means that you can use any binary sequence as a
+Valkey keys are binary safe; this means that you can use any binary sequence as a
 key, from a string like "foo" to the content of a JPEG file.
 The empty string is also a valid key.
 
@@ -68,13 +68,13 @@ of value stored at the specified key:
 
 ## Key expiration
 
-Before moving on, we should look at an important Redis feature that works regardless of the type of value you're storing: key expiration. Key expiration lets you set a timeout for a key, also known as a "time to live", or "TTL". When the time to live elapses, the key is automatically destroyed. 
+Before moving on, we should look at an important Valkey feature that works regardless of the type of value you're storing: key expiration. Key expiration lets you set a timeout for a key, also known as a "time to live", or "TTL". When the time to live elapses, the key is automatically destroyed. 
 
 A few important notes about key expiration:
 
 * They can be set both using seconds or milliseconds precision.
 * However the expire time resolution is always 1 millisecond.
-* Information about expires are replicated and persisted on disk, the time virtually passes when your Redis server remains stopped (this means that Redis saves the date at which a key will expire).
+* Information about expires are replicated and persisted on disk, the time virtually passes when your Valkey server remains stopped (this means that Valkey saves the date at which a key will expire).
 
 Use the `EXPIRE` command to set a key's expiration:
 
@@ -92,7 +92,7 @@ delayed more than 5 seconds. In the example above we used `EXPIRE` in
 order to set the expire (it can also be used in order to set a different
 expire to a key already having one, like `PERSIST` can be used in order
 to remove the expire and make the key persistent forever). However we
-can also create keys with expires using other Redis commands. For example
+can also create keys with expires using other Valkey commands. For example
 using `SET` options:
 
     > set key 100 ex 10
@@ -110,7 +110,7 @@ the `PTTL` commands, and the full list of `SET` options.
 ## Navigating the keyspace
 
 ### Scan
-To incrementally  iterate over the keys in a Redis database in an efficient manner, you can use the `SCAN` command.
+To incrementally  iterate over the keys in a Valkey database in an efficient manner, you can use the `SCAN` command.
 
 Since `SCAN` allows for incremental iteration, returning only a small number of elements per call, it can be used in production without the downside of commands like `KEYS` or `SMEMBERS` that may block the server for a long time (even several seconds) when called against big collections of keys or elements.
 
@@ -119,7 +119,7 @@ The `SCAN` family of commands only offer limited guarantees about the returned e
 
 ### Keys
 
-Another way to iterate over the keyspace is to use the `KEYS` command, but this approach should be used with care, since `KEYS` will block the Redis server until all keys are returned.
+Another way to iterate over the keyspace is to use the `KEYS` command, but this approach should be used with care, since `KEYS` will block the Valkey server until all keys are returned.
 
 **Warning**: consider `KEYS` as a command that should only be used in production
 environments with extreme care.

--- a/docs/manual/patterns/_index.md
+++ b/docs/manual/patterns/_index.md
@@ -1,11 +1,11 @@
 ---
-title: "Redis programming patterns"
+title: "Valkey programming patterns"
 linkTitle: "Patterns"
-description: Novel patterns for working with Redis data structures
+description: Novel patterns for working with Valkey data structures
 weight: 6
 aliases: [
     /docs/reference/patterns
 ]
 ---
 
-The following documents describe some novel development patterns you can use with Redis.
+The following documents describe some novel development patterns you can use with Valkey.

--- a/docs/manual/patterns/bulk-loading.md
+++ b/docs/manual/patterns/bulk-loading.md
@@ -44,8 +44,8 @@ as fast as possible. In the past the way to do this was to use the
 
 However this is not a very reliable way to perform mass import because netcat
 does not really know when all the data was transferred and can't check for
-errors. In 2.6 or later versions of Valkey the `valkey-cli` utility
-supports a new mode called **pipe mode** that was designed in order to perform
+errors. The `valkey-cli` utility
+supports a **pipe mode** that was designed to perform
 bulk loading.
 
 Using the pipe mode the command to run looks like the following:

--- a/docs/manual/patterns/bulk-loading.md
+++ b/docs/manual/patterns/bulk-loading.md
@@ -44,13 +44,13 @@ as fast as possible. In the past the way to do this was to use the
 
 However this is not a very reliable way to perform mass import because netcat
 does not really know when all the data was transferred and can't check for
-errors. In 2.6 or later versions of Valkey the `redis-cli` utility
+errors. In 2.6 or later versions of Valkey the `valkey-cli` utility
 supports a new mode called **pipe mode** that was designed in order to perform
 bulk loading.
 
 Using the pipe mode the command to run looks like the following:
 
-    cat data.txt | redis-cli --pipe
+    cat data.txt | valkey-cli --pipe
 
 That will produce an output similar to this:
 
@@ -58,7 +58,7 @@ That will produce an output similar to this:
     Last reply received from server.
     errors: 0, replies: 1000000
 
-The redis-cli utility will also make sure to only redirect errors received
+The valkey-cli utility will also make sure to only redirect errors received
 from the Valkey instance to the standard output.
 
 ### Generating Valkey Protocol
@@ -115,23 +115,23 @@ in the above example, with this program:
         STDOUT.write(gen_redis_proto("SET","Key#{n}","Value#{n}"))
     }
 
-We can run the program directly in pipe to redis-cli in order to perform our
+We can run the program directly in pipe to valkey-cli in order to perform our
 first mass import session.
 
-    $ ruby proto.rb | redis-cli --pipe
+    $ ruby proto.rb | valkey-cli --pipe
     All data transferred. Waiting for the last reply...
     Last reply received from server.
     errors: 0, replies: 1000
 
 ### How the pipe mode works under the hood
 
-The magic needed inside the pipe mode of redis-cli is to be as fast as netcat
+The magic needed inside the pipe mode of valkey-cli is to be as fast as netcat
 and still be able to understand when the last reply was sent by the server
 at the same time.
 
 This is obtained in the following way:
 
-+ redis-cli --pipe tries to send data as fast as possible to the server.
++ valkey-cli --pipe tries to send data as fast as possible to the server.
 + At the same time it reads data when available, trying to parse it.
 + Once there is no more data to read from stdin, it sends a special **ECHO**
 command with a random 20 byte string: we are sure this is the latest command

--- a/docs/manual/patterns/bulk-loading.md
+++ b/docs/manual/patterns/bulk-loading.md
@@ -3,18 +3,18 @@ title: "Bulk loading"
 linkTitle: "Bulk loading"
 weight: 1
 description: >
-    Writing data in bulk using the Redis protocol
+    Writing data in bulk using the Valkey protocol
 aliases: [
     /topics/mass-insertion,
     /docs/reference/patterns/bulk-loading
 ]
 ---
 
-Bulk loading is the process of loading Redis with a large amount of pre-existing data. Ideally, you want to perform this operation quickly and efficiently. This document describes some strategies for bulk loading data in Redis.
+Bulk loading is the process of loading Valkey with a large amount of pre-existing data. Ideally, you want to perform this operation quickly and efficiently. This document describes some strategies for bulk loading data in Valkey.
 
-## Bulk loading using the Redis protocol
+## Bulk loading using the Valkey protocol
 
-Using a normal Redis client to perform bulk loading is not a good idea
+Using a normal Valkey client to perform bulk loading is not a good idea
 for a few reasons: the naive approach of sending one command after the other
 is slow because you have to pay for the round trip time for every command.
 It is possible to use pipelining, but for bulk loading of many records
@@ -24,19 +24,19 @@ make sure you are inserting as fast as possible.
 Only a small percentage of clients support non-blocking I/O, and not all the
 clients are able to parse the replies in an efficient way in order to maximize
 throughput. For all of these reasons the preferred way to mass import data into
-Redis is to generate a text file containing the Redis protocol, in raw format,
+Valkey is to generate a text file containing the Valkey protocol, in raw format,
 in order to call the commands needed to insert the required data.
 
 For instance if I need to generate a large data set where there are billions
 of keys in the form: `keyN -> ValueN' I will create a file containing the
-following commands in the Redis protocol format:
+following commands in the Valkey protocol format:
 
     SET Key0 Value0
     SET Key1 Value1
     ...
     SET KeyN ValueN
 
-Once this file is created, the remaining action is to feed it to Redis
+Once this file is created, the remaining action is to feed it to Valkey
 as fast as possible. In the past the way to do this was to use the
 `netcat` with the following command:
 
@@ -44,7 +44,7 @@ as fast as possible. In the past the way to do this was to use the
 
 However this is not a very reliable way to perform mass import because netcat
 does not really know when all the data was transferred and can't check for
-errors. In 2.6 or later versions of Redis the `redis-cli` utility
+errors. In 2.6 or later versions of Valkey the `redis-cli` utility
 supports a new mode called **pipe mode** that was designed in order to perform
 bulk loading.
 
@@ -59,11 +59,11 @@ That will produce an output similar to this:
     errors: 0, replies: 1000000
 
 The redis-cli utility will also make sure to only redirect errors received
-from the Redis instance to the standard output.
+from the Valkey instance to the standard output.
 
-### Generating Redis Protocol
+### Generating Valkey Protocol
 
-The Redis protocol is extremely simple to generate and parse, and is
+The Valkey protocol is extremely simple to generate and parse, and is
 [Documented here](/topics/protocol). However in order to generate protocol for
 the goal of bulk loading you don't need to understand every detail of the
 protocol, but just that every command is represented in the following way:

--- a/docs/manual/patterns/distributed-locks.md
+++ b/docs/manual/patterns/distributed-locks.md
@@ -1,9 +1,9 @@
 ---
-title: "Distributed Locks with Redis"
+title: "Distributed Locks with Valkey"
 linkTitle: "Distributed locks"
 weight: 1
 description: >
-    A distributed lock pattern with Redis
+    A distributed lock pattern with Valkey
 aliases: [
     /topics/distlock,
     /docs/reference/patterns/distributed-locks,
@@ -15,12 +15,12 @@ different processes must operate with shared resources in a mutually
 exclusive way.
 
 There are a number of libraries and blog posts describing how to implement
-a DLM (Distributed Lock Manager) with Redis, but every library uses a different
+a DLM (Distributed Lock Manager) with Valkey, but every library uses a different
 approach, and many use a simple approach with lower guarantees compared to
 what can be achieved with slightly more complex designs.
 
 This page describes a more canonical algorithm to implement
-distributed locks with Redis. We propose an algorithm, called **Redlock**,
+distributed locks with Valkey. We propose an algorithm, called **Redlock**,
 which implements a DLM which we believe to be safer than the vanilla single
 instance approach. We hope that the community will analyze it, provide
 feedback, and use it as a starting point for the implementations or more
@@ -58,16 +58,16 @@ We are going to model our design with just three properties that, from our point
 
 1. Safety property: Mutual exclusion. At any given moment, only one client can hold a lock.
 2. Liveness property A: Deadlock free. Eventually it is always possible to acquire a lock, even if the client that locked a resource crashes or gets partitioned.
-3. Liveness property B: Fault tolerance. As long as the majority of Redis nodes are up, clients are able to acquire and release locks.
+3. Liveness property B: Fault tolerance. As long as the majority of Valkey nodes are up, clients are able to acquire and release locks.
 
 ## Why Failover-based Implementations Are Not Enough
 
-To understand what we want to improve, let’s analyze the current state of affairs with most Redis-based distributed lock libraries.
+To understand what we want to improve, let’s analyze the current state of affairs with most Valkey-based distributed lock libraries.
 
-The simplest way to use Redis to lock a resource is to create a key in an instance. The key is usually created with a limited time to live, using the Redis expires feature, so that eventually it will get released (property 2 in our list). When the client needs to release the resource, it deletes the key.
+The simplest way to use Valkey to lock a resource is to create a key in an instance. The key is usually created with a limited time to live, using the Valkey expires feature, so that eventually it will get released (property 2 in our list). When the client needs to release the resource, it deletes the key.
 
-Superficially this works well, but there is a problem: this is a single point of failure in our architecture. What happens if the Redis master goes down?
-Well, let’s add a replica! And use it if the master is unavailable. This is unfortunately not viable. By doing so we can’t implement our safety property of mutual exclusion, because Redis replication is asynchronous.
+Superficially this works well, but there is a problem: this is a single point of failure in our architecture. What happens if the Valkey master goes down?
+Well, let’s add a replica! And use it if the master is unavailable. This is unfortunately not viable. By doing so we can’t implement our safety property of mutual exclusion, because Valkey replication is asynchronous.
 
 There is a race condition with this model:
 
@@ -90,7 +90,7 @@ To acquire the lock, the way to go is the following:
 The command will set the key only if it does not already exist (`NX` option), with an expire of 30000 milliseconds (`PX` option).
 The key is set to a value “my\_random\_value”. This value must be unique across all clients and all lock requests.
 
-Basically the random value is used in order to release the lock in a safe way, with a script that tells Redis: remove the key only if it exists and the value stored at the key is exactly the one I expect to be. This is accomplished by the following Lua script:
+Basically the random value is used in order to release the lock in a safe way, with a script that tells Valkey: remove the key only if it exists and the value stored at the key is exactly the one I expect to be. This is accomplished by the following Lua script:
 
     if redis.call("get",KEYS[1]) == ARGV[1] then
         return redis.call("del",KEYS[1])
@@ -111,12 +111,12 @@ So now we have a good way to acquire and release the lock. With this system, rea
 
 ## The Redlock Algorithm
 
-In the distributed version of the algorithm we assume we have N Redis masters. Those nodes are totally independent, so we don’t use replication or any other implicit coordination system. We already described how to acquire and release the lock safely in a single instance. We take for granted that the algorithm will use this method to acquire and release the lock in a single instance. In our examples we set N=5, which is a reasonable value, so we need to run 5 Redis masters on different computers or virtual machines in order to ensure that they’ll fail in a mostly independent way.
+In the distributed version of the algorithm we assume we have N Valkey masters. Those nodes are totally independent, so we don’t use replication or any other implicit coordination system. We already described how to acquire and release the lock safely in a single instance. We take for granted that the algorithm will use this method to acquire and release the lock in a single instance. In our examples we set N=5, which is a reasonable value, so we need to run 5 Valkey masters on different computers or virtual machines in order to ensure that they’ll fail in a mostly independent way.
 
 In order to acquire the lock, the client performs the following operations:
 
 1. It gets the current time in milliseconds.
-2. It tries to acquire the lock in all the N instances sequentially, using the same key name and random value in all the instances. During step 2, when setting the lock in each instance, the client uses a timeout which is small compared to the total lock auto-release time in order to acquire it. For example if the auto-release time is 10 seconds, the timeout could be in the ~ 5-50 milliseconds range. This prevents the client from remaining blocked for a long time trying to talk with a Redis node which is down: if an instance is not available, we should try to talk with the next instance ASAP.
+2. It tries to acquire the lock in all the N instances sequentially, using the same key name and random value in all the instances. During step 2, when setting the lock in each instance, the client uses a timeout which is small compared to the total lock auto-release time in order to acquire it. For example if the auto-release time is 10 seconds, the timeout could be in the ~ 5-50 milliseconds range. This prevents the client from remaining blocked for a long time trying to talk with a Valkey node which is down: if an instance is not available, we should try to talk with the next instance ASAP.
 3. The client computes how much time elapsed in order to acquire the lock, by subtracting from the current time the timestamp obtained in step 1. If and only if the client was able to acquire the lock in the majority of the instances (at least 3), and the total time elapsed to acquire the lock is less than lock validity time, the lock is considered to be acquired.
 4. If the lock was acquired, its validity time is considered to be the initial validity time minus the time elapsed, as computed in step 3.
 5. If the client failed to acquire the lock for some reason (either it was not able to lock N/2+1 instances or the validity time is negative), it will try to unlock all the instances (even the instances it believed it was not able to lock).
@@ -131,9 +131,9 @@ This paper contains more information about similar systems requiring a bound *cl
 
 ### Retry on Failure
 
-When a client is unable to acquire the lock, it should try again after a random delay in order to try to desynchronize multiple clients trying to acquire the lock for the same resource at the same time (this may result in a split brain condition where nobody wins). Also the faster a client tries to acquire the lock in the majority of Redis instances, the smaller the window for a split brain condition (and the need for a retry), so ideally the client should try to send the `SET` commands to the N instances at the same time using multiplexing.
+When a client is unable to acquire the lock, it should try again after a random delay in order to try to desynchronize multiple clients trying to acquire the lock for the same resource at the same time (this may result in a split brain condition where nobody wins). Also the faster a client tries to acquire the lock in the majority of Valkey instances, the smaller the window for a split brain condition (and the need for a retry), so ideally the client should try to send the `SET` commands to the N instances at the same time using multiplexing.
 
-It is worth stressing how important it is for clients that fail to acquire the majority of locks, to release the (partially) acquired locks ASAP, so that there is no need to wait for key expiry in order for the lock to be acquired again (however if a network partition happens and the client is no longer able to communicate with the Redis instances, there is an availability penalty to pay as it waits for key expiration).
+It is worth stressing how important it is for clients that fail to acquire the majority of locks, to release the (partially) acquired locks ASAP, so that there is no need to wait for key expiry in order for the lock to be acquired again (however if a network partition happens and the client is no longer able to communicate with the Valkey instances, there is an availability penalty to pay as it waits for key expiration).
 
 ### Releasing the Lock
 
@@ -166,14 +166,14 @@ Basically if there are infinite continuous network partitions, the system may be
 
 ### Performance, Crash Recovery and fsync
 
-Many users using Redis as a lock server need high performance in terms of both latency to acquire and release a lock, and number of acquire / release operations that it is possible to perform per second. In order to meet this requirement, the strategy to talk with the N Redis servers to reduce latency is definitely multiplexing (putting the socket in non-blocking mode, send all the commands, and read all the commands later, assuming that the RTT between the client and each instance is similar).
+Many users using Valkey as a lock server need high performance in terms of both latency to acquire and release a lock, and number of acquire / release operations that it is possible to perform per second. In order to meet this requirement, the strategy to talk with the N Valkey servers to reduce latency is definitely multiplexing (putting the socket in non-blocking mode, send all the commands, and read all the commands later, assuming that the RTT between the client and each instance is similar).
 
 However there is another consideration around persistence if we want to target a crash-recovery system model.
 
-Basically to see the problem here, let’s assume we configure Redis without persistence at all. A client acquires the lock in 3 of 5 instances. One of the instances where the client was able to acquire the lock is restarted, at this point there are again 3 instances that we can lock for the same resource, and another client can lock it again, violating the safety property of exclusivity of lock.
+Basically to see the problem here, let’s assume we configure Valkey without persistence at all. A client acquires the lock in 3 of 5 instances. One of the instances where the client was able to acquire the lock is restarted, at this point there are again 3 instances that we can lock for the same resource, and another client can lock it again, violating the safety property of exclusivity of lock.
 
-If we enable AOF persistence, things will improve quite a bit. For example we can upgrade a server by sending it a `SHUTDOWN` command and restarting it. Because Redis expires are semantically implemented so that time still elapses when the server is off, all our requirements are fine.
-However everything is fine as long as it is a clean shutdown. What about a power outage? If Redis is configured, as by default, to fsync on disk every second, it is possible that after a restart our key is missing. In theory, if we want to guarantee the lock safety in the face of any kind of instance restart, we need to enable `fsync=always` in the persistence settings. This will affect performance due to the additional sync overhead.
+If we enable AOF persistence, things will improve quite a bit. For example we can upgrade a server by sending it a `SHUTDOWN` command and restarting it. Because Valkey expires are semantically implemented so that time still elapses when the server is off, all our requirements are fine.
+However everything is fine as long as it is a clean shutdown. What about a power outage? If Valkey is configured, as by default, to fsync on disk every second, it is possible that after a restart our key is missing. In theory, if we want to guarantee the lock safety in the face of any kind of instance restart, we need to enable `fsync=always` in the persistence settings. This will affect performance due to the additional sync overhead.
 
 However things are better than they look like at a first glance. Basically,
 the algorithm safety is retained as long as when an instance restarts after a
@@ -187,7 +187,7 @@ for all the keys about the locks that existed when the instance crashed to
 become invalid and be automatically released.
 
 Using *delayed restarts* it is basically possible to achieve safety even
-without any kind of Redis persistence available, however note that this may
+without any kind of Valkey persistence available, however note that this may
 translate into an availability penalty. For example if a majority of instances
 crash, the system will become globally unavailable for `TTL` (here globally means
 that no resource at all will be lockable during this time).
@@ -220,7 +220,7 @@ If you are concerned about consistency and correctness, you should pay attention
 1. You should implement fencing tokens.
   This is especially important for processes that can take significant time and applies to any distributed locking system.
   Extending locks' lifetime is also an option, but don´t assume that a lock is retained as long as the process that had acquired it is alive.
-2. Redis is not using monotonic clock for TTL expiration mechanism.
+2. Valkey is not using monotonic clock for TTL expiration mechanism.
   That means that a wall-clock shift may result in a lock being acquired by more than one process.
   Even though the problem can be mitigated by preventing admins from manually setting the server's time and setting up NTP properly, there's still a chance of this issue occurring in real life and compromising consistency.
 

--- a/docs/manual/patterns/indexes/index.md
+++ b/docs/manual/patterns/indexes/index.md
@@ -3,31 +3,31 @@ title: Secondary indexing
 linkTitle: Secondary indexing
 weight: 1
 description: >
-    Building secondary indexes in Redis
+    Building secondary indexes in Valkey
 aliases: [
     /topics/indexing,
     /docs/reference/patterns/indexes
 ]
 ---
 
-Redis is not exactly a key-value store, since values can be complex data structures. However it has an external key-value shell: at API level data is addressed by the key name. It is fair to say that, natively, Redis only offers *primary key access*. However since Redis is a data structures server, its capabilities can be used for indexing, in order to create secondary indexes of different kinds, including composite (multi-column) indexes.
+Valkey is not exactly a key-value store, since values can be complex data structures. However it has an external key-value shell: at API level data is addressed by the key name. It is fair to say that, natively, Valkey only offers *primary key access*. However since Valkey is a data structures server, its capabilities can be used for indexing, in order to create secondary indexes of different kinds, including composite (multi-column) indexes.
 
-This document explains how it is possible to create indexes in Redis using the following data structures:
+This document explains how it is possible to create indexes in Valkey using the following data structures:
 
 * Sorted sets to create secondary indexes by ID or other numerical fields.
 * Sorted sets with lexicographical ranges for creating more advanced secondary indexes, composite indexes and graph traversal indexes.
 * Sets for creating random indexes.
 * Lists for creating simple iterable indexes and last N items indexes.
 
-Implementing and maintaining indexes with Redis is an advanced topic, so most
+Implementing and maintaining indexes with Valkey is an advanced topic, so most
 users that need to perform complex queries on data should understand if they
 are better served by a relational store. However often, especially in caching
-scenarios, there is the explicit need to store indexed data into Redis in order to speedup common queries which require some form of indexing in order to be executed.
+scenarios, there is the explicit need to store indexed data into Valkey in order to speedup common queries which require some form of indexing in order to be executed.
 
 Simple numerical indexes with sorted sets
 ===
 
-The simplest secondary index you can create with Redis is by using the
+The simplest secondary index you can create with Valkey is by using the
 sorted set data type, which is a data structure representing a set of
 elements ordered by a floating point number which is the *score* of
 each element. Elements are ordered from the smallest to the highest score.
@@ -136,7 +136,7 @@ is not always true. If you can efficiently represent something
 multi-dimensional in a linear way, they it is often possible to use a simple
 sorted set for indexing.
 
-For example the [Redis geo indexing API](/commands/geoadd) uses a sorted
+For example the [Valkey geo indexing API](/commands/geoadd) uses a sorted
 set to index places by latitude and longitude using a technique called
 [Geo hash](https://en.wikipedia.org/wiki/Geohash). The sorted set score
 represents alternating bits of longitude and latitude, so that we map the
@@ -176,9 +176,9 @@ There are commands such as `ZRANGE` and `ZLEXCOUNT` that
 are able to query and count ranges in a lexicographically fashion, assuming
 they are used with sorted sets where all the elements have the same score.
 
-This Redis feature is basically equivalent to a `b-tree` data structure which
+This Valkey feature is basically equivalent to a `b-tree` data structure which
 is often used in order to implement indexes with traditional databases.
-As you can guess, because of this, it is possible to use this Redis data
+As you can guess, because of this, it is possible to use this Valkey data
 structure in order to implement pretty fancy indexes.
 
 Before we dive into using lexicographical indexes, let's check how
@@ -239,7 +239,7 @@ we'll just do:
 And so forth for each search query ever encountered. Then when we want to
 complete the user input, we execute a range query using `ZRANGE` with the `BYLEX` argument.
 Imagine the user is typing "bit" inside the search form, and we want to
-offer possible search keywords starting for "bit". We send Redis a command
+offer possible search keywords starting for "bit". We send Valkey a command
 like that:
 
     ZRANGE myindex "[bit" "[bit\xff" BYLEX
@@ -365,7 +365,7 @@ However a problem to solve in this case is collisions. The colon character
 may be part of the key itself, so it must be chosen in order to never
 collide with the key we add.
 
-Since lexicographical ranges in Redis are binary safe you can use any
+Since lexicographical ranges in Valkey are binary safe you can use any
 byte or any sequence of bytes. However if you receive untrusted user
 input, it is better to use some form of escaping in order to guarantee
 that the separator will never happen to be part of the key.
@@ -410,7 +410,7 @@ Storing numbers in decimal may use too much memory. An alternative approach
 is just to store numbers, for example 128 bit integers, directly in their
 binary form. However for this to work, you need to store the numbers in
 *big endian format*, so that the most significant bytes are stored before
-the least significant bytes. This way when Redis compares the strings with
+the least significant bytes. This way when Valkey compares the strings with
 `memcmp()`, it will effectively sort the numbers by their value.
 
 Keep in mind that data stored in binary format is less observable for
@@ -448,9 +448,9 @@ the primary key in order to run queries regardless of the price, like
 *give me all the products in room 44*.
 
 Composite indexes are very powerful, and are used in traditional stores
-in order to optimize complex queries. In Redis they could be useful both
-to implement a very fast in-memory Redis index of something stored into
-a traditional data store, or in order to directly index Redis data.
+in order to optimize complex queries. In Valkey they could be useful both
+to implement a very fast in-memory Valkey index of something stored into
+a traditional data store, or in order to directly index Valkey data.
 
 Updating lexicographical indexes
 ===
@@ -547,7 +547,7 @@ queries involving multiple variables using different data structures.
 For example, multi-dimensional trees such as *k-d trees* or *r-trees* are
 sometimes used. Here we'll describe a different way to index data into
 multiple dimensions, using a representation trick that allows us to perform
-the query in a very efficient way using Redis lexicographical ranges.
+the query in a very efficient way using Valkey lexicographical ranges.
 
 Let's say we have points in the space, which represent our data samples, where `x` and `y` are our coordinates. The max value of both variables is 400.
 
@@ -691,10 +691,10 @@ Turning this into code is simple. Here is a Ruby example:
     spacequery(50,100,100,300,6)
 
 While non immediately trivial this is a very useful indexing strategy that
-in the future may be implemented in Redis in a native way.
+in the future may be implemented in Valkey in a native way.
 For now, the good thing is that the complexity may be easily encapsulated
 inside a library that can be used in order to perform indexing and queries.
-One example of such library is [Redimension](https://github.com/antirez/redimension), a proof of concept Ruby library which indexes N-dimensional data inside Redis using the technique described here.
+One example of such library is [Redimension](https://github.com/antirez/redimension), a proof of concept Ruby library which indexes N-dimensional data inside Valkey using the technique described here.
 
 Multi dimensional indexes with negative or floating point numbers
 ===
@@ -712,7 +712,7 @@ Non range indexes
 ===
 
 So far we checked indexes which are useful to query by range or by single
-item. However other Redis data structures such as Sets or Lists can be used
+item. However other Valkey data structures such as Sets or Lists can be used
 in order to build other kind of indexes. They are very commonly used but
 maybe we don't always realize they are actually a form of indexing.
 
@@ -729,7 +729,7 @@ when I want to process a given set of items again and again forever in the
 same order. Think of an RSS feed system that needs to refresh the local copy
 periodically.
 
-Another popular index often used with Redis is a **capped list**, where items
+Another popular index often used with Valkey is a **capped list**, where items
 are added with `LPUSH` and trimmed with `LTRIM`, in order to create a view
 with just the latest N items encountered, in the same order they were
 seen.
@@ -741,8 +741,8 @@ Keeping the index updated may be challenging, in the course of months
 or years it is possible that inconsistencies are added because of software
 bugs, network partitions or other events.
 
-Different strategies could be used. If the index data is outside Redis
+Different strategies could be used. If the index data is outside Valkey
 *read repair* can be a solution, where data is fixed in a lazy way when
-it is requested. When we index data which is stored in Redis itself
+it is requested. When we index data which is stored in Valkey itself
 the `SCAN` family of commands can be used in order to verify, update or
 rebuild the index from scratch, incrementally.

--- a/docs/manual/patterns/twitter-clone.md
+++ b/docs/manual/patterns/twitter-clone.md
@@ -174,7 +174,7 @@ Prerequisites
 
 If you haven't downloaded the [Retwis source code](https://github.com/antirez/retwis) already please grab it now. It contains a few PHP files, and also a copy of [Predis](https://github.com/nrk/predis), the PHP client library we use in this example.
 
-Another thing you probably want is a working Valkey server. Just get the source, build with `make`, run with `./redis-server`, and you're ready to go. No configuration is required at all in order to play with or run Retwis on your computer.
+Another thing you probably want is a working Valkey server. Just get the source, build with `make`, run with `./valkey-server`, and you're ready to go. No configuration is required at all in order to play with or run Retwis on your computer.
 
 Data layout
 ---

--- a/docs/manual/patterns/twitter-clone.md
+++ b/docs/manual/patterns/twitter-clone.md
@@ -1,23 +1,23 @@
 ---
-title: "Redis patterns example"
+title: "Valkey patterns example"
 linkTitle: "Patterns example"
-description: Learn several Redis patterns by building a Twitter clone
+description: Learn several Valkey patterns by building a Twitter clone
 weight: 20
 aliases: [
     /docs/reference/patterns/twitter-clone
 ]
 ---
 
-This article describes the design and implementation of a [very simple Twitter clone](https://github.com/antirez/retwis) written using PHP with Redis as the only database. The programming community has traditionally considered key-value stores as a special purpose database that couldn't be used as a drop-in replacement for a relational database for the development of web applications. This article will try to show that Redis data structures on top of a key-value layer are an effective data model to implement many kinds of applications.
+This article describes the design and implementation of a [very simple Twitter clone](https://github.com/antirez/retwis) written using PHP with Valkey as the only database. The programming community has traditionally considered key-value stores as a special purpose database that couldn't be used as a drop-in replacement for a relational database for the development of web applications. This article will try to show that Valkey data structures on top of a key-value layer are an effective data model to implement many kinds of applications.
 
-Note: the original version of this article was written in 2009 when Redis was
-released. It was not exactly clear at that time that the Redis data model was
+Note: the original version of this article was written in 2009 when Valkey was
+released. It was not exactly clear at that time that the Valkey data model was
 suitable to write entire applications. Now after 5 years there are many cases of
-applications using Redis as their main store, so the goal of the article today
-is to be a tutorial for Redis newcomers. You'll learn how to design a simple
-data layout using Redis, and how to apply different data structures.
+applications using Valkey as their main store, so the goal of the article today
+is to be a tutorial for Valkey newcomers. You'll learn how to design a simple
+data layout using Valkey, and how to apply different data structures.
 
-Our Twitter clone, called [Retwis](https://github.com/antirez/retwis), is structurally simple, has very good performance, and can be distributed among any number of web and Redis servers with little efforts. [View the Retwis source code](https://github.com/antirez/retwis).
+Our Twitter clone, called [Retwis](https://github.com/antirez/retwis), is structurally simple, has very good performance, and can be distributed among any number of web and Valkey servers with little efforts. [View the Retwis source code](https://github.com/antirez/retwis).
 
 I used PHP for the example because of its universal readability. The same (or better) results can be obtained using Ruby, Python, Erlang, and so on.
 A few clones exist (however not all the clones use the same data layout as the
@@ -33,11 +33,11 @@ The essence of a key-value store is the ability to store some data, called a _va
 
     SET foo bar
 
-Redis stores data permanently, so if I later ask "_What is the value stored in key foo?_" Redis will reply with *bar*:
+Valkey stores data permanently, so if I later ask "_What is the value stored in key foo?_" Valkey will reply with *bar*:
 
     GET foo => bar
 
-Other common operations provided by key-value stores are `DEL`, to delete a given key and its associated value, SET-if-not-exists (called `SETNX` on Redis), to assign a value to a key only if the key does not already exist, and `INCR`, to atomically increment a number stored in a given key:
+Other common operations provided by key-value stores are `DEL`, to delete a given key and its associated value, SET-if-not-exists (called `SETNX` on Valkey), to assign a value to a key only if the key does not already exist, and `INCR`, to atomically increment a number stored in a given key:
 
     SET foo 10
     INCR foo => 11
@@ -47,7 +47,7 @@ Other common operations provided by key-value stores are `DEL`, to delete a give
 Atomic operations
 ---
 
-There is something special about `INCR`. You may wonder why Redis provides such an operation if we can do it ourselves with a bit of code? After all, it is as simple as:
+There is something special about `INCR`. You may wonder why Valkey provides such an operation if we can do it ourselves with a bit of code? After all, it is as simple as:
 
     x = GET foo
     x = x + 1
@@ -62,14 +62,14 @@ The problem is that incrementing this way will work as long as there is only one
     SET foo x (foo is now 11)
     SET foo y (foo is now 11)
 
-Something is wrong! We incremented the value two times, but instead of going from 10 to 12, our key holds 11. This is because the increment done with `GET / increment / SET` *is not an atomic operation*. Instead the INCR provided by Redis, Memcached, ..., are atomic implementations, and the server will take care of protecting the key during the time needed to complete the increment in order to prevent simultaneous accesses.
+Something is wrong! We incremented the value two times, but instead of going from 10 to 12, our key holds 11. This is because the increment done with `GET / increment / SET` *is not an atomic operation*. Instead the INCR provided by Valkey, Memcached, ..., are atomic implementations, and the server will take care of protecting the key during the time needed to complete the increment in order to prevent simultaneous accesses.
 
-What makes Redis different from other key-value stores is that it provides other operations similar to INCR that can be used to model complex problems. This is why you can use Redis to write whole web applications without using another database like an SQL database, and without going crazy.
+What makes Valkey different from other key-value stores is that it provides other operations similar to INCR that can be used to model complex problems. This is why you can use Valkey to write whole web applications without using another database like an SQL database, and without going crazy.
 
 Beyond key-value stores: lists
 ---
 
-In this section we will see which Redis features we need to build our Twitter clone. The first thing to know is that Redis values can be more than strings. Redis supports Lists, Sets, Hashes, Sorted Sets, Bitmaps, and HyperLogLog types as values, and there are atomic operations to operate on them so we are safe even with multiple accesses to the same key. Let's start with Lists:
+In this section we will see which Valkey features we need to build our Twitter clone. The first thing to know is that Valkey values can be more than strings. Valkey supports Lists, Sets, Hashes, Sorted Sets, Bitmaps, and HyperLogLog types as values, and there are atomic operations to operate on them so we are safe even with multiple accesses to the same key. Let's start with Lists:
 
     LPUSH mylist a (now mylist holds 'a')
     LPUSH mylist b (now mylist holds 'b','a')
@@ -95,7 +95,7 @@ Sorted Sets, which are kind of a more capable version of Sets, it is better
 to start introducing Sets first (which are a very useful data structure
 per se), and later Sorted Sets.
 
-There are more data types than just Lists. Redis also supports Sets, which are unsorted collections of elements. It is possible to add, remove, and test for existence of members, and perform the intersection between different Sets. Of course it is possible to get the elements of a Set. Some examples will make it more clear. Keep in mind that `SADD` is the _add to set_ operation, `SREM` is the _remove from set_ operation, `SISMEMBER` is the _test if member_ operation, and `SINTER` is the _perform intersection_ operation. Other operations are `SCARD` to get the cardinality (the number of elements) of a Set, and `SMEMBERS` to return all the members of a Set.
+There are more data types than just Lists. Valkey also supports Sets, which are unsorted collections of elements. It is possible to add, remove, and test for existence of members, and perform the intersection between different Sets. Of course it is possible to get the elements of a Set. Some examples will make it more clear. Keep in mind that `SADD` is the _add to set_ operation, `SREM` is the _remove from set_ operation, `SISMEMBER` is the _test if member_ operation, and `SINTER` is the _perform intersection_ operation. Other operations are `SCARD` to get the cardinality (the number of elements) of a Set, and `SMEMBERS` to return all the members of a Set.
 
     SADD myset a
     SADD myset b
@@ -146,7 +146,7 @@ also to retrieve its score if it exists, we use the `ZSCORE` command:
 
 Sorted Sets are a very powerful data structure, you can query elements by
 score range, lexicographically, in reverse order, and so forth.
-To know more [please check the Sorted Set sections in the official Redis commands documentation](https://redis.io/commands/#sorted_set).
+To know more [please check the Sorted Set sections in the official Valkey commands documentation](https://redis.io/commands/#sorted_set).
 
 The Hash data type
 ---
@@ -166,7 +166,7 @@ to increment a hash field with `HINCRBY` and so forth.
 Hashes are the ideal data structure to represent *objects*. For example we
 use Hashes in order to represent Users and Updates in our Twitter clone.
 
-Okay, we just exposed the basics of the Redis main data structures,
+Okay, we just exposed the basics of the Valkey main data structures,
 we are ready to start coding!
 
 Prerequisites
@@ -174,12 +174,12 @@ Prerequisites
 
 If you haven't downloaded the [Retwis source code](https://github.com/antirez/retwis) already please grab it now. It contains a few PHP files, and also a copy of [Predis](https://github.com/nrk/predis), the PHP client library we use in this example.
 
-Another thing you probably want is a working Redis server. Just get the source, build with `make`, run with `./redis-server`, and you're ready to go. No configuration is required at all in order to play with or run Retwis on your computer.
+Another thing you probably want is a working Valkey server. Just get the source, build with `make`, run with `./redis-server`, and you're ready to go. No configuration is required at all in order to play with or run Retwis on your computer.
 
 Data layout
 ---
 
-When working with a relational database, a database schema must be designed so that we'd know the tables, indexes, and so on that the database will contain. We don't have tables in Redis, so what do we need to design? We need to identify what keys are needed to represent our objects and what kind of values these keys need to hold.
+When working with a relational database, a database schema must be designed so that we'd know the tables, indexes, and so on that the database will contain. We don't have tables in Valkey, so what do we need to design? We need to identify what keys are needed to represent our objects and what kind of values these keys need to hold.
 
 Let's start with Users. We need to represent users, of course, with their username, userid, password, the set of users following a given user, the set of users a given user follows, and so on. The first question is, how should we identify a user? Like in a relational DB, a good solution is to identify different users with different numbers, so we can associate a unique ID with every user. Every other reference to this user will be done by id. Creating unique IDs is very simple to do by using our atomic `INCR` operation. When we create a new user we can do something like this, assuming the user is called "antirez":
 
@@ -194,7 +194,7 @@ Besides the fields already defined, we need some more stuff in order to fully de
 
     HSET users antirez 1000
 
-This may appear strange at first, but remember that we are only able to access data in a direct way, without secondary indexes. It's not possible to tell Redis to return the key that holds a specific value. This is also *our strength*. This new paradigm is forcing us to organize data so that everything is accessible by _primary key_, speaking in relational DB terms.
+This may appear strange at first, but remember that we are only able to access data in a direct way, without secondary indexes. It's not possible to tell Valkey to return the key that holds a specific value. This is also *our strength*. This new paradigm is forcing us to organize data so that everything is accessible by _primary key_, speaking in relational DB terms.
 
 Followers, following, and updates
 ---
@@ -228,7 +228,7 @@ Basically, we'll implement a write fanout.
 Authentication
 ---
 
-OK, we have more or less everything about the user except for authentication. We'll handle authentication in a simple but robust way: we don't want to use PHP sessions, as our system must be ready to be distributed among different web servers easily, so we'll keep the whole state in our Redis database. All we need is a random **unguessable** string to set as the cookie of an authenticated user, and a key that will contain the user ID of the client holding the string.
+OK, we have more or less everything about the user except for authentication. We'll handle authentication in a simple but robust way: we don't want to use PHP sessions, as our system must be ready to be distributed among different web servers easily, so we'll keep the whole state in our Valkey database. All we need is a random **unguessable** string to set as the cookie of an authenticated user, and a key that will contain the user ID of the client holding the string.
 
 We need two things in order to make this thing work in a robust way.
 First: the current authentication *secret* (the random unguessable string)
@@ -380,7 +380,7 @@ timeline. This is used in order to trim the list to just 1000 elements. The
 global timeline is actually only used in order to show a few posts in the
 home page, there is no need to have the full history of all the posts.
 
-Basically `LTRIM` + `LPUSH` is a way to create a *capped collection* in Redis.
+Basically `LTRIM` + `LPUSH` is a way to create a *capped collection* in Valkey.
 
 Paginating updates
 ---
@@ -443,7 +443,7 @@ store?
 
 Retwis does not perform any multi-keys operation, so making it scalable is
 simple: you may use client-side sharding, or something like a sharding proxy
-like Twemproxy, or the upcoming Redis Cluster.
+like Twemproxy, or the upcoming Valkey Cluster.
 
 To know more about those topics please read
 [our documentation about sharding](/topics/partitioning). However, the point here

--- a/docs/manual/patterns/twitter-clone.md
+++ b/docs/manual/patterns/twitter-clone.md
@@ -10,11 +10,11 @@ aliases: [
 
 This article describes the design and implementation of a [very simple Twitter clone](https://github.com/antirez/retwis) written using PHP with Valkey as the only database. The programming community has traditionally considered key-value stores as a special purpose database that couldn't be used as a drop-in replacement for a relational database for the development of web applications. This article will try to show that Valkey data structures on top of a key-value layer are an effective data model to implement many kinds of applications.
 
-Note: the original version of this article was written in 2009 when Valkey was
-released. It was not exactly clear at that time that the Valkey data model was
-suitable to write entire applications. Now after 5 years there are many cases of
-applications using Valkey as their main store, so the goal of the article today
-is to be a tutorial for Valkey newcomers. You'll learn how to design a simple
+Note: the original version of this article was written in 2009 when Redis OSS was
+released. It was not exactly clear at that time that the data model was
+suitable to write entire applications. After 5 years there were many cases of
+applications using Redis OSS as their main store, so the goal of the article today
+is to be a tutorial for newcomers. You'll learn how to design a simple
 data layout using Valkey, and how to apply different data structures.
 
 Our Twitter clone, called [Retwis](https://github.com/antirez/retwis), is structurally simple, has very good performance, and can be distributed among any number of web and Valkey servers with little efforts. [View the Retwis source code](https://github.com/antirez/retwis).

--- a/docs/manual/pipelining/index.md
+++ b/docs/manual/pipelining/index.md
@@ -1,17 +1,17 @@
 ---
-title: "Redis pipelining"
+title: "Valkey pipelining"
 linkTitle: "Pipelining"
 weight: 2
-description: How to optimize round-trip times by batching Redis commands
+description: How to optimize round-trip times by batching Valkey commands
 aliases:
   - /topics/pipelining
 ---
 
-Redis pipelining is a technique for improving performance by issuing multiple commands at once without waiting for the response to each individual command. Pipelining is supported by most Redis clients. This document describes the problem that pipelining is designed to solve and how pipelining works in Redis.
+Valkey pipelining is a technique for improving performance by issuing multiple commands at once without waiting for the response to each individual command. Pipelining is supported by most Valkey clients. This document describes the problem that pipelining is designed to solve and how pipelining works in Valkey.
 
 ## Request/Response protocols and round-trip time (RTT)
 
-Redis is a TCP server using the client-server model and what is called a *Request/Response* protocol.
+Valkey is a TCP server using the client-server model and what is called a *Request/Response* protocol.
 
 This means that usually a request is accomplished with the following steps:
 
@@ -41,7 +41,7 @@ If the interface used is a loopback interface, the RTT is much shorter, typicall
 
 Fortunately there is a way to improve this use case.
 
-## Redis Pipelining
+## Valkey Pipelining
 
 A Request/Response server can be implemented so that it is able to process new requests even if the client hasn't already read the old responses.
 This way it is possible to send *multiple commands* to the server without waiting for the replies at all, and finally read the replies in a single step.
@@ -49,7 +49,7 @@ This way it is possible to send *multiple commands* to the server without waitin
 This is called pipelining, and is a technique widely in use for many decades.
 For instance many POP3 protocol implementations already support this feature, dramatically speeding up the process of downloading new emails from the server.
 
-Redis has supported pipelining since its early days, so whatever version you are running, you can use pipelining with Redis.
+Valkey has supported pipelining since its early days, so whatever version you are running, you can use pipelining with Valkey.
 This is an example using the raw netcat utility:
 
 ```bash 
@@ -78,7 +78,7 @@ To be explicit, with pipelining the order of operations of our very first exampl
 
 Pipelining is not just a way to reduce the latency cost associated with the
 round trip time, it actually greatly improves the number of operations
-you can perform per second in a given Redis server.
+you can perform per second in a given Valkey server.
 This is because without using pipelining, serving each command is very cheap from
 the point of view of accessing the data structures and producing the reply,
 but it is very costly from the point of view of doing the socket I/O. This
@@ -97,7 +97,7 @@ reaches 10 times the baseline obtained without pipelining, as shown in this figu
 ## A real world code example
 
 
-In the following benchmark we'll use the Redis Ruby client, supporting pipelining, to test the speed improvement due to pipelining:
+In the following benchmark we'll use the Valkey Ruby client, supporting pipelining, to test the speed improvement due to pipelining:
 
 ```ruby
 require 'rubygems'
@@ -143,32 +143,32 @@ As you can see, using pipelining, we improved the transfer by a factor of five.
 
 ## Pipelining vs Scripting
 
-Using [Redis scripting](/commands/eval), available since Redis 2.6, a number of use cases for pipelining can be addressed more efficiently using scripts that perform a lot of the work needed at the server side.
+Using [Valkey scripting](/commands/eval), available since Redis 2.6, a number of use cases for pipelining can be addressed more efficiently using scripts that perform a lot of the work needed at the server side.
 A big advantage of scripting is that it is able to both read and write data with minimal latency, making operations like *read, compute, write* very fast (pipelining can't help in this scenario since the client needs the reply of the read command before it can call the write command).
 
 Sometimes the application may also want to send `EVAL` or `EVALSHA` commands in a pipeline. 
-This is entirely possible and Redis explicitly supports it with the [SCRIPT LOAD](https://redis.io/commands/script-load) command (it guarantees that `EVALSHA` can be called without the risk of failing).
+This is entirely possible and Valkey explicitly supports it with the [SCRIPT LOAD](https://redis.io/commands/script-load) command (it guarantees that `EVALSHA` can be called without the risk of failing).
 
 ## Appendix: Why are busy loops slow even on the loopback interface?
 
 Even with all the background covered in this page, you may still wonder why
-a Redis benchmark like the following (in pseudo code), is slow even when
+a Valkey benchmark like the following (in pseudo code), is slow even when
 executed in the loopback interface, when the server and the client are running
 in the same physical machine:
 
 ```sh
 FOR-ONE-SECOND:
-    Redis.SET("foo","bar")
+    Valkey.SET("foo","bar")
 END
 ```
 
-After all, if both the Redis process and the benchmark are running in the same
+After all, if both the Valkey process and the benchmark are running in the same
 box, isn't it just copying messages in memory from one place to another without
 any actual latency or networking involved?
 
 The reason is that processes in a system are not always running, actually it is
 the kernel scheduler that lets the process run. 
-So, for instance, when the benchmark is allowed to run, it reads the reply from the Redis server (related to the last command executed), and writes a new command.
+So, for instance, when the benchmark is allowed to run, it reads the reply from the Valkey server (related to the last command executed), and writes a new command.
 The command is now in the loopback interface buffer, but in order to be read by the server, the kernel should schedule the server process (currently blocked in a system call)
 to run, and so forth.
 So in practical terms the loopback interface still involves network-like latency, because of how the kernel scheduler works.

--- a/docs/manual/pipelining/index.md
+++ b/docs/manual/pipelining/index.md
@@ -143,7 +143,7 @@ As you can see, using pipelining, we improved the transfer by a factor of five.
 
 ## Pipelining vs Scripting
 
-Using [Valkey scripting](/commands/eval), available since Redis 2.6, a number of use cases for pipelining can be addressed more efficiently using scripts that perform a lot of the work needed at the server side.
+Using [Valkey scripting](/commands/eval), a number of use cases for pipelining can be addressed more efficiently using scripts that perform a lot of the work needed at the server side.
 A big advantage of scripting is that it is able to both read and write data with minimal latency, making operations like *read, compute, write* very fast (pipelining can't help in this scenario since the client needs the reply of the read command before it can call the write command).
 
 Sometimes the application may also want to send `EVAL` or `EVALSHA` commands in a pipeline. 


### PR DESCRIPTION
Rebranding "Valkey" -> "Redis" all files under docs/manual/.

The bulk replacement is in one commit, using the Perl regex '`\bRedis\b(?! Ltd|\.[a-z]| [2-8]|::|-plus-plus)`' replacing with "Valkey".

Manual changes are in separate commits.