### PR TITLE
Rebranding docs/reference/

### DIFF
--- a/docs/reference/_index.md
+++ b/docs/reference/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Redis reference"
+title: "Valkey reference"
 linkTitle: "Reference"
 description: Specifications and protocols
 weight: 70

--- a/docs/reference/arm.md
+++ b/docs/reference/arm.md
@@ -3,42 +3,42 @@ title: "ARM support"
 linkTitle: "ARM support"
 weight: 11
 description: >
-    Exploring Redis on the ARM CPU Architecture
+    Exploring Valkey on the ARM CPU Architecture
 aliases:
     - /topics/ARM
 ---
 
 Redis OSS versions 4.0 and above support the ARM processor in general, and
-the Raspberry Pi specifically, as a main platform. Every new release of Redis is tested on the Pi
-environment, and we update this documentation page with information about supported devices and other useful information. While Redis does run on Android, in the future we look forward to extend our testing efforts to Android
+the Raspberry Pi specifically, as a main platform. Every new release of Valkey is tested on the Pi
+environment, and we update this documentation page with information about supported devices and other useful information. While Valkey does run on Android, in the future we look forward to extend our testing efforts to Android
 to also make it an officially supported platform.
 
-We believe that Redis is ideal for IoT and embedded devices for several
+We believe that Valkey is ideal for IoT and embedded devices for several
 reasons:
 
-* Redis has a very small memory footprint and CPU requirements. It can run in small devices like the Raspberry Pi Zero without impacting the overall performance, using a small amount of memory while delivering good performance for many use cases.
-* The data structures of Redis are often an ideal way to model IoT/embedded use cases. Some examples include accumulating time series data, receiving or queuing commands to execute or respond to send back to the remote servers, and so forth.
-* Modeling data inside Redis can be very useful in order to make in-device decisions for appliances that must respond very quickly or when the remote servers are offline.
-* Redis can be used as a communication system between the processes running in the device.
-* The append-only file storage of Redis is well suited for SSD cards.
+* Valkey has a very small memory footprint and CPU requirements. It can run in small devices like the Raspberry Pi Zero without impacting the overall performance, using a small amount of memory while delivering good performance for many use cases.
+* The data structures of Valkey are often an ideal way to model IoT/embedded use cases. Some examples include accumulating time series data, receiving or queuing commands to execute or respond to send back to the remote servers, and so forth.
+* Modeling data inside Valkey can be very useful in order to make in-device decisions for appliances that must respond very quickly or when the remote servers are offline.
+* Valkey can be used as a communication system between the processes running in the device.
+* The append-only file storage of Valkey is well suited for SSD cards.
 * The stream data structure included in Redis OSS versions 5.0 and higher was specifically designed for time series applications and has a very low memory overhead.
 
-## Redis /proc/cpu/alignment requirements
+## Valkey /proc/cpu/alignment requirements
 
 Linux on ARM allows to trap unaligned accesses and fix them inside the kernel
 in order to continue the execution of the offending program instead of
 generating a `SIGBUS`. Redis OSS 4.0 and greater are fixed in order to avoid any kind
 of unaligned access, so there is no need to have a specific value for this
-kernel configuration. Even when kernel alignment fixing set as disabled Redis should
+kernel configuration. Even when kernel alignment fixing set as disabled Valkey should
 run as expected.
 
-## Building Redis in the Pi
+## Building Valkey in the Pi
 
 * Download Redis OSS version 4.0 or higher.
 * Use `make` as usual to create the executable.
 
 There is nothing special in the process. The only difference is that by
-default, Redis uses the `libc` allocator instead of defaulting to `jemalloc`
+default, Valkey uses the `libc` allocator instead of defaulting to `jemalloc`
 as it does in other Linux based environments. This is because we believe
 that for the small use cases inside embedded devices, memory fragmentation
 is unlikely to be a problem. Moreover `jemalloc` on ARM may not be as tested
@@ -46,8 +46,8 @@ as the `libc` allocator.
 
 ## Performance
 
-Performance testing of Redis was performed on the Raspberry Pi 3 and Pi 1 model B. The difference between the two Pis in terms of delivered performance is quite big. The benchmarks were performed via the
-loopback interface, since most use cases will probably use Redis from within
+Performance testing of Valkey was performed on the Raspberry Pi 3 and Pi 1 model B. The difference between the two Pis in terms of delivered performance is quite big. The benchmarks were performed via the
+loopback interface, since most use cases will probably use Valkey from within
 the device and not via the network. The following numbers were obtained using
 Redis OSS 4.0.
 
@@ -65,4 +65,4 @@ Raspberry Pi 1 model B:
 * Test 3: Like test 1 but with AOF enabled, fsync 1 sec: 1,820 ops/sec
 * Test 4: Like test 3, but with an AOF rewrite in progress: 1,000 ops/sec
 
-The benchmarks above are referring to simple `SET`/`GET` operations. The performance is similar for all the Redis fast operations (not running in linear time). However sorted sets may show slightly slower numbers.
+The benchmarks above are referring to simple `SET`/`GET` operations. The performance is similar for all the Valkey fast operations (not running in linear time). However sorted sets may show slightly slower numbers.

--- a/docs/reference/arm.md
+++ b/docs/reference/arm.md
@@ -8,7 +8,7 @@ aliases:
     - /topics/ARM
 ---
 
-Redis versions 4.0 and above support the ARM processor in general, and
+Redis OSS versions 4.0 and above support the ARM processor in general, and
 the Raspberry Pi specifically, as a main platform. Every new release of Redis is tested on the Pi
 environment, and we update this documentation page with information about supported devices and other useful information. While Redis does run on Android, in the future we look forward to extend our testing efforts to Android
 to also make it an officially supported platform.
@@ -21,20 +21,20 @@ reasons:
 * Modeling data inside Redis can be very useful in order to make in-device decisions for appliances that must respond very quickly or when the remote servers are offline.
 * Redis can be used as a communication system between the processes running in the device.
 * The append-only file storage of Redis is well suited for SSD cards.
-* The stream data structure included in Redis versions 5.0 and higher was specifically designed for time series applications and has a very low memory overhead.
+* The stream data structure included in Redis OSS versions 5.0 and higher was specifically designed for time series applications and has a very low memory overhead.
 
 ## Redis /proc/cpu/alignment requirements
 
 Linux on ARM allows to trap unaligned accesses and fix them inside the kernel
 in order to continue the execution of the offending program instead of
-generating a `SIGBUS`. Redis 4.0 and greater are fixed in order to avoid any kind
+generating a `SIGBUS`. Redis OSS 4.0 and greater are fixed in order to avoid any kind
 of unaligned access, so there is no need to have a specific value for this
 kernel configuration. Even when kernel alignment fixing set as disabled Redis should
 run as expected.
 
 ## Building Redis in the Pi
 
-* Download Redis version 4.0 or higher.
+* Download Redis OSS version 4.0 or higher.
 * Use `make` as usual to create the executable.
 
 There is nothing special in the process. The only difference is that by
@@ -49,7 +49,7 @@ as the `libc` allocator.
 Performance testing of Redis was performed on the Raspberry Pi 3 and Pi 1 model B. The difference between the two Pis in terms of delivered performance is quite big. The benchmarks were performed via the
 loopback interface, since most use cases will probably use Redis from within
 the device and not via the network. The following numbers were obtained using
-Redis 4.0.
+Redis OSS 4.0.
 
 Raspberry Pi 3:
 

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -172,7 +172,7 @@ The Redis `CLIENT` command allows you to inspect the state of every connected cl
 `CLIENT LIST` is used in order to obtain a list of connected clients and their state:
 
 ```
-redis 127.0.0.1:6379> client list
+127.0.0.1:6379> client list
 addr=127.0.0.1:52555 fd=5 name= age=855 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=32768 obl=0 oll=0 omem=0 events=r cmd=client
 addr=127.0.0.1:52787 fd=6 name= age=6 idle=5 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=ping
 ```

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -47,7 +47,7 @@ However, Valkey does the following two things when serving clients:
 In Redis OSS 2.4 there was a hard-coded limit for the maximum number of clients
 that could be handled simultaneously.
 
-In Redis OSS 2.6 and newer, this limit is configurable using the `maxclients` directive in `redis.conf`. The default is 10,000 clients.
+In Redis OSS 2.6 and newer, this limit is configurable using the `maxclients` directive in `valkey.conf`. The default is 10,000 clients.
 
 However, Valkey checks with the kernel what the maximum number of file
 descriptors that we are able to open is (the *soft limit* is checked). If the
@@ -60,7 +60,7 @@ limit.
 When `maxclients` is set to a number greater than Valkey can support, a message is logged at startup:
 
 ```
-$ ./redis-server --maxclients 100000
+$ ./valkey-server --maxclients 100000
 [41422] 23 Jan 11:28:33.179 # Unable to set the max number of files limit to 100032 (Invalid argument), setting the max clients configuration to 10112.
 ```
 
@@ -101,7 +101,7 @@ Different kind of clients have different default limits:
 * **Pub/Sub clients** have a default hard limit of 32 megabytes and a soft limit of 8 megabytes per 60 seconds.
 * **Replicas** have a default hard limit of 256 megabytes and a soft limit of 64 megabyte per 60 seconds.
 
-It is possible to change the limit at runtime using the `CONFIG SET` command or in a permanent way using the Valkey configuration file `redis.conf`. See the example `redis.conf` in the Valkey distribution for more information about how to set the limit.
+It is possible to change the limit at runtime using the `CONFIG SET` command or in a permanent way using the Valkey configuration file `valkey.conf`. See the example `valkey.conf` in the Valkey distribution for more information about how to set the limit.
 
 ## Query Buffer Hard Limit
 
@@ -123,7 +123,7 @@ The aggregation takes into account all the memory used by the client connections
 
 Note that replica and master connections aren't affected by the client eviction mechanism. Therefore, such connections are never evicted.
 
-`maxmemory-clients` can be set permanently in the configuration file (`redis.conf`) or via the `CONFIG SET` command.
+`maxmemory-clients` can be set permanently in the configuration file (`valkey.conf`) or via the `CONFIG SET` command.
 This setting can either be 0 (meaning no limit), a size in bytes (possibly with `mb`/`gb` suffix),
 or a percentage of `maxmemory` by using the `%` suffix (e.g. setting it to `10%` would mean 10% of the `maxmemory` configuration).
 
@@ -142,7 +142,7 @@ And you can revert that with:
 
 `CLIENT NO-EVICT` `off`
 
-For more information and an example refer to the `maxmemory-clients` section in the default `redis.conf` file.
+For more information and an example refer to the `maxmemory-clients` section in the default `valkey.conf` file.
 
 Client eviction is available from Redis OSS 7.0.
 
@@ -154,7 +154,7 @@ if the client is idle for many seconds: the connection will remain open forever.
 However if you don't like this behavior, you can configure a timeout, so that
 if the client is idle for more than the specified number of seconds, the client connection will be closed.
 
-You can configure this limit via `redis.conf` or simply using `CONFIG SET timeout <value>`.
+You can configure this limit via `valkey.conf` or simply using `CONFIG SET timeout <value>`.
 
 Note that the timeout only applies to normal clients and it **does not apply to Pub/Sub clients**, since a Pub/Sub connection is a *push style* connection so a client that is idle is the norm.
 

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -10,7 +10,7 @@ aliases:
 
 This document provides information about how Redis handles clients at the network layer level: connections, timeouts, buffers, and other similar topics are covered here.
 
-The information contained in this document is **only applicable to Redis version 2.6 or greater**.
+The information contained in this document is **only applicable to Redis OSS version 2.6 or greater**.
 
 ## Accepting Client Connections
 
@@ -44,10 +44,10 @@ However, Redis does the following two things when serving clients:
 
 ## Maximum Concurrent Connected Clients
 
-In Redis 2.4 there was a hard-coded limit for the maximum number of clients
+In Redis OSS 2.4 there was a hard-coded limit for the maximum number of clients
 that could be handled simultaneously.
 
-In Redis 2.6 and newer, this limit is configurable using the `maxclients` directive in `redis.conf`. The default is 10,000 clients.
+In Redis OSS 2.6 and newer, this limit is configurable using the `maxclients` directive in `redis.conf`. The default is 10,000 clients.
 
 However, Redis checks with the kernel what the maximum number of file
 descriptors that we are able to open is (the *soft limit* is checked). If the
@@ -144,7 +144,7 @@ And you can revert that with:
 
 For more information and an example refer to the `maxmemory-clients` section in the default `redis.conf` file.
 
-Client eviction is available from Redis 7.0.
+Client eviction is available from Redis OSS 7.0.
 
 ## Client Timeouts
 
@@ -192,7 +192,7 @@ See the [`CLIENT LIST`](https://redis.io/commands/client-list) documentation for
 
 Once you have the list of clients, you can close a client's connection using the `CLIENT KILL` command, specifying the client address as its argument.
 
-The commands `CLIENT SETNAME` and `CLIENT GETNAME` can be used to set and get the connection name. Starting with Redis 4.0, the client name is shown in the
+The commands `CLIENT SETNAME` and `CLIENT GETNAME` can be used to set and get the connection name. Starting with Redis OSS 4.0, the client name is shown in the
 `SLOWLOG` output, to help identify clients that create latency issues.
 
 ## TCP keepalive

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -1,33 +1,33 @@
 ---
-title: "Redis client handling"
+title: "Valkey client handling"
 linkTitle: "Client handling"
 weight: 5
 description: >
-    How the Redis server manages client connections
+    How the Valkey server manages client connections
 aliases:
     - /topics/clients
 ---
 
-This document provides information about how Redis handles clients at the network layer level: connections, timeouts, buffers, and other similar topics are covered here.
+This document provides information about how Valkey handles clients at the network layer level: connections, timeouts, buffers, and other similar topics are covered here.
 
 The information contained in this document is **only applicable to Redis OSS version 2.6 or greater**.
 
 ## Accepting Client Connections
 
-Redis accepts clients connections on the configured TCP port and on the Unix socket if enabled. When a new client connection is accepted the following operations are performed:
+Valkey accepts clients connections on the configured TCP port and on the Unix socket if enabled. When a new client connection is accepted the following operations are performed:
 
-* The client socket is put in the non-blocking state since Redis uses multiplexing and non-blocking I/O.
+* The client socket is put in the non-blocking state since Valkey uses multiplexing and non-blocking I/O.
 * The `TCP_NODELAY` option is set in order to ensure that there are no delays to the connection.
-* A *readable* file event is created so that Redis is able to collect the client queries as soon as new data is available to read on the socket.
+* A *readable* file event is created so that Valkey is able to collect the client queries as soon as new data is available to read on the socket.
 
-After the client is initialized, Redis checks if it is already at the limit
+After the client is initialized, Valkey checks if it is already at the limit
 configured for the number of simultaneous clients (configured using the `maxclients` configuration directive, see the next section of this document for further information).
 
-When Redis can't accept a new client connection because the maximum number of clients
+When Valkey can't accept a new client connection because the maximum number of clients
 has been reached, it tries to send an error to the client in order to
 make it aware of this condition, closing the connection immediately.
 The error message will reach the client even if the connection is
-closed immediately by Redis because the new socket output buffer is usually
+closed immediately by Valkey because the new socket output buffer is usually
 big enough to contain the error, so the kernel will handle transmission
 of the error.
 
@@ -37,7 +37,7 @@ The order is determined by a combination of the client socket file descriptor
 number and order in which the kernel reports events, so the order should be 
 considered as unspecified.
 
-However, Redis does the following two things when serving clients:
+However, Valkey does the following two things when serving clients:
 
 * It only performs a single `read()` system call every time there is something new to read from the client socket. This ensures that if we have multiple clients connected, and a few send queries at a high rate, other clients are not penalized and will not experience latency issues.
 * However once new data is read from a client, all the queries contained in the current buffers are processed sequentially. This improves locality and does not need iterating a second time to see if there are clients that need some processing time.
@@ -49,22 +49,22 @@ that could be handled simultaneously.
 
 In Redis OSS 2.6 and newer, this limit is configurable using the `maxclients` directive in `redis.conf`. The default is 10,000 clients.
 
-However, Redis checks with the kernel what the maximum number of file
+However, Valkey checks with the kernel what the maximum number of file
 descriptors that we are able to open is (the *soft limit* is checked). If the
 limit is less than the maximum number of clients we want to handle, plus
-32 (that is the number of file descriptors Redis reserves for internal uses),
+32 (that is the number of file descriptors Valkey reserves for internal uses),
 then the maximum number of clients is updated to match the number
 of clients it is *really able to handle* under the current operating system
 limit.
 
-When `maxclients` is set to a number greater than Redis can support, a message is logged at startup:
+When `maxclients` is set to a number greater than Valkey can support, a message is logged at startup:
 
 ```
 $ ./redis-server --maxclients 100000
 [41422] 23 Jan 11:28:33.179 # Unable to set the max number of files limit to 100032 (Invalid argument), setting the max clients configuration to 10112.
 ```
 
-When Redis is configured in order to handle a specific number of clients it
+When Valkey is configured in order to handle a specific number of clients it
 is a good idea to make sure that the operating system limit for the maximum
 number of file descriptors per process is also set accordingly.
 
@@ -76,23 +76,23 @@ system-wide setting with the following commands:
 
 ## Output Buffer Limits
 
-Redis needs to handle a variable-length output buffer for every client, since
+Valkey needs to handle a variable-length output buffer for every client, since
 a command can produce a large amount of data that needs to be transferred to the
 client.
 
 However it is possible that a client sends more commands producing more output
-to serve at a faster rate than that which Redis can send the existing output to the
+to serve at a faster rate than that which Valkey can send the existing output to the
 client. This is especially true with Pub/Sub clients in case a client is not
 able to process new messages fast enough.
 
 Both conditions will cause the client output buffer to grow and consume
 more and more memory. For this reason by default Sets limits to the
 output buffer size for different kind of clients. When the limit is reached
-the client connection is closed and the event logged in the Redis log file.
+the client connection is closed and the event logged in the Valkey log file.
 
-There are two kind of limits Redis uses:
+There are two kind of limits Valkey uses:
 
-* The **hard limit** is a fixed limit that when reached will make Redis close the client connection as soon as possible.
+* The **hard limit** is a fixed limit that when reached will make Valkey close the client connection as soon as possible.
 * The **soft limit** instead is a limit that depends on the time, for instance a soft limit of 32 megabytes per 10 seconds means that if the client has an output buffer bigger than 32 megabytes for, continuously, 10 seconds, the connection gets closed.
 
 Different kind of clients have different default limits:
@@ -101,7 +101,7 @@ Different kind of clients have different default limits:
 * **Pub/Sub clients** have a default hard limit of 32 megabytes and a soft limit of 8 megabytes per 60 seconds.
 * **Replicas** have a default hard limit of 256 megabytes and a soft limit of 64 megabyte per 60 seconds.
 
-It is possible to change the limit at runtime using the `CONFIG SET` command or in a permanent way using the Redis configuration file `redis.conf`. See the example `redis.conf` in the Redis distribution for more information about how to set the limit.
+It is possible to change the limit at runtime using the `CONFIG SET` command or in a permanent way using the Valkey configuration file `redis.conf`. See the example `redis.conf` in the Valkey distribution for more information about how to set the limit.
 
 ## Query Buffer Hard Limit
 
@@ -109,16 +109,16 @@ Every client is also subject to a query buffer limit. This is a non-configurable
 
 ## Client Eviction
 
-Redis is built to handle a very large number of client connections.
+Valkey is built to handle a very large number of client connections.
 Client connections tend to consume memory, and when there are many of them, the aggregate memory consumption can be extremely high, leading to data eviction or out-of-memory errors.
-These cases can be mitigated to an extent using [output buffer limits](#output-buffer-limits), but Redis allows us a more robust configuration to limit the aggregate memory used by all clients' connections.
+These cases can be mitigated to an extent using [output buffer limits](#output-buffer-limits), but Valkey allows us a more robust configuration to limit the aggregate memory used by all clients' connections.
 
 
 This mechanism is called **client eviction**, and it's essentially a safety mechanism that will disconnect clients once the aggregate memory usage of all clients is above a threshold.
 The mechanism first attempts to disconnect clients that use the most memory.
 It disconnects the minimal number of clients needed to return below the `maxmemory-clients` threshold.
 
-`maxmemory-clients` defines the maximum aggregate memory usage of all clients connected to Redis.
+`maxmemory-clients` defines the maximum aggregate memory usage of all clients connected to Valkey.
 The aggregation takes into account all the memory used by the client connections: the [query buffer](#query-buffer-hard-limit), the output buffer, and other intermediate buffers.
 
 Note that replica and master connections aren't affected by the client eviction mechanism. Therefore, such connections are never evicted.
@@ -148,7 +148,7 @@ Client eviction is available from Redis OSS 7.0.
 
 ## Client Timeouts
 
-By default recent versions of Redis don't close the connection with the client
+By default recent versions of Valkey don't close the connection with the client
 if the client is idle for many seconds: the connection will remain open forever.
 
 However if you don't like this behavior, you can configure a timeout, so that
@@ -160,14 +160,14 @@ Note that the timeout only applies to normal clients and it **does not apply to 
 
 Even if by default connections are not subject to timeout, there are two conditions when it makes sense to set a timeout:
 
-* Mission critical applications where a bug in the client software may saturate the Redis server with idle connections, causing service disruption.
+* Mission critical applications where a bug in the client software may saturate the Valkey server with idle connections, causing service disruption.
 * As a debugging mechanism in order to be able to connect with the server if a bug in the client software saturates the server with idle connections, making it impossible to interact with the server.
 
-Timeouts are not to be considered very precise: Redis avoids setting timer events or running O(N) algorithms in order to check idle clients, so the check is performed incrementally from time to time. This means that it is possible that while the timeout is set to 10 seconds, the client connection will be closed, for instance, after 12 seconds if many clients are connected at the same time.
+Timeouts are not to be considered very precise: Valkey avoids setting timer events or running O(N) algorithms in order to check idle clients, so the check is performed incrementally from time to time. This means that it is possible that while the timeout is set to 10 seconds, the client connection will be closed, for instance, after 12 seconds if many clients are connected at the same time.
 
 ## The CLIENT Command
 
-The Redis `CLIENT` command allows you to inspect the state of every connected client, to kill a specific client, and to name connections. It is a very powerful debugging tool if you use Redis at scale.
+The Valkey `CLIENT` command allows you to inspect the state of every connected client, to kill a specific client, and to name connections. It is a very powerful debugging tool if you use Valkey at scale.
 
 `CLIENT LIST` is used in order to obtain a list of connected clients and their state:
 
@@ -177,9 +177,9 @@ addr=127.0.0.1:52555 fd=5 name= age=855 idle=0 flags=N db=0 sub=0 psub=0 multi=-
 addr=127.0.0.1:52787 fd=6 name= age=6 idle=5 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=ping
 ```
 
-In the above example two clients are connected to the Redis server. Let's look at what some of the data returned represents:
+In the above example two clients are connected to the Valkey server. Let's look at what some of the data returned represents:
 
-* **addr**: The client address, that is, the client IP and the remote port number it used to connect with the Redis server.
+* **addr**: The client address, that is, the client IP and the remote port number it used to connect with the Valkey server.
 * **fd**: The client socket file descriptor number.
 * **name**: The client name as set by `CLIENT SETNAME`.
 * **age**: The number of seconds the connection existed for.
@@ -197,4 +197,4 @@ The commands `CLIENT SETNAME` and `CLIENT GETNAME` can be used to set and get th
 
 ## TCP keepalive
 
-From version 3.2 onwards, Redis has TCP keepalive (`SO_KEEPALIVE` socket option) enabled by default and set to about 300 seconds. This option is useful in order to detect dead peers (clients that cannot be reached even if they look connected). Moreover, if there is network equipment between clients and servers that need to see some traffic in order to take the connection open, the option will prevent unexpected connection closed events.
+From version 3.2 onwards, Valkey has TCP keepalive (`SO_KEEPALIVE` socket option) enabled by default and set to about 300 seconds. This option is useful in order to detect dead peers (clients that cannot be reached even if they look connected). Moreover, if there is network equipment between clients and servers that need to see some traffic in order to take the connection open, the option will prevent unexpected connection closed events.

--- a/docs/reference/cluster-spec.md
+++ b/docs/reference/cluster-spec.md
@@ -130,7 +130,7 @@ There are no strict technological limits here. CRDTs or synchronously replicated
 state machines can model complex data types similar to Redis. However, the
 actual run time behavior of such systems would not be similar to Redis Cluster.
 Redis Cluster was designed in order to cover the exact use cases of the
-non-clustered Redis version.
+non-clustered Valkey deployment.
 
 ## Overview of Redis Cluster main components
 

--- a/docs/reference/cluster-spec.md
+++ b/docs/reference/cluster-spec.md
@@ -23,7 +23,7 @@ Redis Cluster is a distributed implementation of Redis with the following goals 
 * Acceptable degree of write safety: the system tries (in a best-effort way) to retain all the writes originating from clients connected with the majority of the master nodes. Usually there are small windows where acknowledged writes can be lost. Windows to lose acknowledged writes are larger when clients are in a minority partition.
 * Availability: Redis Cluster is able to survive partitions where the majority of the master nodes are reachable and there is at least one reachable replica for every master node that is no longer reachable. Moreover using *replicas migration*, masters no longer replicated by any replica will receive one from a master which is covered by multiple replicas.
 
-What is described in this document is implemented in Redis 3.0 or greater.
+What is described in this document is implemented in Redis OSS 3.0 or greater.
 
 ### Implemented subset
 
@@ -1201,7 +1201,7 @@ messages are forwarded as needed.
 The clients can send SUBSCRIBE to any node and can also send PUBLISH to any node. 
 It will simply broadcast each published message to all other nodes.
 
-Redis 7.0 and later features sharded pub/sub, in which shard channels are assigned to slots by the same algorithm used to assign keys to slots. 
+Redis OSS 7.0 and later features sharded pub/sub, in which shard channels are assigned to slots by the same algorithm used to assign keys to slots. 
 A shard message must be sent to a node that owns the slot the shard channel is hashed to. 
 The cluster makes sure the published shard messages are forwarded to all nodes in the shard, so clients can subscribe to a shard channel by connecting to either the master responsible for the slot, or to any of its replicas.
 

--- a/docs/reference/cluster-spec.md
+++ b/docs/reference/cluster-spec.md
@@ -292,7 +292,7 @@ The `CLUSTER NODES` command can be sent to any node in the cluster and provides 
 The following is sample output of the `CLUSTER NODES` command sent to a master
 node in a small cluster of three nodes.
 
-    $ redis-cli cluster nodes
+    $ valkey-cli cluster nodes
     d1861060fe6a534d42d8a19aeb36600e18785e04 127.0.0.1:6379 myself - 0 1318428930 1 connected 0-1364
     3886e65cc906bfd9b1f7e7bde468726a052d1dae 127.0.0.1:6380 master - 1318428930 1318428931 2 connected 1365-2729
     d289c575dcbc4bdd2931585fd4339089e461a27d 127.0.0.1:6381 master - 1318428931 1318428931 3 connected 2730-4095
@@ -307,13 +307,13 @@ incoming connections from other Valkey Cluster nodes. This port will be derived 
 Example 1:
 
 If a Valkey node is listening for client connections on port 6379, 
-and you do not add cluster-port parameter in redis.conf,
+and you do not add cluster-port parameter in valkey.conf,
 the Cluster bus port 16379 will be opened.
 
 Example 2:
 
 If a Valkey node is listening for client connections on port 6379, 
-and you set cluster-port 20000 in redis.conf,
+and you set cluster-port 20000 in valkey.conf,
 the Cluster bus port 20000 will be opened.
 
 Node-to-node communication happens exclusively using the Cluster bus and
@@ -487,7 +487,7 @@ is that:
 * All queries about non-existing keys in A are processed by "B", because "A" will redirect clients to "B".
 
 This way we no longer create new keys in "A".
-In the meantime, `redis-cli` used during reshardings
+In the meantime, `valkey-cli` used during reshardings
 and Valkey Cluster configuration will migrate existing keys in
 hash slot 8 from A to B.
 This is performed using the following command:
@@ -495,7 +495,7 @@ This is performed using the following command:
     CLUSTER GETKEYSINSLOT slot count
 
 The above command will return `count` keys in the specified hash slot.
-For keys returned, `redis-cli` sends node "A" a `MIGRATE` command, that
+For keys returned, `valkey-cli` sends node "A" a `MIGRATE` command, that
 will migrate the specified keys from A to B in an atomic way (both instances
 are locked for the time (usually very small time) needed to migrate keys so
 there are no race conditions). This is how `MIGRATE` works:
@@ -935,7 +935,7 @@ So if we receive a heartbeat from node A claiming to serve hash slots 1 and 2 wi
 16383 -> NULL
 ```
 
-When a new cluster is created, a system administrator needs to manually assign (using the `CLUSTER ADDSLOTS` command, via the redis-cli command line tool, or by any other means) the slots served by each master node only to the node itself, and the information will rapidly propagate across the cluster.
+When a new cluster is created, a system administrator needs to manually assign (using the `CLUSTER ADDSLOTS` command, via the valkey-cli command line tool, or by any other means) the slots served by each master node only to the node itself, and the information will rapidly propagate across the cluster.
 
 However this rule is not enough. We know that hash slot mapping can change
 during two events:
@@ -1141,7 +1141,7 @@ If there are any set of nodes with the same `configEpoch`, all the nodes but the
 
 This mechanism also guarantees that after a fresh cluster is created, all
 nodes start with a different `configEpoch` (even if this is not actually
-used) since `redis-cli` makes sure to use `CLUSTER SET-CONFIG-EPOCH` at startup.
+used) since `valkey-cli` makes sure to use `CLUSTER SET-CONFIG-EPOCH` at startup.
 However if for some reason a node is left misconfigured, it will update
 its configuration to a different configuration epoch automatically.
 

--- a/docs/reference/cluster-spec.md
+++ b/docs/reference/cluster-spec.md
@@ -1,55 +1,55 @@
 ---
-title: Redis cluster specification
+title: Valkey cluster specification
 linkTitle: Cluster spec
 weight: 9
 description: >
-    Detailed specification for Redis cluster
+    Detailed specification for Valkey cluster
 aliases:
   - /topics/cluster-spec
 ---
 
-Welcome to the **Redis Cluster Specification**. Here you'll find information
-about the algorithms and design rationales of Redis Cluster. This document is a work
+Welcome to the **Valkey Cluster Specification**. Here you'll find information
+about the algorithms and design rationales of Valkey Cluster. This document is a work
 in progress as it is continuously synchronized with the actual implementation
-of Redis.
+of Valkey.
 
 ## Main properties and rationales of the design
 
-### Redis Cluster goals
+### Valkey Cluster goals
 
-Redis Cluster is a distributed implementation of Redis with the following goals in order of importance in the design:
+Valkey Cluster is a distributed implementation of Valkey with the following goals in order of importance in the design:
 
 * High performance and linear scalability up to 1000 nodes. There are no proxies, asynchronous replication is used, and no merge operations are performed on values.
 * Acceptable degree of write safety: the system tries (in a best-effort way) to retain all the writes originating from clients connected with the majority of the master nodes. Usually there are small windows where acknowledged writes can be lost. Windows to lose acknowledged writes are larger when clients are in a minority partition.
-* Availability: Redis Cluster is able to survive partitions where the majority of the master nodes are reachable and there is at least one reachable replica for every master node that is no longer reachable. Moreover using *replicas migration*, masters no longer replicated by any replica will receive one from a master which is covered by multiple replicas.
+* Availability: Valkey Cluster is able to survive partitions where the majority of the master nodes are reachable and there is at least one reachable replica for every master node that is no longer reachable. Moreover using *replicas migration*, masters no longer replicated by any replica will receive one from a master which is covered by multiple replicas.
 
 What is described in this document is implemented in Redis OSS 3.0 or greater.
 
 ### Implemented subset
 
-Redis Cluster implements all the single key commands available in the
-non-distributed version of Redis. Commands performing complex multi-key
+Valkey Cluster implements all the single key commands available in the
+non-distributed version of Valkey. Commands performing complex multi-key
 operations like set unions and intersections are implemented for cases where
 all of the keys involved in the operation hash to the same slot.
 
-Redis Cluster implements a concept called **hash tags** that can be used
+Valkey Cluster implements a concept called **hash tags** that can be used
 to force certain keys to be stored in the same hash slot. However, during
 manual resharding, multi-key operations may become unavailable for some time
 while single-key operations are always available.
 
-Redis Cluster does not support multiple databases like the standalone version
-of Redis. We only support database `0`; the `SELECT` command is not allowed.
+Valkey Cluster does not support multiple databases like the standalone version
+of Valkey. We only support database `0`; the `SELECT` command is not allowed.
 
-## Client and Server roles in the Redis cluster protocol
+## Client and Server roles in the Valkey cluster protocol
 
-In Redis Cluster, nodes are responsible for holding the data,
+In Valkey Cluster, nodes are responsible for holding the data,
 and taking the state of the cluster, including mapping keys to the right nodes.
 Cluster nodes are also able to auto-discover other nodes, detect non-working
 nodes, and promote replica nodes to master when needed in order
 to continue to operate when a failure occurs.
 
 To perform their tasks all the cluster nodes are connected using a
-TCP bus and a binary protocol, called the **Redis Cluster Bus**.
+TCP bus and a binary protocol, called the **Valkey Cluster Bus**.
 Every node is connected to every other node in the cluster using the cluster
 bus. Nodes use a gossip protocol to propagate information about the cluster
 in order to discover new nodes, to send ping packets to make sure all the
@@ -57,7 +57,7 @@ other nodes are working properly, and to send cluster messages needed to
 signal specific conditions. The cluster bus is also used in order to
 propagate Pub/Sub messages across the cluster and to orchestrate manual
 failovers when requested by users (manual failovers are failovers which
-are not initiated by the Redis Cluster failure detector, but by the
+are not initiated by the Valkey Cluster failure detector, but by the
 system administrator directly).
 
 Since cluster nodes are not able to proxy requests, clients may be redirected
@@ -69,9 +69,9 @@ keys and nodes can improve the performance in a sensible way.
 
 ### Write safety
 
-Redis Cluster uses asynchronous replication between nodes, and **last failover wins** implicit merge function. This means that the last elected master dataset eventually replaces all the other replicas. There is always a window of time when it is possible to lose writes during partitions. However these windows are very different in the case of a client that is connected to the majority of masters, and a client that is connected to the minority of masters.
+Valkey Cluster uses asynchronous replication between nodes, and **last failover wins** implicit merge function. This means that the last elected master dataset eventually replaces all the other replicas. There is always a window of time when it is possible to lose writes during partitions. However these windows are very different in the case of a client that is connected to the majority of masters, and a client that is connected to the minority of masters.
 
-Redis Cluster tries harder to retain writes that are performed by clients connected to the majority of masters, compared to writes performed in the minority side.
+Valkey Cluster tries harder to retain writes that are performed by clients connected to the majority of masters, compared to writes performed in the minority side.
 The following are examples of scenarios that lead to loss of acknowledged
 writes received in the majority partitions during failures:
 
@@ -86,21 +86,21 @@ writes received in the majority partitions during failures:
 
 The second failure mode is unlikely to happen because master nodes unable to communicate with the majority of the other masters for enough time to be failed over will no longer accept writes, and when the partition is fixed writes are still refused for a small amount of time to allow other nodes to inform about configuration changes. This failure mode also requires that the client's routing table has not yet been updated.
 
-Writes targeting the minority side of a partition have a larger window in which to get lost. For example, Redis Cluster loses a non-trivial number of writes on partitions where there is a minority of masters and at least one or more clients, since all the writes sent to the masters may potentially get lost if the masters are failed over in the majority side.
+Writes targeting the minority side of a partition have a larger window in which to get lost. For example, Valkey Cluster loses a non-trivial number of writes on partitions where there is a minority of masters and at least one or more clients, since all the writes sent to the masters may potentially get lost if the masters are failed over in the majority side.
 
-Specifically, for a master to be failed over it must be unreachable by the majority of masters for at least `NODE_TIMEOUT`, so if the partition is fixed before that time, no writes are lost. When the partition lasts for more than `NODE_TIMEOUT`, all the writes performed in the minority side up to that point may be lost. However the minority side of a Redis Cluster will start refusing writes as soon as `NODE_TIMEOUT` time has elapsed without contact with the majority, so there is a maximum window after which the minority becomes no longer available. Hence, no writes are accepted or lost after that time.
+Specifically, for a master to be failed over it must be unreachable by the majority of masters for at least `NODE_TIMEOUT`, so if the partition is fixed before that time, no writes are lost. When the partition lasts for more than `NODE_TIMEOUT`, all the writes performed in the minority side up to that point may be lost. However the minority side of a Valkey Cluster will start refusing writes as soon as `NODE_TIMEOUT` time has elapsed without contact with the majority, so there is a maximum window after which the minority becomes no longer available. Hence, no writes are accepted or lost after that time.
 
 ### Availability
 
-Redis Cluster is not available in the minority side of the partition. In the majority side of the partition assuming that there are at least the majority of masters and a replica for every unreachable master, the cluster becomes available again after `NODE_TIMEOUT` time plus a few more seconds required for a replica to get elected and failover its master (failovers are usually executed in a matter of 1 or 2 seconds).
+Valkey Cluster is not available in the minority side of the partition. In the majority side of the partition assuming that there are at least the majority of masters and a replica for every unreachable master, the cluster becomes available again after `NODE_TIMEOUT` time plus a few more seconds required for a replica to get elected and failover its master (failovers are usually executed in a matter of 1 or 2 seconds).
 
-This means that Redis Cluster is designed to survive failures of a few nodes in the cluster, but it is not a suitable solution for applications that require availability in the event of large net splits.
+This means that Valkey Cluster is designed to survive failures of a few nodes in the cluster, but it is not a suitable solution for applications that require availability in the event of large net splits.
 
 In the example of a cluster composed of N master nodes where every node has a single replica, the majority side of the cluster will remain available as long as a single node is partitioned away, and will remain available with a probability of `1-(1/(N*2-1))` when two nodes are partitioned away (after the first node fails we are left with `N*2-1` nodes in total, and the probability of the only master without a replica to fail is `1/(N*2-1))`.
 
 For example, in a cluster with 5 nodes and a single replica per node, there is a `1/(5*2-1) = 11.11%` probability that after two nodes are partitioned away from the majority, the cluster will no longer be available.
 
-Thanks to a Redis Cluster feature called **replicas migration** the Cluster
+Thanks to a Valkey Cluster feature called **replicas migration** the Cluster
 availability is improved in many real world scenarios by the fact that
 replicas migrate to orphaned masters (masters no longer having replicas).
 So at every successful failure event, the cluster may reconfigure the replicas
@@ -108,7 +108,7 @@ layout in order to better resist the next failure.
 
 ### Performance
 
-In Redis Cluster nodes don't proxy commands to the right node in charge for a given key, but instead they redirect clients to the right nodes serving a given portion of the key space.
+In Valkey Cluster nodes don't proxy commands to the right node in charge for a given key, but instead they redirect clients to the right nodes serving a given portion of the key space.
 
 Eventually clients obtain an up-to-date representation of the cluster and which node serves which subset of keys, so during normal operations clients directly contact the right nodes in order to send a given command.
 
@@ -116,23 +116,23 @@ Because of the use of asynchronous replication, nodes do not wait for other node
 
 Also, because multi-key commands are only limited to *near* keys, data is never moved between nodes except when resharding.
 
-Normal operations are handled exactly as in the case of a single Redis instance. This means that in a Redis Cluster with N master nodes you can expect the same performance as a single Redis instance multiplied by N as the design scales linearly. At the same time the query is usually performed in a single round trip, since clients usually retain persistent connections with the nodes, so latency figures are also the same as the single standalone Redis node case.
+Normal operations are handled exactly as in the case of a single Valkey instance. This means that in a Valkey Cluster with N master nodes you can expect the same performance as a single Valkey instance multiplied by N as the design scales linearly. At the same time the query is usually performed in a single round trip, since clients usually retain persistent connections with the nodes, so latency figures are also the same as the single standalone Valkey node case.
 
 Very high performance and scalability while preserving weak but
 reasonable forms of data safety and availability is the main goal of
-Redis Cluster.
+Valkey Cluster.
 
 ### Why merge operations are avoided
 
-The Redis Cluster design avoids conflicting versions of the same key-value pair in multiple nodes as in the case of the Redis data model this is not always desirable. Values in Redis are often very large; it is common to see lists or sorted sets with millions of elements. Also data types are semantically complex. Transferring and merging these kind of values can be a major bottleneck and/or may require the non-trivial involvement of application-side logic, additional memory to store meta-data, and so forth.
+The Valkey Cluster design avoids conflicting versions of the same key-value pair in multiple nodes as in the case of the Valkey data model this is not always desirable. Values in Valkey are often very large; it is common to see lists or sorted sets with millions of elements. Also data types are semantically complex. Transferring and merging these kind of values can be a major bottleneck and/or may require the non-trivial involvement of application-side logic, additional memory to store meta-data, and so forth.
 
 There are no strict technological limits here. CRDTs or synchronously replicated
-state machines can model complex data types similar to Redis. However, the
-actual run time behavior of such systems would not be similar to Redis Cluster.
-Redis Cluster was designed in order to cover the exact use cases of the
+state machines can model complex data types similar to Valkey. However, the
+actual run time behavior of such systems would not be similar to Valkey Cluster.
+Valkey Cluster was designed in order to cover the exact use cases of the
 non-clustered Valkey deployment.
 
-## Overview of Redis Cluster main components
+## Overview of Valkey Cluster main components
 
 ### Key distribution model
 
@@ -176,7 +176,7 @@ keys evenly across the 16384 slots.
 There is an exception for the computation of the hash slot that is used in order
 to implement **hash tags**. Hash tags are a way to ensure that multiple keys
 are allocated in the same hash slot. This is used in order to implement
-multi-key operations in Redis Cluster.
+multi-key operations in Valkey Cluster.
 
 To implement hash tags, the hash slot for a key is computed in a
 slightly different way in certain conditions.
@@ -203,7 +203,7 @@ Examples:
 
 Commands accepting a glob-style pattern, including `KEYS`, `SCAN` and `SORT`, are optimized for patterns that imply a single slot.
 This means that if all keys that can match a pattern must belong to a specific slot, only this slot is searched for keys matching the pattern.
-The pattern slot optimization is introduced in Redis 8.0.
+The pattern slot optimization is introduced in Valkey 8.0.
 
 The optimization kicks in when the pattern meets the following conditions:
 
@@ -297,22 +297,22 @@ node in a small cluster of three nodes.
     3886e65cc906bfd9b1f7e7bde468726a052d1dae 127.0.0.1:6380 master - 1318428930 1318428931 2 connected 1365-2729
     d289c575dcbc4bdd2931585fd4339089e461a27d 127.0.0.1:6381 master - 1318428931 1318428931 3 connected 2730-4095
 
-In the above listing the different fields are in order: node id, address:port, flags, last ping sent, last pong received, configuration epoch, link state, slots. Details about the above fields will be covered as soon as we talk of specific parts of Redis Cluster.
+In the above listing the different fields are in order: node id, address:port, flags, last ping sent, last pong received, configuration epoch, link state, slots. Details about the above fields will be covered as soon as we talk of specific parts of Valkey Cluster.
 
 ### The cluster bus
 
-Every Redis Cluster node has an additional TCP port for receiving
-incoming connections from other Redis Cluster nodes. This port will be derived by adding 10000 to the data port or it can be specified with the cluster-port config. 
+Every Valkey Cluster node has an additional TCP port for receiving
+incoming connections from other Valkey Cluster nodes. This port will be derived by adding 10000 to the data port or it can be specified with the cluster-port config. 
 
 Example 1:
 
-If a Redis node is listening for client connections on port 6379, 
+If a Valkey node is listening for client connections on port 6379, 
 and you do not add cluster-port parameter in redis.conf,
 the Cluster bus port 16379 will be opened.
 
 Example 2:
 
-If a Redis node is listening for client connections on port 6379, 
+If a Valkey node is listening for client connections on port 6379, 
 and you set cluster-port 20000 in redis.conf,
 the Cluster bus port 20000 will be opened.
 
@@ -320,13 +320,13 @@ Node-to-node communication happens exclusively using the Cluster bus and
 the Cluster bus protocol: a binary protocol composed of frames
 of different types and sizes. The Cluster bus binary protocol is not
 publicly documented since it is not intended for external software devices
-to talk with Redis Cluster nodes using this protocol. However you can
+to talk with Valkey Cluster nodes using this protocol. However you can
 obtain more details about the Cluster bus protocol by reading the
-`cluster.h` and `cluster.c` files in the Redis Cluster source code.
+`cluster.h` and `cluster.c` files in the Valkey Cluster source code.
 
 ### Cluster topology
 
-Redis Cluster is a full mesh where every node is connected with every other node using a TCP connection.
+Valkey Cluster is a full mesh where every node is connected with every other node using a TCP connection.
 
 In a cluster of N nodes, every node has N-1 outgoing TCP connections, and N-1 incoming connections.
 
@@ -334,7 +334,7 @@ These TCP connections are kept alive all the time and are not created on demand.
 When a node expects a pong reply in response to a ping in the cluster bus, before waiting long enough to mark the node as unreachable, it will try to
 refresh the connection with the node by reconnecting from scratch.
 
-While Redis Cluster nodes form a full mesh, **nodes use a gossip protocol and
+While Valkey Cluster nodes form a full mesh, **nodes use a gossip protocol and
 a configuration update mechanism in order to avoid exchanging too many
 messages between nodes during normal conditions**, so the number of messages
 exchanged is not exponential.
@@ -358,13 +358,13 @@ the cluster. Nodes will send `MEET` messages to other nodes **only if** the syst
 
 This means that as long as we join nodes in any connected graph, they'll eventually form a fully connected graph automatically. This means that the cluster is able to auto-discover other nodes, but only if there is a trusted relationship that was forced by the system administrator.
 
-This mechanism makes the cluster more robust but prevents different Redis clusters from accidentally mixing after change of IP addresses or other network related events.
+This mechanism makes the cluster more robust but prevents different Valkey clusters from accidentally mixing after change of IP addresses or other network related events.
 
 ## Redirection and resharding
 
 ### MOVED Redirection
 
-A Redis client is free to send queries to every node in the cluster, including
+A Valkey client is free to send queries to every node in the cluster, including
 replica nodes. The node will analyze the query, and if it is acceptable
 (that is, only a single key is mentioned in the query, or the multiple keys
 mentioned are all to the same hash slot) it will lookup what
@@ -389,7 +389,7 @@ another node. The same happens if the contacted node had no updated information.
 
 So while from the point of view of the cluster nodes are identified by
 IDs we try to simplify our interface with the client just exposing a map
-between hash slots and Redis nodes identified by endpoint:port pairs.
+between hash slots and Valkey nodes identified by endpoint:port pairs.
 
 The client is not required to, but should try to memorize that hash slot
 3999 is served by 127.0.0.1:6381. This way once a new command needs to
@@ -408,11 +408,11 @@ the cluster efficient, with clients directly addressing the right nodes
 without redirections, proxies or other single point of failure entities.
 
 A client **must be also able to handle -ASK redirections** that are described
-later in this document, otherwise it is not a complete Redis Cluster client.
+later in this document, otherwise it is not a complete Valkey Cluster client.
 
 ### Live reconfiguration
 
-Redis Cluster supports the ability to add and remove nodes while the cluster
+Valkey Cluster supports the ability to add and remove nodes while the cluster
 is running. Adding or removing a node is abstracted into the same
 operation: moving a hash slot from one node to another. This means
 that the same basic mechanism can be used in order to rebalance the cluster, add
@@ -424,12 +424,12 @@ or remove nodes, and so forth.
 
 The core of the implementation is the ability to move hash slots around.
 From a practical point of view a hash slot is just a set of keys, so
-what Redis Cluster really does during *resharding* is to move keys from
+what Valkey Cluster really does during *resharding* is to move keys from
 an instance to another instance. Moving a hash slot means moving all the keys
 that happen to hash into this hash slot.
 
 To understand how this works we need to show the `CLUSTER` subcommands
-that are used to manipulate the slots translation table in a Redis Cluster node.
+that are used to manipulate the slots translation table in a Valkey Cluster node.
 
 The following subcommands are available (among others not useful in this case):
 
@@ -442,7 +442,7 @@ The following subcommands are available (among others not useful in this case):
 * `CLUSTER SETSLOT` slot IMPORTING node
 
 The first four commands, `ADDSLOTS`, `DELSLOTS`, `ADDSLOTSRANGE` and `DELSLOTSRANGE`, are simply used to assign
-(or remove) slots to a Redis node. Assigning a slot means to tell a given
+(or remove) slots to a Valkey node. Assigning a slot means to tell a given
 master node that it will be in charge of storing and serving content for
 the specified hash slot.
 
@@ -473,7 +473,7 @@ by the client, the query is redirected to the real hash slot owner via
 a `-MOVED` redirection error, as would happen normally.
 
 Let's make this clearer with an example of hash slot migration.
-Assume that we have two Redis master nodes, called A and B.
+Assume that we have two Valkey master nodes, called A and B.
 We want to move hash slot 8 from A to B, so we issue commands like this:
 
 * We send B: CLUSTER SETSLOT 8 IMPORTING A
@@ -488,7 +488,7 @@ is that:
 
 This way we no longer create new keys in "A".
 In the meantime, `redis-cli` used during reshardings
-and Redis Cluster configuration will migrate existing keys in
+and Valkey Cluster configuration will migrate existing keys in
 hash slot 8 from A to B.
 This is performed using the following command:
 
@@ -507,11 +507,11 @@ the key, and once an OK code is received, the old key from its own dataset
 will be deleted. From the point of view of an external client a key exists
 either in A or B at any given time.
 
-In Redis Cluster there is no need to specify a database other than 0, but
+In Valkey Cluster there is no need to specify a database other than 0, but
 `MIGRATE` is a general command that can be used for other tasks not
-involving Redis Cluster.
+involving Valkey Cluster.
 `MIGRATE` is optimized to be as fast as possible even when moving complex
-keys such as long lists, but in Redis Cluster reconfiguring the
+keys such as long lists, but in Valkey Cluster reconfiguring the
 cluster where big keys are present is not considered a wise procedure if
 there are latency constraints in the application using the database.
 
@@ -559,7 +559,7 @@ command documentation.
 
 ### Client connections and redirection handling
 
-To be efficient, Redis Cluster clients maintain a map of the current slot
+To be efficient, Valkey Cluster clients maintain a map of the current slot
 configuration. However, this configuration is not *required* to be up to date.
 When contacting the wrong node results in a redirection, the client
 can update its internal slot map accordingly.
@@ -651,7 +651,7 @@ Normally replica nodes will redirect clients to the authoritative master for
 the hash slot involved in a given command, however clients can use replicas
 in order to scale reads using the `READONLY` command.
 
-`READONLY` tells a Redis Cluster replica node that the client is ok reading
+`READONLY` tells a Valkey Cluster replica node that the client is ok reading
 possibly stale data and is not interested in running write queries.
 
 When the connection is in readonly mode, the cluster will send a redirection
@@ -670,7 +670,7 @@ The readonly state of the connection can be cleared using the `READWRITE` comman
 
 ### Heartbeat and gossip messages
 
-Redis Cluster nodes continuously exchange ping and pong packets. Those two kinds of packets have the same structure, and both carry important configuration information. The only actual difference is the message type field. We'll refer to the sum of ping and pong packets as *heartbeat packets*.
+Valkey Cluster nodes continuously exchange ping and pong packets. Those two kinds of packets have the same structure, and both carry important configuration information. The only actual difference is the message type field. We'll refer to the sum of ping and pong packets as *heartbeat packets*.
 
 Usually nodes send ping packets that will trigger the receivers to reply with pong packets. However this is not necessarily true. It is possible for nodes to just send pong packets to send information to other nodes about their configuration, without triggering a reply. This is useful, for example, in order to broadcast a new configuration as soon as possible.
 
@@ -683,7 +683,7 @@ The number of messages globally exchanged can be sizable if `NODE_TIMEOUT` is se
 For example in a 100 node cluster with a node timeout set to 60 seconds, every node will try to send 99 pings every 30 seconds, with a total amount of pings of 3.3 per second. Multiplied by 100 nodes, this is 330 pings per second in the total cluster.
 
 There are ways to lower the number of messages, however there have been no
-reported issues with the bandwidth currently used by Redis Cluster failure
+reported issues with the bandwidth currently used by Valkey Cluster failure
 detection, so for now the obvious and direct design is used. Note that even
 in the above example, the 330 packets per second exchanged are evenly
 divided among 100 different nodes, so the traffic each node receives
@@ -695,12 +695,12 @@ Ping and pong packets contain a header that is common to all types of packets (f
 
 The common header has the following information:
 
-* Node ID, a 160 bit pseudorandom string that is assigned the first time a node is created and remains the same for all the life of a Redis Cluster node.
-* The `currentEpoch` and `configEpoch` fields of the sending node that are used to mount the distributed algorithms used by Redis Cluster (this is explained in detail in the next sections). If the node is a replica the `configEpoch` is the last known `configEpoch` of its master.
+* Node ID, a 160 bit pseudorandom string that is assigned the first time a node is created and remains the same for all the life of a Valkey Cluster node.
+* The `currentEpoch` and `configEpoch` fields of the sending node that are used to mount the distributed algorithms used by Valkey Cluster (this is explained in detail in the next sections). If the node is a replica the `configEpoch` is the last known `configEpoch` of its master.
 * The node flags, indicating if the node is a replica, a master, and other single-bit node information.
 * A bitmap of the hash slots served by the sending node, or if the node is a replica, a bitmap of the slots served by its master.
-* The sender TCP base port that is the port used by Redis to accept client commands.
-* The cluster port that is the port used by Redis for node-to-node communication.
+* The sender TCP base port that is the port used by Valkey to accept client commands.
+* The cluster port that is the port used by Valkey for node-to-node communication.
 * The state of the cluster from the point of view of the sender (down or ok).
 * The master node ID of the sending node, if it is a replica.
 
@@ -716,7 +716,7 @@ Gossip sections allow receiving nodes to get information about the state of othe
 
 ### Failure detection
 
-Redis Cluster failure detection is used to recognize when a master or replica node is no longer reachable by the majority of nodes and then respond by promoting a replica to the role of master. When replica promotion is not possible the cluster is put in an error state to stop receiving queries from clients.
+Valkey Cluster failure detection is used to recognize when a master or replica node is no longer reachable by the majority of nodes and then respond by promoting a replica to the role of master. When replica promotion is not possible the cluster is put in an error state to stop receiving queries from clients.
 
 As already mentioned, every node takes a list of flags associated with other known nodes. There are two flags that are used for failure detection that are called `PFAIL` and `FAIL`. `PFAIL` means *Possible failure*, and is a non-acknowledged failure type. `FAIL` means that a node is failing and that this condition was confirmed by a majority of masters within a fixed amount of time.
 
@@ -724,7 +724,7 @@ As already mentioned, every node takes a list of flags associated with other kno
 
 A node flags another node with the `PFAIL` flag when the node is not reachable for more than `NODE_TIMEOUT` time. Both master and replica nodes can flag another node as `PFAIL`, regardless of its type.
 
-The concept of non-reachability for a Redis Cluster node is that we have an **active ping** (a ping that we sent for which we have yet to get a reply) pending for longer than `NODE_TIMEOUT`. For this mechanism to work the `NODE_TIMEOUT` must be large compared to the network round trip time. In order to add reliability during normal operations, nodes will try to reconnect with other nodes in the cluster as soon as half of the `NODE_TIMEOUT` has elapsed without a reply to a ping. This mechanism ensures that connections are kept alive so broken connections usually won't result in false failure reports between nodes.
+The concept of non-reachability for a Valkey Cluster node is that we have an **active ping** (a ping that we sent for which we have yet to get a reply) pending for longer than `NODE_TIMEOUT`. For this mechanism to work the `NODE_TIMEOUT` must be large compared to the network round trip time. In order to add reliability during normal operations, nodes will try to reconnect with other nodes in the cluster as soon as half of the `NODE_TIMEOUT` has elapsed without a reply to a ping. This mechanism ensures that connections are kept alive so broken connections usually won't result in false failure reports between nodes.
 
 **FAIL flag:**
 
@@ -756,23 +756,23 @@ It is useful to note that while the `PFAIL` -> `FAIL` transition uses a form of 
 1. Nodes collect views of other nodes over some time period, so even if the majority of master nodes need to "agree", actually this is just state that we collected from different nodes at different times and we are not sure, nor we require, that at a given moment the majority of masters agreed. However we discard failure reports which are old, so the failure was signaled by the majority of masters within a window of time.
 2. While every node detecting the `FAIL` condition will force that condition on other nodes in the cluster using the `FAIL` message, there is no way to ensure the message will reach all the nodes. For instance a node may detect the `FAIL` condition and because of a partition will not be able to reach any other node.
 
-However the Redis Cluster failure detection has a liveness requirement: eventually all the nodes should agree about the state of a given node. There are two cases that can originate from split brain conditions. Either some minority of nodes believe the node is in `FAIL` state, or a minority of nodes believe the node is not in `FAIL` state. In both the cases eventually the cluster will have a single view of the state of a given node:
+However the Valkey Cluster failure detection has a liveness requirement: eventually all the nodes should agree about the state of a given node. There are two cases that can originate from split brain conditions. Either some minority of nodes believe the node is in `FAIL` state, or a minority of nodes believe the node is not in `FAIL` state. In both the cases eventually the cluster will have a single view of the state of a given node:
 
 **Case 1**: If a majority of masters have flagged a node as `FAIL`, because of failure detection and the *chain effect* it generates, every other node will eventually flag the master as `FAIL`, since in the specified window of time enough failures will be reported.
 
 **Case 2**: When only a minority of masters have flagged a node as `FAIL`, the replica promotion will not happen (as it uses a more formal algorithm that makes sure everybody knows about the promotion eventually) and every node will clear the `FAIL` state as per the `FAIL` state clearing rules above (i.e. no promotion after N times the `NODE_TIMEOUT` has elapsed).
 
-**The `FAIL` flag is only used as a trigger to run the safe part of the algorithm** for the replica promotion. In theory a replica may act independently and start a replica promotion when its master is not reachable, and wait for the masters to refuse to provide the acknowledgment if the master is actually reachable by the majority. However the added complexity of the `PFAIL -> FAIL` state, the weak agreement, and the `FAIL` message forcing the propagation of the state in the shortest amount of time in the reachable part of the cluster, have practical advantages. Because of these mechanisms, usually all the nodes will stop accepting writes at about the same time if the cluster is in an error state. This is a desirable feature from the point of view of applications using Redis Cluster. Also erroneous election attempts initiated by replicas that can't reach its master due to local problems (the master is otherwise reachable by the majority of other master nodes) are avoided.
+**The `FAIL` flag is only used as a trigger to run the safe part of the algorithm** for the replica promotion. In theory a replica may act independently and start a replica promotion when its master is not reachable, and wait for the masters to refuse to provide the acknowledgment if the master is actually reachable by the majority. However the added complexity of the `PFAIL -> FAIL` state, the weak agreement, and the `FAIL` message forcing the propagation of the state in the shortest amount of time in the reachable part of the cluster, have practical advantages. Because of these mechanisms, usually all the nodes will stop accepting writes at about the same time if the cluster is in an error state. This is a desirable feature from the point of view of applications using Valkey Cluster. Also erroneous election attempts initiated by replicas that can't reach its master due to local problems (the master is otherwise reachable by the majority of other master nodes) are avoided.
 
 ## Configuration handling, propagation, and failovers
 
 ### Cluster current epoch
 
-Redis Cluster uses a concept similar to the Raft algorithm "term". In Redis Cluster the term is called epoch instead, and it is used in order to give incremental versioning to events. When multiple nodes provide conflicting information, it becomes possible for another node to understand which state is the most up to date.
+Valkey Cluster uses a concept similar to the Raft algorithm "term". In Valkey Cluster the term is called epoch instead, and it is used in order to give incremental versioning to events. When multiple nodes provide conflicting information, it becomes possible for another node to understand which state is the most up to date.
 
 The `currentEpoch` is a 64 bit unsigned number.
 
-At node creation every Redis Cluster node, both replicas and master nodes, set the `currentEpoch` to 0.
+At node creation every Valkey Cluster node, both replicas and master nodes, set the `currentEpoch` to 0.
 
 Every time a packet is received from another node, if the epoch of the sender (part of the cluster bus messages header) is greater than the local node epoch, the `currentEpoch` is updated to the sender epoch.
 
@@ -900,7 +900,7 @@ has stale information and will send an `UPDATE` message.
 
 ### Hash slots configuration propagation
 
-An important part of Redis Cluster is the mechanism used to propagate the information about which cluster node is serving a given set of hash slots. This is vital to both the startup of a fresh cluster and the ability to upgrade the configuration after a replica was promoted to serve the slots of its failing master.
+An important part of Valkey Cluster is the mechanism used to propagate the information about which cluster node is serving a given set of hash slots. This is vital to both the startup of a fresh cluster and the ability to upgrade the configuration after a replica was promoted to serve the slots of its failing master.
 
 The same mechanism allows nodes partitioned away for an indefinite amount of
 time to rejoin the cluster in a sensible way.
@@ -911,7 +911,7 @@ There are two ways hash slot configurations are propagated:
 2. `UPDATE` messages. Since in every heartbeat packet there is information about the sender `configEpoch` and set of hash slots served, if a receiver of a heartbeat packet finds the sender information is stale, it will send a packet with new information, forcing the stale node to update its info.
 
 The receiver of a heartbeat or `UPDATE` message uses certain simple rules in
-order to update its table mapping hash slots to nodes. When a new Redis Cluster node is created, its local hash slot table is simply initialized to `NULL` entries so that each hash slot is not bound or linked to any node. This looks similar to the following:
+order to update its table mapping hash slots to nodes. When a new Valkey Cluster node is created, its local hash slot table is simply initialized to `NULL` entries so that each hash slot is not bound or linked to any node. This looks similar to the following:
 
 ```
 0 -> NULL
@@ -965,7 +965,7 @@ So after receiving messages from B that claim to serve hash slots 1 and 2 with c
 
 Liveness property: because of the second rule, eventually all nodes in the cluster will agree that the owner of a slot is the one with the greatest `configEpoch` among the nodes advertising it.
 
-This mechanism in Redis Cluster is called **last failover wins**.
+This mechanism in Valkey Cluster is called **last failover wins**.
 
 The same happens during resharding. When a node importing a hash slot completes
 the import operation, its configuration epoch is incremented to make sure the
@@ -995,7 +995,7 @@ happen that A rejoins after a lot of time, in the meantime it may happen that
 hash slots originally served by A are served by multiple nodes, for example
 hash slot 1 may be served by B, and hash slot 2 by C.
 
-So the actual *Redis Cluster node role switch rule* is: **A master node will change its configuration to replicate (be a replica of) the node that stole its last hash slot**.
+So the actual *Valkey Cluster node role switch rule* is: **A master node will change its configuration to replicate (be a replica of) the node that stole its last hash slot**.
 
 During reconfiguration, eventually the number of served hash slots will drop to zero, and the node will reconfigure accordingly. Note that in the base case this just means that the old master will be a replica of the replica that replaced it after a failover. However in the general form the rule covers all possible cases.
 
@@ -1004,7 +1004,7 @@ stole the last hash slot of its former master.
 
 ### Replica migration
 
-Redis Cluster implements a concept called *replica migration* in order to
+Valkey Cluster implements a concept called *replica migration* in order to
 improve the availability of the system. The idea is that in a cluster with
 a master-replica setup, if the map between replicas and masters is fixed
 availability is limited over time if multiple independent failures of single
@@ -1022,7 +1022,7 @@ that can accumulate over time. For example:
 
 If the map between masters and replicas is fixed, the only way to make the cluster
 more resistant to the above scenario is to add replicas to every master, however
-this is costly as it requires more instances of Redis to be executed, more
+this is costly as it requires more instances of Valkey to be executed, more
 memory, and so forth.
 
 An alternative is to create an asymmetry in the cluster, and let the cluster
@@ -1044,7 +1044,7 @@ following:
 ### Replica migration algorithm
 
 The migration algorithm does not use any form of agreement since the replica
-layout in a Redis Cluster is not part of the cluster configuration that needs
+layout in a Valkey Cluster is not part of the cluster configuration that needs
 to be consistent and/or versioned with config epochs. Instead it uses an
 algorithm to avoid mass-migration of replicas when a master is not backed.
 The algorithm guarantees that eventually (once the cluster configuration is
@@ -1125,7 +1125,7 @@ are no issues. It is more important that replicas failing over a master have
 unique configuration epochs.
 
 That said, manual interventions or resharding may change the cluster
-configuration in different ways. The Redis Cluster main liveness property
+configuration in different ways. The Valkey Cluster main liveness property
 requires that slot configurations always converge, so under every circumstance
 we really want all the master nodes to have a different `configEpoch`.
 
@@ -1153,7 +1153,7 @@ operations, in testing, and in cloud environments where a given node can
 be reprovisioned to join a different set of nodes to enlarge or create a new
 cluster.
 
-In Redis Cluster nodes are reset using the `CLUSTER RESET` command. The
+In Valkey Cluster nodes are reset using the `CLUSTER RESET` command. The
 command is provided in two variants:
 
 * `CLUSTER RESET SOFT`
@@ -1188,13 +1188,13 @@ The command does two things:
 1. It removes the node with the specified node ID from the nodes table.
 2. It sets a 60 second ban which prevents a node with the same node ID from being re-added.
 
-The second operation is needed because Redis Cluster uses gossip in order to auto-discover nodes, so removing the node X from node A, could result in node B gossiping about node X to A again. Because of the 60 second ban, the Redis Cluster administration tools have 60 seconds in order to remove the node from all the nodes, preventing the re-addition of the node due to auto discovery.
+The second operation is needed because Valkey Cluster uses gossip in order to auto-discover nodes, so removing the node X from node A, could result in node B gossiping about node X to A again. Because of the 60 second ban, the Valkey Cluster administration tools have 60 seconds in order to remove the node from all the nodes, preventing the re-addition of the node due to auto discovery.
 
 Further information is available in the `CLUSTER FORGET` documentation.
 
 ## Publish/Subscribe
 
-In a Redis Cluster, clients can subscribe to every node, and can also
+In a Valkey Cluster, clients can subscribe to every node, and can also
 publish to every other node. The cluster will make sure that published
 messages are forwarded as needed.
 
@@ -1211,7 +1211,7 @@ The cluster makes sure the published shard messages are forwarded to all nodes i
 
     /*
      * Copyright 2001-2010 Georges Menie (www.menie.org)
-     * Copyright 2010 Salvatore Sanfilippo (adapted to Redis coding style)
+     * Copyright 2010 Salvatore Sanfilippo (adapted to Valkey coding style)
      * All rights reserved.
      * Redistribution and use in source and binary forms, with or without
      * modification, are permitted provided that the following conditions are met:

--- a/docs/reference/command-arguments.md
+++ b/docs/reference/command-arguments.md
@@ -38,8 +38,8 @@ Every element in the _arguments_ array is a map with the following fields:
   It is a 0-based index of the specification in the command's [key specifications][tr] that corresponds to the argument.
 * **token**: a constant literal that precedes the argument (user input) itself.
 * **summary:** a short description of the argument.
-* **since:** the debut Redis version of the argument (or for module commands, the module version).
-* **deprecated_since:** the Redis version that deprecated the command (or for module commands, the module version).
+* **since:** the debut Redis OSS version of the argument (or for module commands, the module version).
+* **deprecated_since:** the Redis OSS version that deprecated the command (or for module commands, the module version).
 * **flags:** an array of argument flags.
   Possible flags are:
   - **optional**: denotes that the argument is optional (for example, the _GET_ clause of the  `SET` command).

--- a/docs/reference/command-arguments.md
+++ b/docs/reference/command-arguments.md
@@ -1,13 +1,13 @@
 ---
-title: "Redis command arguments"
+title: "Valkey command arguments"
 linkTitle: "Command arguments"
 weight: 7
-description: How Redis commands expose their documentation programmatically
+description: How Valkey commands expose their documentation programmatically
 aliases:
     - /topics/command-arguments
 ---
 
-The `COMMAND DOCS` command returns documentation-focused information about available Redis commands.
+The `COMMAND DOCS` command returns documentation-focused information about available Valkey commands.
 The map reply that the command returns includes the _arguments_ key.
 This key stores an array that describes the command's arguments.
 

--- a/docs/reference/command-tips.md
+++ b/docs/reference/command-tips.md
@@ -23,14 +23,14 @@ That means that calls to the command may yield different results with the same a
 That difference could be the result of the command's random nature (e.g., `RANDOMKEY` and `SPOP`); the call's timing (e.g., `TTL`); or generic differences that relate to the server's state (e.g., `INFO` and `CLIENT LIST`).
 
 **Note:**
-Prior to Redis 7.0, this tip was the _random_ command flag.
+Prior to Redis OSS 7.0, this tip was the _random_ command flag.
 
 ## nondeterministic_output_order
 
 The existence of this tip indicates that the command's output is deterministic, but its ordering is random (e.g., `HGETALL` and `SMEMBERS`).
 
 **Note:**
-Prior to Redis 7.0, this tip was the _sort_\__for_\__script_ flag.
+Prior to Redis OSS 7.0, this tip was the _sort_\__for_\__script_ flag.
 
 ## request_policy
 

--- a/docs/reference/command-tips.md
+++ b/docs/reference/command-tips.md
@@ -1,5 +1,5 @@
 ---
-title: "Redis command tips"
+title: "Valkey command tips"
 linkTitle: "Command tips"
 weight: 1
 description: Get additional information about a command
@@ -8,8 +8,8 @@ aliases:
 ---
 
 Command tips are an array of strings.
-These provide Redis clients with additional information about the command.
-The information can instruct Redis Cluster clients as to how the command should be executed and its output processed in a clustered deployment.
+These provide Valkey clients with additional information about the command.
+The information can instruct Valkey Cluster clients as to how the command should be executed and its output processed in a clustered deployment.
 
 Unlike the command's flags (see the 3rd element of `COMMAND`'s reply), which are strictly internal to the server's operation, tips don't serve any purpose other than being reported to clients.
 

--- a/docs/reference/eviction/index.md
+++ b/docs/reference/eviction/index.md
@@ -22,11 +22,11 @@ the exact LRU.
 
 The `maxmemory` configuration directive configures Valkey
 to use a specified amount of memory for the data set. You can
-set the configuration directive using the `redis.conf` file, or later using
+set the configuration directive using the `valkey.conf` file, or later using
 the `CONFIG SET` command at runtime.
 
 For example, to configure a memory limit of 100 megabytes, you can use the
-following directive inside the `redis.conf` file:
+following directive inside the `valkey.conf` file:
 
     maxmemory 100mb
 
@@ -160,7 +160,7 @@ By default Valkey is configured to:
 
 Those should be reasonable values and were tested experimentally, but the user may want to play with these configuration settings to pick optimal values.
 
-Instructions about how to tune these parameters can be found inside the example `redis.conf` file in the source distribution. Briefly, they are:
+Instructions about how to tune these parameters can be found inside the example `valkey.conf` file in the source distribution. Briefly, they are:
 
 ```
 lfu-log-factor 10
@@ -185,4 +185,4 @@ The counter *logarithm factor* changes how many hits are needed to saturate the 
 +--------+------------+------------+------------+------------+------------+
 ```
 
-So basically the factor is a trade off between better distinguishing items with low accesses VS distinguishing items with high accesses. More information is available in the example `redis.conf` file.
+So basically the factor is a trade off between better distinguishing items with low accesses VS distinguishing items with high accesses. More information is available in the example `valkey.conf` file.

--- a/docs/reference/eviction/index.md
+++ b/docs/reference/eviction/index.md
@@ -94,7 +94,7 @@ was accessed the furthest in the past. Instead it will try to run an approximati
 of the LRU algorithm, by sampling a small number of keys, and evicting the
 one that is the best (with the oldest access time) among the sampled keys.
 
-However, since Redis 3.0 the algorithm was improved to also take a pool of good
+However, since Redis OSS 3.0 the algorithm was improved to also take a pool of good
 candidates for eviction. This improved the performance of the algorithm, making
 it able to approximate more closely the behavior of a real LRU algorithm.
 
@@ -119,7 +119,7 @@ You can see three kind of dots in the graphs, forming three distinct bands.
 
 In a theoretical LRU implementation we expect that, among the old keys, the first half will be expired. The Redis LRU algorithm will instead only *probabilistically* expire the older keys.
 
-As you can see Redis 3.0 does a better job with 5 samples compared to Redis 2.8, however most objects that are among the latest accessed are still retained by Redis 2.8. Using a sample size of 10 in Redis 3.0 the approximation is very close to the theoretical performance of Redis 3.0.
+As you can see Redis OSS 3.0 does a better job with 5 samples compared to Redis OSS 2.8, however most objects that are among the latest accessed are still retained by Redis OSS 2.8. Using a sample size of 10 in Redis OSS 3.0 the approximation is very close to the theoretical performance of Redis OSS 3.0.
 
 Note that LRU is just a model to predict how likely a given key will be accessed in the future. Moreover, if your data access pattern closely
 resembles the power law, most of the accesses will be in the set of keys
@@ -136,7 +136,7 @@ the `CONFIG SET maxmemory-samples <count>` command, is very simple.
 
 ## The new LFU mode
 
-Starting with Redis 4.0, the [Least Frequently Used eviction mode](http://antirez.com/news/109) is available. This mode may work better (provide a better
+Starting with Redis OSS 4.0, the [Least Frequently Used eviction mode](http://antirez.com/news/109) is available. This mode may work better (provide a better
 hits/misses ratio) in certain cases. In LFU mode, Redis will try to track
 the frequency of access of items, so the ones used rarely are evicted. This means
 the keys used often have a higher chance of remaining in memory.

--- a/docs/reference/gopher.md
+++ b/docs/reference/gopher.md
@@ -1,20 +1,20 @@
 ---
-title: "Redis and the Gopher protocol"
+title: "Valkey and the Gopher protocol"
 linkTitle: "Gopher protocol"
 weight: 10
-description: The Redis Gopher protocol implementation
+description: The Valkey Gopher protocol implementation
 aliases:
   - /topics/gopher
 ---
 
 ** Note: Support for Gopher was removed in Redis OSS 7.0 **
 
-Redis contains an implementation of the Gopher protocol, as specified in
+Valkey contains an implementation of the Gopher protocol, as specified in
 the [RFC 1436](https://www.ietf.org/rfc/rfc1436.txt).
 
 The Gopher protocol was very popular in the late '90s. It is an alternative
 to the web, and the implementation both server and client side is so simple
-that the Redis server has just 100 lines of code in order to implement this
+that the Valkey server has just 100 lines of code in order to implement this
 support.
 
 What do you do with Gopher nowadays? Well Gopher never *really* died, and
@@ -24,18 +24,18 @@ internet, others believe that the mainstream internet became too much
 controlled, and it's cool to create an alternative space for people that
 want a bit of fresh air.
 
-Anyway, for the 10th birthday of the Redis, we gave it the Gopher protocol
+Anyway, for the 10th birthday of the Valkey, we gave it the Gopher protocol
 as a gift.
 
 ## How it works
 
-The Redis Gopher support uses the inline protocol of Redis, and specifically
+The Valkey Gopher support uses the inline protocol of Valkey, and specifically
 two kind of inline requests that were anyway illegal: an empty request
-or any request that starts with "/" (there are no Redis commands starting
+or any request that starts with "/" (there are no Valkey commands starting
 with such a slash). Normal RESP2/RESP3 requests are completely out of the
 path of the Gopher protocol implementation and are served as usually as well.
 
-If you open a connection to Redis when Gopher is enabled and send it
+If you open a connection to Valkey when Gopher is enabled and send it
 a string like "/foo", if there is a key named "/foo" it is served via the
 Gopher protocol.
 
@@ -44,7 +44,7 @@ talking), you likely need a script such as the one in [https://github.com/antire
 
 ## SECURITY WARNING
 
-If you plan to put Redis on the internet in a publicly accessible address
+If you plan to put Valkey on the internet in a publicly accessible address
 to server Gopher pages **make sure to set a password** to the instance.
 Once a password is set:
 

--- a/docs/reference/gopher.md
+++ b/docs/reference/gopher.md
@@ -7,7 +7,7 @@ aliases:
   - /topics/gopher
 ---
 
-** Note: Support for Gopher was removed in Redis 7.0 **
+** Note: Support for Gopher was removed in Redis OSS 7.0 **
 
 Redis contains an implementation of the Gopher protocol, as specified in
 the [RFC 1436](https://www.ietf.org/rfc/rfc1436.txt).

--- a/docs/reference/internals/_index.md
+++ b/docs/reference/internals/_index.md
@@ -1,10 +1,10 @@
 ---
-title: "Redis internals"
+title: "Valkey internals"
 linkTitle: "Internals"
 weight: 12
-description: Documents describing internals in early Redis implementations
+description: Documents describing internals in early Valkey implementations
 aliases:
   - /topics/internals
 ---
 
-**The following Redis documents were written by the creator of Redis, Salvatore Sanfilippo, early in the development of Redis (c. 2010), and do not necessarily reflect the latest Redis implementation.**
+**The following Valkey documents were written by the creator of Valkey, Salvatore Sanfilippo, early in the development of Valkey (c. 2010), and do not necessarily reflect the latest Valkey implementation.**

--- a/docs/reference/internals/internals-rediseventlib.md
+++ b/docs/reference/internals/internals-rediseventlib.md
@@ -2,13 +2,13 @@
 title: "Event library"
 linkTitle: "Event library"
 weight: 1
-description: What's an event library, and how was the original Redis event library implemented?
+description: What's an event library, and how was the original Valkey event library implemented?
 aliases:
   - /topics/internals-eventlib
   - /topics/internals-rediseventlib
 ---
 
-**Note: this document was written by the creator of Redis, Salvatore Sanfilippo, early in the development of Redis (c. 2010), and does not necessarily reflect the latest Redis implementation.**
+**Note: this document was written by the creator of Valkey, Salvatore Sanfilippo, early in the development of Valkey (c. 2010), and does not necessarily reflect the latest Valkey implementation.**
 
 ## Why is an Event Library needed at all?
 
@@ -32,19 +32,19 @@ A: They use the operating system's polling facility along with timers.
 Q: So are there any open source event libraries that do what you just described? <br/>
 A: Yes. `libevent` and `libev` are two such event libraries that I can recall off the top of my head.
 
-Q: Does Redis use such open source event libraries for handling socket I/O?<br/>
-A: No. For various [reasons](http://groups.google.com/group/redis-db/browse_thread/thread/b52814e9ef15b8d0/) Redis uses its own event library.
+Q: Does Valkey use such open source event libraries for handling socket I/O?<br/>
+A: No. For various [reasons](http://groups.google.com/group/redis-db/browse_thread/thread/b52814e9ef15b8d0/) Valkey uses its own event library.
 
-## The Redis event library
+## The Valkey event library
 
-Redis implements its own event library. The event library is implemented in `ae.c`.
+Valkey implements its own event library. The event library is implemented in `ae.c`.
 
-The best way to understand how the Redis event library works is to understand how Redis uses it.
+The best way to understand how the Valkey event library works is to understand how Valkey uses it.
 
 Event Loop Initialization
 ---
 
-`initServer` function defined in `redis.c` initializes the numerous fields of the `redisServer` structure variable. One such field is the Redis event loop `el`:
+`initServer` function defined in `redis.c` initializes the numerous fields of the `redisServer` structure variable. One such field is the Valkey event loop `el`:
 
     aeEventLoop *el
 
@@ -86,7 +86,7 @@ Next is `ae.c:aeCreateTimeEvent`. But before that `initServer` call `anet.c:anet
 
     aeCreateTimeEvent(server.el /*eventLoop*/, 1 /*milliseconds*/, serverCron /*proc*/, NULL /*clientData*/, NULL /*finalizerProc*/);
 
-`redis.c:serverCron` performs many operations that helps keep Redis running properly.
+`redis.c:serverCron` performs many operations that helps keep Valkey running properly.
 
 `aeCreateFileEvent`
 ---
@@ -102,7 +102,7 @@ Following is an explanation of what precisely `aeCreateFileEvent` does when call
   * `AE_READABLE`: Signifies that `server.fd` has to be watched for `EPOLLIN` event.
   * `acceptHandler`: The function that has to be executed when the event being watched for is ready. This function pointer is stored in `eventLoop->events[server.fd]->rfileProc`.
 
-This completes the initialization of Redis event loop.
+This completes the initialization of Valkey event loop.
 
 Event Loop Processing
 ---

--- a/docs/reference/internals/internals-sds.md
+++ b/docs/reference/internals/internals-sds.md
@@ -7,7 +7,7 @@ aliases:
   - /topics/internals-sds
 ---
 
-**Note: this document was written by the creator of Redis, Salvatore Sanfilippo, early in the development of Redis (c. 2010). Virtual Memory has been deprecated since Redis 2.6, so this documentation
+**Note: this document was written by the creator of Redis, Salvatore Sanfilippo, early in the development of Redis (c. 2010). Virtual Memory has been deprecated since Redis OSS 2.6, so this documentation
 is here only for historical interest.**
 
 The implementation of Strings is contained in `sds.c` (`sds` stands for

--- a/docs/reference/internals/internals-sds.md
+++ b/docs/reference/internals/internals-sds.md
@@ -7,7 +7,7 @@ aliases:
   - /topics/internals-sds
 ---
 
-**Note: this document was written by the creator of Redis, Salvatore Sanfilippo, early in the development of Redis (c. 2010). Virtual Memory has been deprecated since Redis OSS 2.6, so this documentation
+**Note: this document was written by the creator of Valkey, Salvatore Sanfilippo, early in the development of Valkey (c. 2010). Virtual Memory has been deprecated since Redis OSS 2.6, so this documentation
 is here only for historical interest.**
 
 The implementation of Strings is contained in `sds.c` (`sds` stands for

--- a/docs/reference/internals/internals-vm.md
+++ b/docs/reference/internals/internals-vm.md
@@ -2,42 +2,42 @@
 title: "Virtual memory (deprecated)"
 linkTitle: "Virtual memory"
 weight: 1
-description: A description of the Redis virtual memory system that was deprecated in 2.6. This document exists for historical interest.
+description: A description of the Valkey virtual memory system that was deprecated in 2.6. This document exists for historical interest.
 aliases:
   - /topics/internals-vm
   - /topics/virtual-memory
 ---
 
-**Note: this document was written by the creator of Redis, Salvatore Sanfilippo, early in the development of Redis (c. 2010). Virtual Memory has been deprecated since Redis OSS 2.6, so this documentation
+**Note: this document was written by the creator of Valkey, Salvatore Sanfilippo, early in the development of Valkey (c. 2010). Virtual Memory has been deprecated since Redis OSS 2.6, so this documentation
 is here only for historical interest.**
 
-This document details the internals of the Redis Virtual Memory subsystem prior to Redis OSS 2.6. The intended audience is not the final user but programmers willing to understand or modify the Virtual Memory implementation.
+This document details the internals of the Valkey Virtual Memory subsystem prior to Redis OSS 2.6. The intended audience is not the final user but programmers willing to understand or modify the Virtual Memory implementation.
 
 Keys vs Values: what is swapped out?
 ---
 
-The goal of the VM subsystem is to free memory transferring Redis Objects from memory to disk. This is a very generic command, but specifically, Redis transfers only objects associated with _values_. In order to understand better this concept we'll show, using the DEBUG command, how a key holding a value looks from the point of view of the Redis internals:
+The goal of the VM subsystem is to free memory transferring Valkey Objects from memory to disk. This is a very generic command, but specifically, Valkey transfers only objects associated with _values_. In order to understand better this concept we'll show, using the DEBUG command, how a key holding a value looks from the point of view of the Valkey internals:
 
     redis> set foo bar
     OK
     redis> debug object foo
     Key at:0x100101d00 refcount:1, value at:0x100101ce0 refcount:1 encoding:raw serializedlength:4
 
-As you can see from the above output, the Redis top level hash table maps Redis Objects (keys) to other Redis Objects (values). The Virtual Memory is only able to swap _values_ on disk, the objects associated to _keys_ are always taken in memory: this trade off guarantees very good lookup performances, as one of the main design goals of the Redis VM is to have performances similar to Redis with VM disabled when the part of the dataset frequently used fits in RAM.
+As you can see from the above output, the Valkey top level hash table maps Valkey Objects (keys) to other Valkey Objects (values). The Virtual Memory is only able to swap _values_ on disk, the objects associated to _keys_ are always taken in memory: this trade off guarantees very good lookup performances, as one of the main design goals of the Valkey VM is to have performances similar to Valkey with VM disabled when the part of the dataset frequently used fits in RAM.
 
 How does a swapped value looks like internally
 ---
 
 When an object is swapped out, this is what happens in the hash table entry:
 
- * The key continues to hold a Redis Object representing the key.
+ * The key continues to hold a Valkey Object representing the key.
  * The value is set to NULL
 
 So you may wonder where we store the information that a given value (associated to a given key) was swapped out. Just in the key object!
 
-This is how the Redis Object structure _robj_ looks like:
+This is how the Valkey Object structure _robj_ looks like:
 
-    /* The actual Redis Object */
+    /* The actual Valkey Object */
     typedef struct redisObject {
         void *ptr;
         unsigned char type;
@@ -50,7 +50,7 @@ This is how the Redis Object structure _robj_ looks like:
         /* VM fields, this are only allocated if VM is active, otherwise the
          * object allocation function will just allocate
          * sizeof(redisObject) minus sizeof(redisObjectVM), so using
-         * Redis without VM active will not have any overhead. */
+         * Valkey without VM active will not have any overhead. */
         struct redisObjectVM vm;
     } robj;
 
@@ -59,9 +59,9 @@ As you can see there are a few fields about VM. The most important one is _stora
  * `REDIS_VM_MEMORY`: the associated value is in memory.
  * `REDIS_VM_SWAPPED`: the associated values is swapped, and the value entry of the hash table is just set to NULL.
  * `REDIS_VM_LOADING`: the value is swapped on disk, the entry is NULL, but there is a job to load the object from the swap to the memory (this field is only used when threaded VM is active).
- * `REDIS_VM_SWAPPING`: the value is in memory, the entry is a pointer to the actual Redis Object, but there is an I/O job in order to transfer this value to the swap file.
+ * `REDIS_VM_SWAPPING`: the value is in memory, the entry is a pointer to the actual Valkey Object, but there is an I/O job in order to transfer this value to the swap file.
 
-If an object is swapped on disk (`REDIS_VM_SWAPPED` or `REDIS_VM_LOADING`), how do we know where it is stored, what type it is, and so forth? That's simple: the _vtype_ field is set to the original type of the Redis object swapped, while the _vm_ field (that is a _redisObjectVM_ structure) holds information about the location of the object. This is the definition of this additional structure:
+If an object is swapped on disk (`REDIS_VM_SWAPPED` or `REDIS_VM_LOADING`), how do we know where it is stored, what type it is, and so forth? That's simple: the _vtype_ field is set to the original type of the Valkey object swapped, while the _vm_ field (that is a _redisObjectVM_ structure) holds information about the location of the object. This is the definition of this additional structure:
 
     /* The VM object structure */
     struct redisObjectVM {
@@ -72,7 +72,7 @@ If an object is swapped on disk (`REDIS_VM_SWAPPED` or `REDIS_VM_LOADING`), how 
 
 As you can see the structure contains the page at which the object is located in the swap file, the number of pages used, and the last access time of the object (this is very useful for the algorithm that select what object is a good candidate for swapping, as we want to transfer on disk objects that are rarely accessed).
 
-As you can see, while all the other fields are using unused bytes in the old Redis Object structure (we had some free bit due to natural memory alignment concerns), the _vm_ field is new, and indeed uses additional memory. Should we pay such a memory cost even when VM is disabled? No! This is the code to create a new Redis Object:
+As you can see, while all the other fields are using unused bytes in the old Valkey Object structure (we had some free bit due to natural memory alignment concerns), the _vm_ field is new, and indeed uses additional memory. Should we pay such a memory cost even when VM is disabled? No! This is the code to create a new Valkey Object:
 
     ... some code ...
             if (server.vm_enabled) {
@@ -83,19 +83,19 @@ As you can see, while all the other fields are using unused bytes in the old Red
             }
     ... some code ...
 
-As you can see if the VM system is not enabled we allocate just `sizeof(*o)-sizeof(struct redisObjectVM)` of memory. Given that the _vm_ field is the last in the object structure, and that this fields are never accessed if VM is disabled, we are safe and Redis without VM does not pay the memory overhead.
+As you can see if the VM system is not enabled we allocate just `sizeof(*o)-sizeof(struct redisObjectVM)` of memory. Given that the _vm_ field is the last in the object structure, and that this fields are never accessed if VM is disabled, we are safe and Valkey without VM does not pay the memory overhead.
 
 The Swap File
 ---
 
-The next step in order to understand how the VM subsystem works is understanding how objects are stored inside the swap file. The good news is that's not some kind of special format, we just use the same format used to store the objects in .rdb files, that are the usual dump files produced by Redis using the `SAVE` command.
+The next step in order to understand how the VM subsystem works is understanding how objects are stored inside the swap file. The good news is that's not some kind of special format, we just use the same format used to store the objects in .rdb files, that are the usual dump files produced by Valkey using the `SAVE` command.
 
-The swap file is composed of a given number of pages, where every page size is a given number of bytes. This parameters can be changed in redis.conf, since different Redis instances may work better with different values: it depends on the actual data you store inside it. The following are the default values:
+The swap file is composed of a given number of pages, where every page size is a given number of bytes. This parameters can be changed in redis.conf, since different Valkey instances may work better with different values: it depends on the actual data you store inside it. The following are the default values:
 
     vm-page-size 32
     vm-pages 134217728
 
-Redis takes a "bitmap" (a contiguous array of bits set to zero or one) in memory, every bit represent a page of the swap file on disk: if a given bit is set to 1, it represents a page that is already used (there is some Redis Object stored there), while if the corresponding bit is zero, the page is free.
+Valkey takes a "bitmap" (a contiguous array of bits set to zero or one) in memory, every bit represent a page of the swap file on disk: if a given bit is set to 1, it represents a page that is already used (there is some Valkey Object stored there), while if the corresponding bit is zero, the page is free.
 
 Taking this bitmap (that will call the page table) in memory is a huge win in terms of performances, and the memory used is small: we just need 1 bit for every page on disk. For instance in the example below 134217728 pages of 32 bytes each (4GB swap file) is using just 16 MB of RAM for the page table.
 
@@ -117,15 +117,15 @@ Loading an object from swap to memory is simpler, as we already know where the o
 
 Calling the function `vmLoadObject` passing the key object associated to the value object we want to load back is enough. The function will also take care of fixing the storage type of the key (that will be `REDIS_VM_MEMORY`), marking the pages as freed in the page table, and so forth.
 
-The return value of the function is the loaded Redis Object itself, that we'll have to set again as value in the main hash table (instead of the NULL value we put in place of the object pointer when the value was originally swapped out).
+The return value of the function is the loaded Valkey Object itself, that we'll have to set again as value in the main hash table (instead of the NULL value we put in place of the object pointer when the value was originally swapped out).
 
 How blocking VM works
 ---
 
-Now we have all the building blocks in order to describe how the blocking VM works. First of all, an important detail about configuration. In order to enable blocking VM in Redis `server.vm_max_threads` must be set to zero.
-We'll see later how this max number of threads info is used in the threaded VM, for now all it's needed to now is that Redis reverts to fully blocking VM when this is set to zero.
+Now we have all the building blocks in order to describe how the blocking VM works. First of all, an important detail about configuration. In order to enable blocking VM in Valkey `server.vm_max_threads` must be set to zero.
+We'll see later how this max number of threads info is used in the threaded VM, for now all it's needed to now is that Valkey reverts to fully blocking VM when this is set to zero.
 
-We also need to introduce another important VM parameter, that is, `server.vm_max_memory`. This parameter is very important as it is used in order to trigger swapping: Redis will try to swap objects only if it is using more memory than the max memory setting, otherwise there is no need to swap as we are matching the user requested memory usage.
+We also need to introduce another important VM parameter, that is, `server.vm_max_memory`. This parameter is very important as it is used in order to trigger swapping: Valkey will try to swap objects only if it is using more memory than the max memory setting, otherwise there is no need to swap as we are matching the user requested memory usage.
 
 Blocking VM swapping
 ---
@@ -154,11 +154,11 @@ The age is the number of seconds the key was not requested, while size_in_memory
 Blocking VM loading
 ---
 
-What happens if an operation against a key associated with a swapped out object is requested? For instance Redis may just happen to process the following command:
+What happens if an operation against a key associated with a swapped out object is requested? For instance Valkey may just happen to process the following command:
 
     GET foo
 
-If the value object of the `foo` key is swapped we need to load it back in memory before processing the operation. In Redis the key lookup process is centralized in the `lookupKeyRead` and `lookupKeyWrite` functions, this two functions are used in the implementation of all the Redis commands accessing the keyspace, so we have a single point in the code where to handle the loading of the key from the swap file to memory.
+If the value object of the `foo` key is swapped we need to load it back in memory before processing the operation. In Valkey the key lookup process is centralized in the `lookupKeyRead` and `lookupKeyWrite` functions, this two functions are used in the implementation of all the Valkey commands accessing the keyspace, so we have a single point in the code where to handle the loading of the key from the swap file to memory.
 
 So this is what happens:
 
@@ -171,7 +171,7 @@ This is pretty straightforward, but things will get more _interesting_ with the 
 Background saving when VM is active
 ---
 
-The default Redis way to persist on disk is to create .rdb files using a child process. Redis calls the fork() system call in order to create a child, that has the exact copy of the in memory dataset, since fork duplicates the whole program memory space (actually thanks to a technique called Copy on Write memory pages are shared between the parent and child process, so the fork() call will not require too much memory).
+The default Valkey way to persist on disk is to create .rdb files using a child process. Valkey calls the fork() system call in order to create a child, that has the exact copy of the in memory dataset, since fork duplicates the whole program memory space (actually thanks to a technique called Copy on Write memory pages are shared between the parent and child process, so the fork() call will not require too much memory).
 
 In the child process we have a copy of the dataset in a given point in the time. Other commands issued by clients will just be served by the parent process and will not modify the child data.
 
@@ -180,7 +180,7 @@ The child process will just store the whole dataset into the dump.rdb file and f
 * The parent process needs to access the swap file in order to load values back into memory if an operation against swapped out values are performed.
 * The child process needs to access the swap file in order to retrieve the full dataset while saving the data set on disk.
 
-In order to avoid problems while both the processes are accessing the same swap file we do a simple thing, that is, not allowing values to be swapped out in the parent process while a background saving is in progress. This way both the processes will access the swap file in read only. This approach has the problem that while the child process is saving no new values can be transferred on the swap file even if Redis is using more memory than the max memory parameters dictates. This is usually not a problem as the background saving will terminate in a short amount of time and if still needed a percentage of values will be swapped on disk ASAP.
+In order to avoid problems while both the processes are accessing the same swap file we do a simple thing, that is, not allowing values to be swapped out in the parent process while a background saving is in progress. This way both the processes will access the swap file in read only. This approach has the problem that while the child process is saving no new values can be transferred on the swap file even if Valkey is using more memory than the max memory parameters dictates. This is usually not a problem as the background saving will terminate in a short amount of time and if still needed a percentage of values will be swapped on disk ASAP.
 
 An alternative to this scenario is to enable the Append Only File that will have this problem only when a log rewrite is performed using the `BGREWRITEAOF` command.
 
@@ -188,7 +188,7 @@ The problem with the blocking VM
 ---
 
 The problem of blocking VM is that... it's blocking :)
-This is not a problem when Redis is used in batch processing activities, but for real-time usage one of the good points of Redis is the low latency. The blocking VM will have bad latency behaviors as when a client is accessing a swapped out value, or when Redis needs to swap out values, no other clients will be served in the meantime.
+This is not a problem when Valkey is used in batch processing activities, but for real-time usage one of the good points of Valkey is the low latency. The blocking VM will have bad latency behaviors as when a client is accessing a swapped out value, or when Valkey needs to swap out values, no other clients will be served in the meantime.
 
 Swapping out keys should happen in background. Similarly when a client is accessing a swapped out value other clients accessing in memory values should be served mostly as fast as when VM is disabled. Only the clients dealing with swapped out keys should be delayed.
 
@@ -198,27 +198,27 @@ Threaded VM
 ---
 
 There are basically three main ways to turn the blocking VM into a non blocking one.
-* 1: One way is obvious, and in my opinion, not a good idea at all, that is, turning Redis itself into a threaded server: if every request is served by a different thread automatically other clients don't need to wait for blocked ones. Redis is fast, exports atomic operations, has no locks, and is just 10k lines of code, *because* it is single threaded, so this was not an option for me.
-* 2: Using non-blocking I/O against the swap file. After all you can think Redis already event-loop based, why don't just handle disk I/O in a non-blocking fashion? I also discarded this possibility because of two main reasons. One is that non blocking file operations, unlike sockets, are an incompatibility nightmare. It's not just like calling select, you need to use OS-specific things. The other problem is that the I/O is just one part of the time consumed to handle VM, another big part is the CPU used in order to encode/decode data to/from the swap file. This is I picked option three, that is...
-* 3: Using I/O threads, that is, a pool of threads handling the swap I/O operations. This is what the Redis VM is using, so let's detail how this works.
+* 1: One way is obvious, and in my opinion, not a good idea at all, that is, turning Valkey itself into a threaded server: if every request is served by a different thread automatically other clients don't need to wait for blocked ones. Valkey is fast, exports atomic operations, has no locks, and is just 10k lines of code, *because* it is single threaded, so this was not an option for me.
+* 2: Using non-blocking I/O against the swap file. After all you can think Valkey already event-loop based, why don't just handle disk I/O in a non-blocking fashion? I also discarded this possibility because of two main reasons. One is that non blocking file operations, unlike sockets, are an incompatibility nightmare. It's not just like calling select, you need to use OS-specific things. The other problem is that the I/O is just one part of the time consumed to handle VM, another big part is the CPU used in order to encode/decode data to/from the swap file. This is I picked option three, that is...
+* 3: Using I/O threads, that is, a pool of threads handling the swap I/O operations. This is what the Valkey VM is using, so let's detail how this works.
 
 I/O Threads
 ---
 
 The threaded VM design goals where the following, in order of importance:
 
- * Simple implementation, little room for race conditions, simple locking, VM system more or less completely decoupled from the rest of Redis code.
+ * Simple implementation, little room for race conditions, simple locking, VM system more or less completely decoupled from the rest of Valkey code.
  * Good performances, no locks for clients accessing values in memory.
  * Ability to decode/encode objects in the I/O threads.
 
-The above goals resulted in an implementation where the Redis main thread (the one serving actual clients) and the I/O threads communicate using a queue of jobs, with a single mutex.
+The above goals resulted in an implementation where the Valkey main thread (the one serving actual clients) and the I/O threads communicate using a queue of jobs, with a single mutex.
 Basically when main thread requires some work done in the background by some I/O thread, it pushes an I/O job structure in the `server.io_newjobs` queue (that is, just a linked list). If there are no active I/O threads, one is started. At this point some I/O thread will process the I/O job, and the result of the processing is pushed in the `server.io_processed` queue. The I/O thread will send a byte using an UNIX pipe to the main thread in order to signal that a new job was processed and the result is ready to be processed.
 
 This is how the `iojob` structure looks like:
 
     typedef struct iojob {
         int type;   /* Request type, REDIS_IOJOB_* */
-        redisDb *db;/* Redis database */
+        redisDb *db;/* Valkey database */
         robj *key;  /* This I/O request is about swapping this key */
         robj *val;  /* the value to swap for REDIS_IOREQ_*_SWAP, otherwise this
                      * field is populated by the I/O thread for REDIS_IOREQ_LOAD. */
@@ -234,7 +234,7 @@ There are just three type of jobs that an I/O thread can perform (the type is sp
 * `REDIS_IOJOB_PREPARE_SWAP`: compute the number of pages needed in order to save the object pointed by `val` into the swap. The result of this operation will populate the `pages` field.
 * `REDIS_IOJOB_DO_SWAP`: Transfer the object pointed by `val` to the swap file, at page offset `page`.
 
-The main thread delegates just the above three tasks. All the rest is handled by the I/O thread itself, for instance finding a suitable range of free pages in the swap file page table (that is a fast operation), deciding what object to swap, altering the storage field of a Redis object to reflect the current state of a value.
+The main thread delegates just the above three tasks. All the rest is handled by the I/O thread itself, for instance finding a suitable range of free pages in the swap file page table (that is a fast operation), deciding what object to swap, altering the storage field of a Valkey object to reflect the current state of a value.
 
 Non blocking VM as probabilistic enhancement of blocking VM
 ---
@@ -245,7 +245,7 @@ Fortunately there was a much, much simpler way to do this. And we love simple th
 
 This is what we do:
 
- * Every time a client sends us a command, *before* the command is executed, we examine the argument vector of the command in search for swapped keys. After all we know for every command what arguments are keys, as the Redis command format is pretty simple.
+ * Every time a client sends us a command, *before* the command is executed, we examine the argument vector of the command in search for swapped keys. After all we know for every command what arguments are keys, as the Valkey command format is pretty simple.
  * If we detect that at least a key in the requested command is swapped on disk, we block the client instead of really issuing the command. For every swapped value associated to a requested key, an I/O job is created, in order to bring the values back in memory. The main thread continues the execution of the event loop, without caring about the blocked client.
  * In the meanwhile, I/O threads are loading values in memory. Every time an I/O thread finished loading a value, it sends a byte to the main thread using an UNIX pipe. The pipe file descriptor has a readable event associated in the main thread event loop, that is the function `vmThreadedIOCompletedJob`. If this function detects that all the values needed for a blocked client were loaded, the client is restarted and the original command called.
 

--- a/docs/reference/internals/internals-vm.md
+++ b/docs/reference/internals/internals-vm.md
@@ -90,7 +90,7 @@ The Swap File
 
 The next step in order to understand how the VM subsystem works is understanding how objects are stored inside the swap file. The good news is that's not some kind of special format, we just use the same format used to store the objects in .rdb files, that are the usual dump files produced by Valkey using the `SAVE` command.
 
-The swap file is composed of a given number of pages, where every page size is a given number of bytes. This parameters can be changed in redis.conf, since different Valkey instances may work better with different values: it depends on the actual data you store inside it. The following are the default values:
+The swap file is composed of a given number of pages, where every page size is a given number of bytes. This parameters can be changed in valkey.conf, since different Valkey instances may work better with different values: it depends on the actual data you store inside it. The following are the default values:
 
     vm-page-size 32
     vm-pages 134217728

--- a/docs/reference/internals/internals-vm.md
+++ b/docs/reference/internals/internals-vm.md
@@ -8,10 +8,10 @@ aliases:
   - /topics/virtual-memory
 ---
 
-**Note: this document was written by the creator of Redis, Salvatore Sanfilippo, early in the development of Redis (c. 2010). Virtual Memory has been deprecated since Redis 2.6, so this documentation
+**Note: this document was written by the creator of Redis, Salvatore Sanfilippo, early in the development of Redis (c. 2010). Virtual Memory has been deprecated since Redis OSS 2.6, so this documentation
 is here only for historical interest.**
 
-This document details the internals of the Redis Virtual Memory subsystem prior to Redis 2.6. The intended audience is not the final user but programmers willing to understand or modify the Virtual Memory implementation.
+This document details the internals of the Redis Virtual Memory subsystem prior to Redis OSS 2.6. The intended audience is not the final user but programmers willing to understand or modify the Virtual Memory implementation.
 
 Keys vs Values: what is swapped out?
 ---
@@ -130,7 +130,7 @@ We also need to introduce another important VM parameter, that is, `server.vm_ma
 Blocking VM swapping
 ---
 
-Swapping of object from memory to disk happens in the cron function. This function used to be called every second, while in the recent Redis versions on git it is called every 100 milliseconds (that is, 10 times per second).
+Swapping of object from memory to disk happens in the cron function. This function used to be called every second, while in the recent Redis OSS versions on git it is called every 100 milliseconds (that is, 10 times per second).
 If this function detects we are out of memory, that is, the memory used is greater than the vm-max-memory setting, it starts transferring objects from memory to disk in a loop calling the function `vmSwapOneObect`. This function takes just one argument, if 0 it will swap objects in a blocking way, otherwise if it is 1, I/O threads are used. In the blocking scenario we just call it with zero as argument.
 
 vmSwapOneObject acts performing the following steps:

--- a/docs/reference/internals/rdd.md
+++ b/docs/reference/internals/rdd.md
@@ -27,12 +27,12 @@ without causing a backward compatibility issue even if the added meta data
 is not required in order to load data from the RDB file.
 
 For example thanks to the info fields specified in this document it will
-be possible to add to RDB information like file creation time, Redis version
+be possible to add to RDB information like file creation time, Redis OSS version
 generating the file, and any other useful information, in a way that not
 every field is required for an RDB version 7 file to be correctly processed.
 
 Also with minimal changes it will be possible to add RDB version 7 support to
-Redis 2.6 without actually supporting the additional fields but just skipping
+Redis OSS 2.6 without actually supporting the additional fields but just skipping
 them when loading an RDB file.
 
 RDB info fields may have semantic meaning if needed, so that the presence
@@ -97,7 +97,7 @@ This field represents the unix time at which the RDB file was created.
 The format of the unix time is a 64 bit little endian integer representing
 seconds since 1th January 1970.
 
-### Info field 2 -- Redis version
+### Info field 2 -- Redis OSS version
 
-This field represents a null-terminated string containing the Redis version
-that generated the file, as displayed in the Redis version INFO field.
+This field represents a null-terminated string containing the Redis OSS version
+that generated the file, as displayed in the Redis OSS version INFO field.

--- a/docs/reference/internals/rdd.md
+++ b/docs/reference/internals/rdd.md
@@ -1,17 +1,17 @@
 ---
-title: "Redis design draft #2 (historical)"
-linkTitle: "Redis design draft"
+title: "Valkey design draft #2 (historical)"
+linkTitle: "Valkey design draft"
 weight: 2
-description: A design for the RDB format written in the early days of Redis
+description: A design for the RDB format written in the early days of Valkey
 aliases:
   - /topics/rdd
   - /topics/rdd-1
   - /topics/rdd-2
 ---
 
-**Note: this document was written by the creator of Redis, Salvatore Sanfilippo, early in the development of Redis (c. 2013), as part of a series of design drafts. This is preserved for historical interest.**
+**Note: this document was written by the creator of Valkey, Salvatore Sanfilippo, early in the development of Valkey (c. 2013), as part of a series of design drafts. This is preserved for historical interest.**
 
-# Redis Design Draft 2 -- RDB version 7 info fields
+# Valkey Design Draft 2 -- RDB version 7 info fields
 
 * Author: Salvatore Sanfilippo `antirez@gmail.com`
 * GitHub issue [#1048](https://github.com/redis/redis/issues/1048)
@@ -22,7 +22,7 @@ aliases:
 
 ## Overview
 
-The Redis RDB format lacks a simple way to add info fields to an RDB file
+The Valkey RDB format lacks a simple way to add info fields to an RDB file
 without causing a backward compatibility issue even if the added meta data
 is not required in order to load data from the RDB file.
 
@@ -39,7 +39,7 @@ RDB info fields may have semantic meaning if needed, so that the presence
 of the field may add information about the data set specified in the RDB
 file format, however when an info field is required to be correctly decoded
 in order to understand and load the data set content of the RDB file, the
-RDB file format must be increased so that previous versions of Redis will not
+RDB file format must be increased so that previous versions of Valkey will not
 attempt to load it.
 
 However currently the info fields are designed to only hold additional

--- a/docs/reference/key-specs.md
+++ b/docs/reference/key-specs.md
@@ -11,7 +11,7 @@ Many of the commands in Redis accept key names as input arguments.
 The 9th element in the reply of `COMMAND` (and `COMMAND INFO`) is an array that consists of the command's key specifications.
 
 A _key specification_ describes a rule for extracting the names of one or more keys from the arguments of a given command.
-Key specifications provide a robust and flexible mechanism, compared to the _first key_, _last key_ and _step_ scheme employed until Redis 7.0.
+Key specifications provide a robust and flexible mechanism, compared to the _first key_, _last key_ and _step_ scheme employed until Redis OSS 7.0.
 Before introducing these specifications, Redis clients had no trivial programmatic means to extract key names for all commands.
 
 Cluster-aware Redis clients had to have the keys' extraction logic hard-coded in the cases of commands such as `EVAL` and `ZUNIONSTORE` that rely on a _numkeys_ argument or `SORT` and its many clauses.

--- a/docs/reference/key-specs.md
+++ b/docs/reference/key-specs.md
@@ -7,20 +7,20 @@
    - /topics/key-specs
 ---
 
-Many of the commands in Redis accept key names as input arguments.
+Many of the commands in Valkey accept key names as input arguments.
 The 9th element in the reply of `COMMAND` (and `COMMAND INFO`) is an array that consists of the command's key specifications.
 
 A _key specification_ describes a rule for extracting the names of one or more keys from the arguments of a given command.
 Key specifications provide a robust and flexible mechanism, compared to the _first key_, _last key_ and _step_ scheme employed until Redis OSS 7.0.
-Before introducing these specifications, Redis clients had no trivial programmatic means to extract key names for all commands.
+Before introducing these specifications, Valkey clients had no trivial programmatic means to extract key names for all commands.
 
-Cluster-aware Redis clients had to have the keys' extraction logic hard-coded in the cases of commands such as `EVAL` and `ZUNIONSTORE` that rely on a _numkeys_ argument or `SORT` and its many clauses.
+Cluster-aware Valkey clients had to have the keys' extraction logic hard-coded in the cases of commands such as `EVAL` and `ZUNIONSTORE` that rely on a _numkeys_ argument or `SORT` and its many clauses.
 Alternatively, the `COMMAND GETKEYS` can be used to achieve a similar extraction effect but at a higher latency.
 
-A Redis client isn't obligated to support key specifications.
+A Valkey client isn't obligated to support key specifications.
 It can continue using the legacy _first key_, _last key_ and _step_ scheme along with the [_movablekeys_ flag](/commands/command#flags) that remain unchanged.
 
-However, a Redis client that implements key specifications support can consolidate most of its keys' extraction logic.
+However, a Valkey client that implements key specifications support can consolidate most of its keys' extraction logic.
 Even if the client encounters an unfamiliar type of key specification, it can always revert to the `COMMAND GETKEYS` command.
 
 That said, most cluster-aware clients only require a single key name to perform correct command routing, so it is possible that although a command features one unfamiliar specification, its other specification may still be usable by the client.
@@ -161,7 +161,7 @@ In addition, the specification may include precisely one of the following:
 Key specifications may have the following flags:
 
 * **not_key:** this flag indicates that the specified argument isn't a key.
-  This argument is treated the same as a key when computing which slot a command should be assigned to for Redis cluster. 
+  This argument is treated the same as a key when computing which slot a command should be assigned to for Valkey cluster. 
   For all other purposes this argument should not be considered a key.
 * **incomplete:** this flag is explained below.
 * **variable_flags:** this flag is explained below.

--- a/docs/reference/modules/_index.md
+++ b/docs/reference/modules/_index.md
@@ -1,37 +1,37 @@
 ---
-title: "Redis modules API"
+title: "Valkey modules API"
 linkTitle: "Modules API"
 weight: 2
 description: >
-    Introduction to writing Redis modules
+    Introduction to writing Valkey modules
 aliases:
     - /topics/modules-intro
 ---
 
 The modules documentation is composed of the following pages:
 
-* Introduction to Redis modules (this file). An overview about Redis Modules system and API. It's a good idea to start your reading here.
+* Introduction to Valkey modules (this file). An overview about Valkey Modules system and API. It's a good idea to start your reading here.
 * [Implementing native data types](/topics/modules-native-types) covers the implementation of native data types into modules.
-* [Blocking operations](/topics/modules-blocking-ops) shows how to write blocking commands that will not reply immediately, but will block the client, without blocking the Redis server, and will provide a reply whenever will be possible.
-* [Redis modules API reference](/topics/modules-api-ref) is generated from module.c top comments of RedisModule functions. It is a good reference in order to understand how each function works.
+* [Blocking operations](/topics/modules-blocking-ops) shows how to write blocking commands that will not reply immediately, but will block the client, without blocking the Valkey server, and will provide a reply whenever will be possible.
+* [Valkey modules API reference](/topics/modules-api-ref) is generated from module.c top comments of RedisModule functions. It is a good reference in order to understand how each function works.
 
-Redis modules make it possible to extend Redis functionality using external
-modules, rapidly implementing new Redis commands with features
+Valkey modules make it possible to extend Valkey functionality using external
+modules, rapidly implementing new Valkey commands with features
 similar to what can be done inside the core itself.
 
-Redis modules are dynamic libraries that can be loaded into Redis at
-startup, or using the `MODULE LOAD` command. Redis exports a C API, in the
+Valkey modules are dynamic libraries that can be loaded into Valkey at
+startup, or using the `MODULE LOAD` command. Valkey exports a C API, in the
 form of a single C header file called `redismodule.h`. Modules are meant
 to be written in C, however it will be possible to use C++ or other languages
 that have C binding functionalities.
 
-Modules are designed in order to be loaded into different versions of Redis,
+Modules are designed in order to be loaded into different versions of Valkey,
 so a given module does not need to be designed, or recompiled, in order to
-run with a specific version of Redis. For this reason, the module will
-register to the Redis core using a specific API version. The current API
+run with a specific version of Valkey. For this reason, the module will
+register to the Valkey core using a specific API version. The current API
 version is "1".
 
-This document is about an alpha version of Redis modules. API, functionalities
+This document is about an alpha version of Valkey modules. API, functionalities
 and other details may change in the future.
 
 ## Loading modules
@@ -55,10 +55,10 @@ following command:
     MODULE UNLOAD mymodule
 
 Note that `mymodule` above is not the filename without the `.so` suffix, but
-instead, the name the module used to register itself into the Redis core.
+instead, the name the module used to register itself into the Valkey core.
 The name can be obtained using `MODULE LIST`. However it is good practice
 that the filename of the dynamic library is the same as the name the module
-uses to register itself into the Redis core.
+uses to register itself into the Valkey core.
 
 ## The simplest module you can write
 
@@ -88,7 +88,7 @@ simple module that implements a command that outputs a random number.
 The example module has two functions. One implements a command called
 HELLOWORLD.RAND. This function is specific of that module. However the
 other function called `RedisModule_OnLoad()` must be present in each
-Redis module. It is the entry point for the module to be initialized,
+Valkey module. It is the entry point for the module to be initialized,
 register its commands, and potentially other private data structures
 it uses.
 
@@ -98,7 +98,7 @@ like in the case of `HELLOWORLD.RAND`. This way it is less likely to
 have collisions.
 
 Note that if different modules have colliding commands, they'll not be
-able to work in Redis at the same time, since the function
+able to work in Valkey at the same time, since the function
 `RedisModule_CreateCommand` will fail in one of the modules, so the module
 loading will abort returning an error condition.
 
@@ -111,7 +111,7 @@ The following is the function prototype:
     int RedisModule_Init(RedisModuleCtx *ctx, const char *modulename,
                          int module_version, int api_version);
 
-The `Init` function announces the Redis core that the module has a given
+The `Init` function announces the Valkey core that the module has a given
 name, its version (that is reported by `MODULE LIST`), and that is willing
 to use a specific version of the API.
 
@@ -120,16 +120,16 @@ similar errors, the function will return `REDISMODULE_ERR`, and the module
 `OnLoad` function should return ASAP with an error.
 
 Before the `Init` function is called, no other API function can be called,
-otherwise the module will segfault and the Redis instance will crash.
+otherwise the module will segfault and the Valkey instance will crash.
 
 The second function called, `RedisModule_CreateCommand`, is used in order
-to register commands into the Redis core. The following is the prototype:
+to register commands into the Valkey core. The following is the prototype:
 
     int RedisModule_CreateCommand(RedisModuleCtx *ctx, const char *name,
                                   RedisModuleCmdFunc cmdfunc, const char *strflags,
                                   int firstkey, int lastkey, int keystep);
 
-As you can see, most Redis modules API calls all take as first argument
+As you can see, most Valkey modules API calls all take as first argument
 the `context` of the module, so that they have a reference to the module
 calling it, to the command and client executing a given command, and so forth.
 
@@ -154,12 +154,12 @@ Zooming into the example command implementation, we can find another call:
     int RedisModule_ReplyWithLongLong(RedisModuleCtx *ctx, long long integer);
 
 This function returns an integer to the client that invoked the command,
-exactly like other Redis commands do, like for example `INCR` or `SCARD`.
+exactly like other Valkey commands do, like for example `INCR` or `SCARD`.
 
 ## Module cleanup
 
 In most cases, there is no need for special cleanup.
-When a module is unloaded, Redis will automatically unregister commands and
+When a module is unloaded, Valkey will automatically unregister commands and
 unsubscribe from notifications.
 However in the case where a module contains some persistent memory or
 configuration, a module may include an optional `RedisModule_OnUnload`
@@ -174,16 +174,16 @@ The `OnUnload` function may prevent module unloading by returning
 `REDISMODULE_ERR`.
 Otherwise, `REDISMODULE_OK` should be returned.
 
-## Setup and dependencies of a Redis module
+## Setup and dependencies of a Valkey module
 
-Redis modules don't depend on Redis or some other library, nor they
+Valkey modules don't depend on Valkey or some other library, nor they
 need to be compiled with a specific `redismodule.h` file. In order
 to create a new module, just copy a recent version of `redismodule.h`
 in your source tree, link all the libraries you want, and create
 a dynamic library having the `RedisModule_OnLoad()` function symbol
 exported.
 
-The module will be able to load into different versions of Redis.
+The module will be able to load into different versions of Valkey.
 
 A module can be designed to support both newer and older Redis OSS versions where certain API functions are not available in all versions.
 If an API function is not implemented in the currently running Redis OSS version, the function pointer is set to NULL.
@@ -196,7 +196,7 @@ This allows the module to check if a function exists before using it:
 In recent versions of `redismodule.h`, a convenience macro `RMAPI_FUNC_SUPPORTED(funcname)` is defined.
 Using the macro or just comparing with NULL is a matter of personal preference.
 
-# Passing configuration parameters to Redis modules
+# Passing configuration parameters to Valkey modules
 
 When the module is loaded with the `MODULE LOAD` command, or using the
 `loadmodule` directive in the `redis.conf` file, the user is able to pass
@@ -264,31 +264,31 @@ Similarly in order to parse a string as a number:
         /* Do something with 'myval' */
     }
 
-## Accessing Redis keys from modules
+## Accessing Valkey keys from modules
 
-Most Redis modules, in order to be useful, have to interact with the Redis
+Most Valkey modules, in order to be useful, have to interact with the Valkey
 data space (this is not always true, for example an ID generator may
-never touch Redis keys). Redis modules have two different APIs in order to
-access the Redis data space, one is a low level API that provides very
-fast access and a set of functions to manipulate Redis data structures.
-The other API is more high level, and allows to call Redis commands and
-fetch the result, similarly to how Lua scripts access Redis.
+never touch Valkey keys). Valkey modules have two different APIs in order to
+access the Valkey data space, one is a low level API that provides very
+fast access and a set of functions to manipulate Valkey data structures.
+The other API is more high level, and allows to call Valkey commands and
+fetch the result, similarly to how Lua scripts access Valkey.
 
-The high level API is also useful in order to access Redis functionalities
+The high level API is also useful in order to access Valkey functionalities
 that are not available as APIs.
 
 In general modules developers should prefer the low level API, because commands
 implemented using the low level API run at a speed comparable to the speed
-of native Redis commands. However there are definitely use cases for the
+of native Valkey commands. However there are definitely use cases for the
 higher level API. For example often the bottleneck could be processing the
 data and not accessing it.
 
 Also note that sometimes using the low level API is not harder compared to
 the higher level one.
 
-## Calling Redis commands
+## Calling Valkey commands
 
-The high level API to access Redis is the sum of the `RedisModule_Call()`
+The high level API to access Valkey is the sum of the `RedisModule_Call()`
 function, together with the functions needed in order to access the
 reply object returned by `Call()`.
 
@@ -296,7 +296,7 @@ reply object returned by `Call()`.
 that is used to specify what kind of objects you are passing as arguments
 to the function.
 
-Redis commands are invoked just using a command name and a list of arguments.
+Valkey commands are invoked just using a command name and a list of arguments.
 However when calling commands, the arguments may originate from different
 kind of strings: null-terminated C strings, RedisModuleString objects as
 received from the `argv` parameter in the command implementation, binary
@@ -323,7 +323,7 @@ This is the full list of format specifiers:
 
 * **c** -- Null terminated C string pointer.
 * **b** -- C buffer, two arguments needed: C string pointer and `size_t` length.
-* **s** -- RedisModuleString as received in `argv` or by other Redis module APIs returning a RedisModuleString object.
+* **s** -- RedisModuleString as received in `argv` or by other Valkey module APIs returning a RedisModuleString object.
 * **l** -- Long long integer.
 * **v** -- Array of RedisModuleString objects.
 * **!** -- This modifier just tells the function to replicate the command to replicas and AOF. It is ignored from the point of view of arguments parsing.
@@ -344,7 +344,7 @@ keys are about non local hash slots. In this case `errno` is set to `EPERM`.
 `RedisModule_CallReply*` family of functions.
 
 In order to obtain the type or reply (corresponding to one of the data types
-supported by the Redis protocol), the function `RedisModule_CallReplyType()`
+supported by the Valkey protocol), the function `RedisModule_CallReplyType()`
 is used:
 
     reply = RedisModule_Call(ctx,"INCRBY","sc",argv[1],"10");
@@ -421,11 +421,11 @@ If you use automatic memory management (explained later in this document)
 you don't need to free replies (but you still could if you wish to release
 memory ASAP).
 
-## Returning values from Redis commands
+## Returning values from Valkey commands
 
-Like normal Redis commands, new commands implemented via modules must be
+Like normal Valkey commands, new commands implemented via modules must be
 able to return values to the caller. The API exports a set of functions for
-this goal, in order to return the usual types of the Redis protocol, and
+this goal, in order to return the usual types of the Valkey protocol, and
 arrays of such types as elements. Also errors can be returned with any
 error string and code (the error code is the initial uppercase letters in
 the error message, like the "BUSY" string in the "BUSY the sever is busy" error
@@ -480,7 +480,7 @@ sub array elements.
 ## Returning arrays with dynamic length
 
 Sometimes it is not possible to know beforehand the number of items of
-an array. As an example, think of a Redis module implementing a FACTOR
+an array. As an example, think of a Valkey module implementing a FACTOR
 command that given a number outputs the prime factors. Instead of
 factorializing the number, storing the prime factors into an array, and
 later produce the command reply, a better solution is to start an array
@@ -549,7 +549,7 @@ is of the expected type, or if it's empty.
 ## Low level access to keys
 
 Low level access to keys allow to perform operations on value objects associated
-to keys directly, with a speed similar to what Redis uses internally to
+to keys directly, with a speed similar to what Valkey uses internally to
 implement the built-in commands.
 
 Once a key is opened, a key pointer is returned that will be used with all the
@@ -586,7 +586,7 @@ Once you are done using a key, you can close it with:
     RedisModule_CloseKey(key);
 
 Note that if automatic memory management is enabled, you are not forced to
-close keys. When the module function returns, Redis will take care to close
+close keys. When the module function returns, Valkey will take care to close
 all the keys which are still open.
 
 ## Getting the key type
@@ -604,7 +604,7 @@ It returns one of the following values:
     REDISMODULE_KEYTYPE_SET
     REDISMODULE_KEYTYPE_ZSET
 
-The above are just the usual Redis key types, with the addition of an empty
+The above are just the usual Valkey key types, with the addition of an empty
 type, that signals the key pointer is associated with an empty key that
 does not yet exists.
 
@@ -659,7 +659,7 @@ no expire, a new expire is set. If the key already have an expire, it is
 replaced with the new value.
 
 If the key has an expire, and the special value `REDISMODULE_NO_EXPIRE` is
-used as a new expire, the expire is removed, similarly to the Redis
+used as a new expire, the expire is removed, similarly to the Valkey
 `PERSIST` command. In case the key was already persistent, no operation is
 performed.
 
@@ -676,12 +676,12 @@ If the key does not exist, 0 is returned by the function:
 
 ## String type API
 
-Setting a new string value, like the Redis `SET` command does, is performed
+Setting a new string value, like the Valkey `SET` command does, is performed
 using:
 
     int RedisModule_StringSet(RedisModuleKey *key, RedisModuleString *str);
 
-The function works exactly like the Redis `SET` command itself, that is, if
+The function works exactly like the Valkey `SET` command itself, that is, if
 there is a prior value (of any type) it will be deleted.
 
 Accessing existing string values is performed using DMA (direct memory
@@ -769,8 +769,8 @@ Work in progress.
 
 ## Replicating commands
 
-If you want to use module commands exactly like normal Redis commands, in the
-context of replicated Redis instances, or using the AOF file for persistence,
+If you want to use module commands exactly like normal Valkey commands, in the
+context of replicated Valkey instances, or using the AOF file for persistence,
 it is important for module commands to handle their replication in a consistent
 way.
 
@@ -796,7 +796,7 @@ When you use the above API, you should not use any other replication function
 since they are not guaranteed to mix well.
 
 However this is not the only option. It's also possible to exactly tell
-Redis what commands to replicate as the effect of the command execution, using
+Valkey what commands to replicate as the effect of the command execution, using
 an API similar to `RedisModule_Call()` but that instead of calling the command
 sends it to the AOF / replicas stream. Example:
 
@@ -816,11 +816,11 @@ the commands emitted with `Replicate()` will follow.
 ## Automatic memory management
 
 Normally when writing programs in the C language, programmers need to manage
-memory manually. This is why the Redis modules API has functions to release
+memory manually. This is why the Valkey modules API has functions to release
 strings, close open keys, free replies, and so forth.
 
 However given that commands are executed in a contained environment and
-with a set of strict APIs, Redis is able to provide automatic memory management
+with a set of strict APIs, Valkey is able to provide automatic memory management
 to modules, at the cost of some performance (most of the time, a very low
 cost).
 
@@ -846,8 +846,8 @@ benefit.
 ## Allocating memory into modules
 
 Normal C programs use `malloc()` and `free()` in order to allocate and
-release memory dynamically. While in Redis modules the use of malloc is
-not technically forbidden, it is a lot better to use the Redis Modules
+release memory dynamically. While in Valkey modules the use of malloc is
+not technically forbidden, it is a lot better to use the Valkey Modules
 specific functions, that are exact replacements for `malloc`, `free`,
 `realloc` and `strdup`. These functions are:
 
@@ -858,11 +858,11 @@ specific functions, that are exact replacements for `malloc`, `free`,
     char *RedisModule_Strdup(const char *str);
 
 They work exactly like their `libc` equivalent calls, however they use
-the same allocator Redis uses, and the memory allocated using these
+the same allocator Valkey uses, and the memory allocated using these
 functions is reported by the `INFO` command in the memory section, is
 accounted when enforcing the `maxmemory` policy, and in general is
-a first citizen of the Redis executable. On the contrary, the method
-allocated inside modules with libc `malloc()` is transparent to Redis.
+a first citizen of the Valkey executable. On the contrary, the method
+allocated inside modules with libc `malloc()` is transparent to Valkey.
 
 Another reason to use the modules functions in order to allocate memory
 is that, when creating native data types inside modules, the RDB loading
@@ -877,7 +877,7 @@ Sometimes in commands implementations, it is required to perform many
 small allocations that will be not retained at the end of the command
 execution, but are just functional to execute the command itself.
 
-This work can be more easily accomplished using the Redis pool allocator:
+This work can be more easily accomplished using the Valkey pool allocator:
 
     void *RedisModule_PoolAlloc(RedisModuleCtx *ctx, size_t bytes);
 
@@ -890,7 +890,7 @@ is automatically released when the command returns.
 So in general short living allocations are a good candidates for the pool
 allocator.
 
-## Writing commands compatible with Redis Cluster
+## Writing commands compatible with Valkey Cluster
 
 Documentation missing, please check the following functions inside `module.c`:
 

--- a/docs/reference/modules/_index.md
+++ b/docs/reference/modules/_index.md
@@ -185,8 +185,8 @@ exported.
 
 The module will be able to load into different versions of Redis.
 
-A module can be designed to support both newer and older Redis versions where certain API functions are not available in all versions.
-If an API function is not implemented in the currently running Redis version, the function pointer is set to NULL.
+A module can be designed to support both newer and older Redis OSS versions where certain API functions are not available in all versions.
+If an API function is not implemented in the currently running Redis OSS version, the function pointer is set to NULL.
 This allows the module to check if a function exists before using it:
 
     if (RedisModule_SetCommandInfo != NULL) {

--- a/docs/reference/modules/_index.md
+++ b/docs/reference/modules/_index.md
@@ -37,7 +37,7 @@ and other details may change in the future.
 ## Loading modules
 
 In order to test the module you are developing, you can load the module
-using the following `redis.conf` configuration directive:
+using the following `valkey.conf` configuration directive:
 
     loadmodule /path/to/mymodule.so
 
@@ -199,7 +199,7 @@ Using the macro or just comparing with NULL is a matter of personal preference.
 # Passing configuration parameters to Valkey modules
 
 When the module is loaded with the `MODULE LOAD` command, or using the
-`loadmodule` directive in the `redis.conf` file, the user is able to pass
+`loadmodule` directive in the `valkey.conf` file, the user is able to pass
 configuration parameters to the module by adding arguments after the module
 file name:
 

--- a/docs/reference/modules/modules-api-ref.md
+++ b/docs/reference/modules/modules-api-ref.md
@@ -3,7 +3,7 @@ title: "Modules API reference"
 linkTitle: "API reference"
 weight: 1
 description: >
-    Reference for the Redis Modules API
+    Reference for the Valkey Modules API
 aliases:
     - /topics/modules-api-ref
 ---
@@ -27,7 +27,7 @@ aliases:
 * [Key API for Sorted Set iterator](#section-key-api-for-sorted-set-iterator)
 * [Key API for Hash type](#section-key-api-for-hash-type)
 * [Key API for Stream type](#section-key-api-for-stream-type)
-* [Calling Redis commands from modules](#section-calling-redis-commands-from-modules)
+* [Calling Valkey commands from modules](#section-calling-redis-commands-from-modules)
 * [Modules data types](#section-modules-data-types)
 * [RDB loading and saving functions](#section-rdb-loading-and-saving-functions)
 * [Key digest API (DEBUG DIGEST interface for modules types)](#section-key-digest-api-debug-digest-interface-for-modules-types)
@@ -60,8 +60,8 @@ aliases:
 
 ## Heap allocation raw functions
 
-Memory allocated with these functions are taken into account by Redis key
-eviction algorithms and are reported in Redis memory usage information.
+Memory allocated with these functions are taken into account by Valkey key
+eviction algorithms and are reported in Valkey memory usage information.
 
 <span id="RedisModule_Alloc"></span>
 
@@ -72,8 +72,8 @@ eviction algorithms and are reported in Redis memory usage information.
 **Available since:** 4.0.0
 
 Use like `malloc()`. Memory allocated with this function is reported in
-Redis INFO memory, used for keys eviction according to maxmemory settings
-and in general is taken into account as memory allocated by Redis.
+Valkey INFO memory, used for keys eviction according to maxmemory settings
+and in general is taken into account as memory allocated by Valkey.
 You should avoid using `malloc()`.
 This function panics if unable to allocate enough memory.
 
@@ -97,8 +97,8 @@ of panicking.
 **Available since:** 4.0.0
 
 Use like `calloc()`. Memory allocated with this function is reported in
-Redis INFO memory, used for keys eviction according to maxmemory settings
-and in general is taken into account as memory allocated by Redis.
+Valkey INFO memory, used for keys eviction according to maxmemory settings
+and in general is taken into account as memory allocated by Valkey.
 You should avoid using `calloc()` directly.
 
 <span id="RedisModule_Realloc"></span>
@@ -158,7 +158,7 @@ The function returns NULL if `bytes` is 0.
 
 ## Commands API
 
-These functions are used to implement custom Redis commands.
+These functions are used to implement custom Valkey commands.
 
 For examples, see [https://valkey.io/topics/modules-intro](https://valkey.io/topics/modules-intro).
 
@@ -248,7 +248,7 @@ The supported flags are:
 * `REDISMODULE_CMD_CHANNEL_PATTERN`: Instead of acting on a specific channel, will act on any 
                                    channel specified by the pattern. This is the same access
                                    used by the PSUBSCRIBE and PUNSUBSCRIBE commands available 
-                                   in Redis. Not intended to be used with PUBLISH permissions.
+                                   in Valkey. Not intended to be used with PUBLISH permissions.
 
 The following is an example of how it could be used:
 
@@ -276,7 +276,7 @@ it allows the ACLs to be checked before the command is executed.
 
 **Available since:** 4.0.0
 
-Register a new command in the Redis server, that will be handled by
+Register a new command in the Valkey server, that will be handled by
 calling the function pointer 'cmdfunc' using the RedisModule calling
 convention.
 
@@ -334,7 +334,7 @@ example "write deny-oom". The set of flags are:
 * **"getkeys-api"**: The command implements the interface to return
                      the arguments that are keys. Used when start/stop/step
                      is not enough because of the command syntax.
-* **"no-cluster"**: The command should not register in Redis Cluster
+* **"no-cluster"**: The command should not register in Valkey Cluster
                     since is not designed to work with it because, for
                     example, is unable to report the position of the
                     keys, programmatically creates key names, or any
@@ -353,7 +353,7 @@ example "write deny-oom". The set of flags are:
                          the arguments that are channels.
 
 The last three parameters specify which arguments of the new command are
-Redis keys. See [https://redis.io/commands/command](https://redis.io/commands/command) for more information.
+Valkey keys. See [https://redis.io/commands/command](https://redis.io/commands/command) for more information.
 
 * `firstkey`: One-based index of the first argument that's a key.
               Position 0 is always the command name itself.
@@ -371,7 +371,7 @@ NOTE: The scheme described above serves a limited purpose and can
 only be used to find keys that exist at constant indices.
 For non-trivial key arguments, you may pass 0,0,0 and use
 [`RedisModule_SetCommandInfo`](#RedisModule_SetCommandInfo) to set key specs using a more advanced scheme and use
-[`RedisModule_SetCommandACLCategories`](#RedisModule_SetCommandACLCategories) to set Redis ACL categories of the commands.
+[`RedisModule_SetCommandACLCategories`](#RedisModule_SetCommandACLCategories) to set Valkey ACL categories of the commands.
 
 <span id="RedisModule_GetCommand"></span>
 
@@ -511,7 +511,7 @@ All fields except `version` are optional. Explanation of the fields:
 
 - `arity`: Number of arguments, including the command name itself. A positive
   number specifies an exact number of arguments and a negative number
-  specifies a minimum number of arguments, so use -N to say >= N. Redis
+  specifies a minimum number of arguments, so use -N to say >= N. Valkey
   validates a call before passing it to a module, so this can replace an
   arity check inside the module command implementation. A value of 0 (or an
   omitted arity field) is equivalent to -2 if the command has sub commands
@@ -528,7 +528,7 @@ All fields except `version` are optional. Explanation of the fields:
 
     Key-specs cause the triplet (firstkey, lastkey, keystep) given in
     RedisModule_CreateCommand to be recomputed, but it is still useful to provide
-    these three parameters in RedisModule_CreateCommand, to better support old Redis
+    these three parameters in RedisModule_CreateCommand, to better support old Valkey
     versions where RedisModule_SetCommandInfo is not available.
 
     Note that key-specs don't fully replace the "getkeys-api" (see
@@ -861,21 +861,21 @@ previously defined ( meaning [`RedisModule_BlockedClientMeasureTimeStart`](#Redi
 
 **Available since:** 7.0.0
 
-This API allows modules to let Redis process background tasks, and some
+This API allows modules to let Valkey process background tasks, and some
 commands during long blocking execution of a module command.
 The module can call this API periodically.
 The flags is a bit mask of these:
 
 - `REDISMODULE_YIELD_FLAG_NONE`: No special flags, can perform some background
                                  operations, but not process client commands.
-- `REDISMODULE_YIELD_FLAG_CLIENTS`: Redis can also process client commands.
+- `REDISMODULE_YIELD_FLAG_CLIENTS`: Valkey can also process client commands.
 
 The `busy_reply` argument is optional, and can be used to control the verbose
 error string after the `-BUSY` error code.
 
-When the `REDISMODULE_YIELD_FLAG_CLIENTS` is used, Redis will only start
+When the `REDISMODULE_YIELD_FLAG_CLIENTS` is used, Valkey will only start
 processing client commands after the time defined by the
-`busy-reply-threshold` config, in which case Redis will start rejecting most
+`busy-reply-threshold` config, in which case Valkey will start rejecting most
 commands with `-BUSY` error, but allow the ones marked with the `allow-busy`
 flag to be executed.
 This API can also be used in thread safe context (while locked), and during
@@ -909,7 +909,7 @@ and that redis could be serving reads during replication instead of blocking wit
 
 `REDISMODULE_OPTIONS_ALLOW_NESTED_KEYSPACE_NOTIFICATIONS`:
 Declare that the module wants to get nested key-space notifications.
-By default, Redis will not fire key-space notifications that happened inside
+By default, Valkey will not fire key-space notifications that happened inside
 a key-space notification callback. This flag allows to change this behavior
 and fire nested key-space notifications. Notice: if enabled, the module
 should protected itself from infinite recursion.
@@ -1113,7 +1113,7 @@ The passed context `ctx` may be NULL if necessary. See the
 
 **Available since:** 4.0.0
 
-Free a module string object obtained with one of the Redis modules API calls
+Free a module string object obtained with one of the Valkey modules API calls
 that return new string objects.
 
 It is possible to call this function even when automatic memory management
@@ -1332,11 +1332,11 @@ no concurrent access to the string is guaranteed. Using it for an argv
 string in a module command before the string is potentially available
 to other threads is generally safe.
 
-Currently, Redis may also automatically trim retained strings when a
+Currently, Valkey may also automatically trim retained strings when a
 module command returns. However, doing this explicitly should still be
 a preferred option:
 
-1. Future versions of Redis may abandon auto-trimming.
+1. Future versions of Valkey may abandon auto-trimming.
 2. Auto-trimming as currently implemented is *not thread safe*.
    A background thread manipulating a recently retained string may end up
    in a race condition with the auto-trim, which could result with
@@ -1753,7 +1753,7 @@ The function always returns `REDISMODULE_OK`.
 
 **Available since:** 4.0.0
 
-Reply exactly what a Redis command returned us with [`RedisModule_Call()`](#RedisModule_Call).
+Reply exactly what a Valkey command returned us with [`RedisModule_Call()`](#RedisModule_Call).
 This function is useful when we use [`RedisModule_Call()`](#RedisModule_Call) in order to
 execute some command, as we want to reply to the client exactly the
 same reply we obtained by the command.
@@ -1863,8 +1863,8 @@ Otherwise, by default, the command will be propagated in both channels.
 #### Note about calling this function from a thread safe context:
 
 Normally when you call this function from the callback implementing a
-module command, or any other callback provided by the Redis Module API,
-Redis will accumulate all the calls to this function in the context of
+module command, or any other callback provided by the Valkey Module API,
+Valkey will accumulate all the calls to this function in the context of
 the callback, and will propagate all the commands wrapped in a MULTI/EXEC
 transaction. However when calling this function from a threaded safe context
 that can live an undefined amount of time, and can be locked/unlocked in
@@ -2067,7 +2067,7 @@ Return the currently selected DB.
 
 Return the current context's flags. The flags provide information on the
 current request context (whether the client is a Lua script or in a MULTI),
-and about the Redis instance in general, i.e replication and persistence.
+and about the Valkey instance in general, i.e replication and persistence.
 
 It is possible to call this function even with a NULL context, however
 in this case the following flags will not be reported:
@@ -2083,15 +2083,15 @@ Available flags and their meaning:
  * `REDISMODULE_CTX_FLAGS_REPLICATED`: The command was sent over the replication
    link by the MASTER
 
- * `REDISMODULE_CTX_FLAGS_MASTER`: The Redis instance is a master
+ * `REDISMODULE_CTX_FLAGS_MASTER`: The Valkey instance is a master
 
- * `REDISMODULE_CTX_FLAGS_SLAVE`: The Redis instance is a slave
+ * `REDISMODULE_CTX_FLAGS_SLAVE`: The Valkey instance is a slave
 
- * `REDISMODULE_CTX_FLAGS_READONLY`: The Redis instance is read-only
+ * `REDISMODULE_CTX_FLAGS_READONLY`: The Valkey instance is read-only
 
- * `REDISMODULE_CTX_FLAGS_CLUSTER`: The Redis instance is in cluster mode
+ * `REDISMODULE_CTX_FLAGS_CLUSTER`: The Valkey instance is in cluster mode
 
- * `REDISMODULE_CTX_FLAGS_AOF`: The Redis instance has AOF enabled
+ * `REDISMODULE_CTX_FLAGS_AOF`: The Valkey instance has AOF enabled
 
  * `REDISMODULE_CTX_FLAGS_RDB`: The instance has RDB enabled
 
@@ -2100,7 +2100,7 @@ Available flags and their meaning:
  * `REDISMODULE_CTX_FLAGS_EVICT`:  Maxmemory is set and has an eviction
    policy that may delete keys
 
- * `REDISMODULE_CTX_FLAGS_OOM`: Redis is out of memory according to the
+ * `REDISMODULE_CTX_FLAGS_OOM`: Valkey is out of memory according to the
    maxmemory setting.
 
  * `REDISMODULE_CTX_FLAGS_OOM_WARNING`: Less than 25% of memory remains before
@@ -2126,13 +2126,13 @@ Available flags and their meaning:
  * `REDISMODULE_CTX_FLAGS_MULTI_DIRTY`: The next EXEC will fail due to dirty
                                       CAS (touched keys).
 
- * `REDISMODULE_CTX_FLAGS_IS_CHILD`: Redis is currently running inside
+ * `REDISMODULE_CTX_FLAGS_IS_CHILD`: Valkey is currently running inside
                                    background child process.
 
  * `REDISMODULE_CTX_FLAGS_RESP3`: Indicate the that client attached to this
                                 context is using RESP3.
 
- * `REDISMODULE_CTX_FLAGS_SERVER_STARTUP`: The Redis instance is starting
+ * `REDISMODULE_CTX_FLAGS_SERVER_STARTUP`: The Valkey instance is starting
 
 <span id="RedisModule_AvoidReplicaTraffic"></span>
 
@@ -2143,7 +2143,7 @@ Available flags and their meaning:
 **Available since:** 6.0.0
 
 Returns true if a client sent the CLIENT PAUSE command to the server or
-if Redis Cluster does a manual failover, pausing the clients.
+if Valkey Cluster does a manual failover, pausing the clients.
 This is needed when we have a master with replicas, and want to write,
 without adding further data to the replication channel, that the replicas
 replication offset, match the one of the master. When this happens, it is
@@ -2174,7 +2174,7 @@ Change the currently selected DB. Returns an error if the id
 is out of range.
 
 Note that the client will retain the currently selected DB even after
-the Redis command implemented by the module calling this function
+the Valkey command implemented by the module calling this function
 returns.
 
 If the module command wishes to change something in a different DB and
@@ -2205,7 +2205,7 @@ calling [`RedisModule_CloseKey`](#RedisModule_CloseKey) on the opened key.
 
 **Available since:** 4.0.0
 
-Return a handle representing a Redis key, so that it is possible
+Return a handle representing a Valkey key, so that it is possible
 to call other APIs with the key handle as argument to perform
 operations on the key.
 
@@ -2994,7 +2994,7 @@ set to `REDISMODULE_HASH_NONE` if no special behavior is needed.
                               strings instead of RedisModuleString objects.
     REDISMODULE_HASH_COUNT_ALL: Include the number of inserted fields in the
                                 returned number, in addition to the number of
-                                updated and deleted fields. (Added in Redis
+                                updated and deleted fields. (Added in Valkey
                                 6.2.)
 
 Unless NX is specified, the command overwrites the old field value with
@@ -3379,9 +3379,9 @@ returned and `errno` is set as follows:
 
 <span id="section-calling-redis-commands-from-modules"></span>
 
-## Calling Redis commands from modules
+## Calling Valkey commands from modules
 
-[`RedisModule_Call()`](#RedisModule_Call) sends a command to Redis. The remaining functions handle the reply.
+[`RedisModule_Call()`](#RedisModule_Call) sends a command to Valkey. The remaining functions handle the reply.
 
 <span id="RedisModule_FreeCallReply"></span>
 
@@ -3589,7 +3589,7 @@ so the caller will be able to release the private data.
 If the execution was aborted successfully, it is promised that the unblock handler will not be called.
 That said, it is possible that the abort operation will successes but the operation will still continue.
 This can happened if, for example, a module implements some blocking command and does not respect the
-disconnect callback. For pure Redis commands this can not happened.
+disconnect callback. For pure Valkey commands this can not happened.
 
 <span id="RedisModule_CallReplyStringPtr"></span>
 
@@ -3635,9 +3635,9 @@ Modifies the user that [`RedisModule_Call`](#RedisModule_Call) will use (e.g. fo
 
 **Available since:** 4.0.0
 
-Exported API to call any Redis command from modules.
+Exported API to call any Valkey command from modules.
 
-* **cmdname**: The Redis command to call.
+* **cmdname**: The Valkey command to call.
 * **fmt**: A format specifier string for the command's arguments. Each
   of the arguments should be specified by a valid type specification. The
   format specifier can also contain the modifiers `!`, `A`, `3` and `R` which
@@ -3649,7 +3649,7 @@ Exported API to call any Redis command from modules.
     * `l` -- The argument is a `long long` integer.
     * `s` -- The argument is a RedisModuleString.
     * `v` -- The argument(s) is a vector of RedisModuleString.
-    * `!` -- Sends the Redis command and its arguments to replicas and AOF.
+    * `!` -- Sends the Valkey command and its arguments to replicas and AOF.
     * `A` -- Suppress AOF propagation, send only to replicas (requires `!`).
     * `R` -- Suppress replicas propagation, send only to AOF (requires `!`).
     * `3` -- Return a RESP3 reply. This will change the command reply.
@@ -3667,7 +3667,7 @@ Exported API to call any Redis command from modules.
              the command to run as the determined user, so that any future user
              dependent activity, such as ACL checks within scripts will proceed as
              expected.
-             Otherwise, the command will run as the Redis unrestricted user.
+             Otherwise, the command will run as the Valkey unrestricted user.
     * `S` -- Run the command in a script mode, this means that it will raise
              an error if a command which are not allowed inside a script
              (flagged with the `deny-script` flag) is invoked (like SHUTDOWN).
@@ -3690,7 +3690,7 @@ Exported API to call any Redis command from modules.
              The module can use this reply object to set a handler which will be called when
              the command gets unblocked using RedisModule_CallReplyPromiseSetUnblockHandler.
              The handler must be set immediately after the command invocation (without releasing
-             the Redis lock in between). If the handler is not set, the blocking command will
+             the Valkey lock in between). If the handler is not set, the blocking command will
              still continue its execution but the reply will be ignored (fire and forget),
              notice that this is dangerous in case of role change, as explained below.
              The module can use RedisModule_CallReplyPromiseAbort to abort the command invocation
@@ -3698,21 +3698,21 @@ Exported API to call any Redis command from modules.
              details). It is also the module's responsibility to abort the execution on role change, either by using
              server event (to get notified when the instance becomes a replica) or relying on the disconnect
              callback of the original client. Failing to do so can result in a write operation on a replica.
-             Unlike other call replies, promise call reply **must** be freed while the Redis GIL is locked.
+             Unlike other call replies, promise call reply **must** be freed while the Valkey GIL is locked.
              Notice that on unblocking, the only promise is that the unblock handler will be called,
              If the blocking RedisModule_Call caused the module to also block some real client (using RedisModule_BlockClient),
              it is the module responsibility to unblock this client on the unblock handler.
              On the unblock handler it is only allowed to perform the following:
-             * Calling additional Redis commands using RedisModule_Call
+             * Calling additional Valkey commands using RedisModule_Call
              * Open keys using RedisModule_OpenKey
              * Replicate data to the replica or AOF
 
-             Specifically, it is not allowed to call any Redis module API which are client related such as:
+             Specifically, it is not allowed to call any Valkey module API which are client related such as:
              * RedisModule_Reply* API's
              * RedisModule_BlockClient
              * RedisModule_GetCurrentUserName
 
-* **...**: The actual arguments to the Redis command.
+* **...**: The actual arguments to the Valkey command.
 
 On success a `RedisModuleCallReply` object is returned, otherwise
 NULL is returned and errno is set to the following values:
@@ -3757,7 +3757,7 @@ that returned the reply object.
 
 When String DMA or using existing data structures is not enough, it is
 possible to create new data types from scratch and export them to
-Redis. The module must provide a set of callbacks for handling the
+Valkey. The module must provide a set of callbacks for handling the
 new values exported (for example in order to provide RDB saving/loading,
 AOF rewrite, and so forth). In this section we define this API.
 
@@ -3776,7 +3776,7 @@ Register a new data type exported by the module. The parameters are the
 following. Please for in depth documentation check the modules API
 documentation, especially [https://valkey.io/topics/modules-native-types](https://valkey.io/topics/modules-native-types).
 
-* **name**: A 9 characters data type name that MUST be unique in the Redis
+* **name**: A 9 characters data type name that MUST be unique in the Valkey
   Modules ecosystem. Be creative... and there will be no collisions. Use
   the charset A-Z a-z 9-0, plus the two "-_" characters. A good
   idea is to use, for example `<typename>-<vendor>`. For example
@@ -3880,7 +3880,7 @@ happens to be pretty lame as well.
 If [`RedisModule_CreateDataType()`](#RedisModule_CreateDataType) is called outside of `RedisModule_OnLoad()` function,
 there is already a module registering a type with the same name,
 or if the module name or encver is invalid, NULL is returned.
-Otherwise the new type is registered into Redis, and a reference of
+Otherwise the new type is registered into Valkey, and a reference of
 type `RedisModuleType` is returned: the caller of the function should store
 this reference into a global variable to make future use of it in the
 modules type API, since a single module may register multiple types.
@@ -4146,11 +4146,11 @@ Add a new element to the digest. This function can be called multiple times
 one element after the other, for all the elements that constitute a given
 data structure. The function call must be followed by the call to
 [`RedisModule_DigestEndSequence`](#RedisModule_DigestEndSequence) eventually, when all the elements that are
-always in a given order are added. See the Redis Modules data types
-documentation for more info. However this is a quick example that uses Redis
+always in a given order are added. See the Valkey Modules data types
+documentation for more info. However this is a quick example that uses Valkey
 data types as an example.
 
-To add a sequence of unordered elements (for example in the case of a Redis
+To add a sequence of unordered elements (for example in the case of a Valkey
 Set), the pattern to use is:
 
     foreach element {
@@ -4215,13 +4215,13 @@ from string 'str' and return a newly allocated value, or NULL if decoding failed
 
 This call basically reuses the '`rdb_load`' callback which module data types
 implement in order to allow a module to arbitrarily serialize/de-serialize
-keys, similar to how the Redis 'DUMP' and 'RESTORE' commands are implemented.
+keys, similar to how the Valkey 'DUMP' and 'RESTORE' commands are implemented.
 
 Modules should generally use the `REDISMODULE_OPTIONS_HANDLE_IO_ERRORS` flag and
 make sure the de-serialization code properly checks and handles IO errors
 (freeing allocated buffers and returning a NULL).
 
-If this is NOT done, Redis will handle corrupted (or just truncated) serialized
+If this is NOT done, Valkey will handle corrupted (or just truncated) serialized
 data by producing an error message and terminating the process.
 
 <span id="RedisModule_LoadDataTypeFromString"></span>
@@ -4251,7 +4251,7 @@ as a newly allocated `RedisModuleString`.
 
 This call basically reuses the '`rdb_save`' callback which module data types
 implement in order to allow a module to arbitrarily serialize/de-serialize
-keys, similar to how the Redis 'DUMP' and 'RESTORE' commands are implemented.
+keys, similar to how the Valkey 'DUMP' and 'RESTORE' commands are implemented.
 
 <span id="RedisModule_GetKeyNameFromDigest"></span>
 
@@ -4292,7 +4292,7 @@ Emits a command into the AOF during the AOF rewriting process. This function
 is only called in the context of the `aof_rewrite` method of data types exported
 by a module. The command works exactly like [`RedisModule_Call()`](#RedisModule_Call) in the way
 the parameters are passed, but it does not return anything as the error
-handling is performed by Redis itself.
+handling is performed by Valkey itself.
 
 <span id="section-io-context-handling"></span>
 
@@ -4355,7 +4355,7 @@ There is no guarantee that this info is always available, so this may return -1.
 
 **Available since:** 4.0.0
 
-Produces a log message to the standard Redis log, the format accepts
+Produces a log message to the standard Valkey log, the format accepts
 printf-alike specifiers, while level is a string describing the log
 level to use when emitting the log, and must be one of the following:
 
@@ -4398,13 +4398,13 @@ critical reason.
 
 **Available since:** 6.0.0
 
-Redis-like assert function.
+Valkey-like assert function.
 
 The macro `RedisModule_Assert(expression)` is recommended, rather than
 calling this function directly.
 
 A failed assertion will shut down the server and produce logging information
-that looks identical to information generated by Redis itself.
+that looks identical to information generated by Valkey itself.
 
 <span id="RedisModule_LatencyAddSample"></span>
 
@@ -4583,10 +4583,10 @@ Set private data on a blocked client
 **Available since:** 6.0.0
 
 This call is similar to [`RedisModule_BlockClient()`](#RedisModule_BlockClient), however in this case we
-don't just block the client, but also ask Redis to unblock it automatically
+don't just block the client, but also ask Valkey to unblock it automatically
 once certain keys become "ready", that is, contain more data.
 
-Basically this is similar to what a typical Redis command usually does,
+Basically this is similar to what a typical Valkey command usually does,
 like BLPOP or BZPOPMAX: the client blocks if it cannot be served ASAP,
 and later when the key receives new data (a list push for instance), the
 client is unblocked and served.
@@ -4625,7 +4625,7 @@ we pass the private data directly when blocking the client: it will
 be accessible later in the reply callback. Normally when blocking with
 [`RedisModule_BlockClient()`](#RedisModule_BlockClient) the private data to reply to the client is
 passed when calling [`RedisModule_UnblockClient()`](#RedisModule_UnblockClient) but here the unblocking
-is performed by Redis itself, so we need to have some private data before
+is performed by Valkey itself, so we need to have some private data before
 hand. The private data is used to store any information about the specific
 unblocking operation that you are implementing. Such information will be
 freed using the `free_privdata` callback provided by the user.
@@ -4815,7 +4815,7 @@ while it was blocked.
 
 **Available since:** 4.0.0
 
-Return a context which can be used inside threads to make Redis context
+Return a context which can be used inside threads to make Valkey context
 calls with certain modules APIs. If 'bc' is not NULL then the module will
 be bound to a blocked client, and it will be possible to use the
 `RedisModule_Reply*` family of functions to accumulate a reply for when the
@@ -4958,7 +4958,7 @@ The subscriber signature is:
 
 `type` is the event type bit, that must match the mask given at registration
 time. The event string is the actual command being executed, and key is the
-relevant Redis key.
+relevant Valkey key.
 
 Notification callback gets executed with a redis context that can not be
 used to send anything to the client, and has the db number where the event
@@ -4968,11 +4968,11 @@ Notice that it is not necessary to enable notifications in redis.conf for
 module notifications to work.
 
 Warning: the notification callbacks are performed in a synchronous manner,
-so notification callbacks must to be fast, or they would slow Redis down.
+so notification callbacks must to be fast, or they would slow Valkey down.
 If you need to take long actions, use threads to offload them.
 
 Moreover, the fact that the notification is executed synchronously means
-that the notification code will be executed in the middle on Redis logic
+that the notification code will be executed in the middle on Valkey logic
 (commands logic, eviction, expire). Changing the key space while the logic
 runs is dangerous and discouraged. In order to react to key space events with
 write actions, please refer to [`RedisModule_AddPostNotificationJob`](#RedisModule_AddPostNotificationJob).
@@ -4992,7 +4992,7 @@ See [https://valkey.io/topics/notifications](https://valkey.io/topics/notificati
 
 When running inside a key space notification callback, it is dangerous and highly discouraged to perform any write
 operation (See [`RedisModule_SubscribeToKeyspaceEvents`](#RedisModule_SubscribeToKeyspaceEvents)). In order to still perform write actions in this scenario,
-Redis provides [`RedisModule_AddPostNotificationJob`](#RedisModule_AddPostNotificationJob) API. The API allows to register a job callback which Redis will call
+Valkey provides [`RedisModule_AddPostNotificationJob`](#RedisModule_AddPostNotificationJob) API. The API allows to register a job callback which Valkey will call
 when the following condition are promised to be fulfilled:
 1. It is safe to perform any write operation.
 2. The job will be called atomically along side the key space notification.
@@ -5001,7 +5001,7 @@ Notice, one job might trigger key space notifications that will trigger more job
 This raises a concerns of entering an infinite loops, we consider infinite loops
 as a logical bug that need to be fixed in the module, an attempt to protect against
 infinite loops by halting the execution could result in violation of the feature correctness
-and so Redis will make no attempt to protect the module from infinite loops.
+and so Valkey will make no attempt to protect the module from infinite loops.
 
 '`free_pd`' can be NULL and in such case will not be used.
 
@@ -5083,8 +5083,8 @@ known cluster node, `REDISMODULE_ERR` is returned.
 Return an array of string pointers, each string pointer points to a cluster
 node ID of exactly `REDISMODULE_NODE_ID_LEN` bytes (without any null term).
 The number of returned node IDs is stored into `*numnodes`.
-However if this function is called by a module not running an a Redis
-instance with Redis Cluster enabled, NULL is returned instead.
+However if this function is called by a module not running an a Valkey
+instance with Valkey Cluster enabled, NULL is returned instead.
 
 The IDs returned can be used with [`RedisModule_GetClusterNodeInfo()`](#RedisModule_GetClusterNodeInfo) in order
 to get more information about single node.
@@ -5177,10 +5177,10 @@ The list of flags reported is the following:
 
 **Available since:** 5.0.0
 
-Set Redis Cluster flags in order to change the normal behavior of
-Redis Cluster, especially with the goal of disabling certain functions.
+Set Valkey Cluster flags in order to change the normal behavior of
+Valkey Cluster, especially with the goal of disabling certain functions.
 This is useful for modules that use the Cluster API in order to create
-a different distributed system, but still want to use the Redis Cluster
+a different distributed system, but still want to use the Valkey Cluster
 message bus. Flags that can be set:
 
 * `CLUSTER_MODULE_FLAG_NO_FAILOVER`
@@ -5188,11 +5188,11 @@ message bus. Flags that can be set:
 
 With the following effects:
 
-* `NO_FAILOVER`: prevent Redis Cluster slaves from failing over a dead master.
+* `NO_FAILOVER`: prevent Valkey Cluster slaves from failing over a dead master.
                Also disables the replica migration feature.
 
 * `NO_REDIRECTION`: Every node will accept any key, without trying to perform
-                  partitioning according to the Redis Cluster algorithm.
+                  partitioning according to the Valkey Cluster algorithm.
                   Slots information will still be propagated across the
                   cluster, but without effect.
 
@@ -5206,7 +5206,7 @@ the actual event loop will just have a single timer that is used to awake the
 module timers subsystem in order to process the next event.
 
 All the timers are stored into a radix tree, ordered by expire time, when
-the main Redis event loop timer callback is called, we try to process all
+the main Valkey event loop timer callback is called, we try to process all
 the timers already expired one after the other. Then we re-enter the event
 loop registering a timer that will expire when the next to process module
 timer will expire.
@@ -5298,7 +5298,7 @@ Add a pipe / socket event to the event loop.
 On success `REDISMODULE_OK` is returned, otherwise
 `REDISMODULE_ERR` is returned and errno is set to the following values:
 
-* ERANGE: `fd` is negative or higher than `maxclients` Redis config.
+* ERANGE: `fd` is negative or higher than `maxclients` Valkey config.
 * EINVAL: `callback` is NULL or `mask` value is invalid.
 
 `errno` might take other values in case of an internal error.
@@ -5331,7 +5331,7 @@ Delete a pipe / socket event from the event loop.
 On success `REDISMODULE_OK` is returned, otherwise
 `REDISMODULE_ERR` is returned and errno is set to the following values:
 
-* ERANGE: `fd` is negative or higher than `maxclients` Redis config.
+* ERANGE: `fd` is negative or higher than `maxclients` Valkey config.
 * EINVAL: `mask` value is invalid.
 
 <span id="RedisModule_EventLoopAddOneShot"></span>
@@ -5343,7 +5343,7 @@ On success `REDISMODULE_OK` is returned, otherwise
 
 **Available since:** 7.0.0
 
-This function can be called from other threads to trigger callback on Redis
+This function can be called from other threads to trigger callback on Valkey
 main thread. On success `REDISMODULE_OK` is returned. If `func` is NULL
 `REDISMODULE_ERR` is returned and errno is set to EINVAL.
 
@@ -5351,7 +5351,7 @@ main thread. On success `REDISMODULE_OK` is returned. If `func` is NULL
 
 ## Modules ACL API
 
-Implements a hook into the authentication and authorization within Redis.
+Implements a hook into the authentication and authorization within Valkey.
 
 <span id="RedisModule_CreateModuleUser"></span>
 
@@ -5361,7 +5361,7 @@ Implements a hook into the authentication and authorization within Redis.
 
 **Available since:** 6.0.0
 
-Creates a Redis ACL user that the module can use to authenticate a client.
+Creates a Valkey ACL user that the module can use to authenticate a client.
 After obtaining the user, the module should set what such user can do
 using the `RedisModule_SetUserACL()` function. Once configured, the user
 can be used in order to authenticate a connection, with the specified
@@ -5373,7 +5373,7 @@ Note that:
 * Users created here are not checked for duplicated name, so it's up to
   the module calling this function to take care of not creating users
   with the same name.
-* The created user can be used to authenticate multiple Redis connections.
+* The created user can be used to authenticate multiple Valkey connections.
 
 The caller can later free the user using the function
 [`RedisModule_FreeModuleUser()`](#RedisModule_FreeModuleUser). When this function is called, if there are
@@ -6359,11 +6359,11 @@ And the function registerAPI() is:
 
 Register a new command filter function.
 
-Command filtering makes it possible for modules to extend Redis by plugging
+Command filtering makes it possible for modules to extend Valkey by plugging
 into the execution flow of all commands.
 
-A registered filter gets called before Redis executes *any* command.  This
-includes both core Redis commands and commands registered by any module.  The
+A registered filter gets called before Valkey executes *any* command.  This
+includes both core Valkey commands and commands registered by any module.  The
 filter applies in all execution paths including:
 
 1. Invocation by a client.
@@ -6374,21 +6374,21 @@ filter applies in all execution paths including:
 The filter executes in a special filter context, which is different and more
 limited than a `RedisModuleCtx`.  Because the filter affects any command, it
 must be implemented in a very efficient way to reduce the performance impact
-on Redis.  All Redis Module API calls that require a valid context (such as
+on Valkey.  All Valkey Module API calls that require a valid context (such as
 [`RedisModule_Call()`](#RedisModule_Call), [`RedisModule_OpenKey()`](#RedisModule_OpenKey), etc.) are not supported in a
 filter context.
 
 The `RedisModuleCommandFilterCtx` can be used to inspect or modify the
-executed command and its arguments.  As the filter executes before Redis
+executed command and its arguments.  As the filter executes before Valkey
 begins processing the command, any change will affect the way the command is
-processed.  For example, a module can override Redis commands this way:
+processed.  For example, a module can override Valkey commands this way:
 
 1. Register a `MODULE.SET` command which implements an extended version of
-   the Redis `SET` command.
+   the Valkey `SET` command.
 2. Register a command filter which detects invocation of `SET` on a specific
    pattern of keys.  Once detected, the filter will replace the first
    argument from `SET` to `MODULE.SET`.
-3. When filter execution is complete, Redis considers the new command name
+3. When filter execution is complete, Valkey considers the new command name
    and therefore executes the module's own command.
 
 Note that in the above use case, if `MODULE.SET` itself uses
@@ -6453,7 +6453,7 @@ the command itself, and the rest are user-provided args.
 **Available since:** 5.0.5
 
 Modify the filtered command by inserting a new argument at the specified
-position.  The specified `RedisModuleString` argument may be used by Redis
+position.  The specified `RedisModuleString` argument may be used by Valkey
 after the filter context is destroyed, so it must not be auto-memory
 allocated, freed or used elsewhere.
 
@@ -6468,7 +6468,7 @@ allocated, freed or used elsewhere.
 **Available since:** 5.0.5
 
 Modify the filtered command by replacing an existing argument with a new one.
-The specified `RedisModuleString` argument may be used by Redis after the
+The specified `RedisModuleString` argument may be used by Valkey after the
 filter context is destroyed, so it must not be auto-memory allocated, freed
 or used elsewhere.
 
@@ -6550,7 +6550,7 @@ it does not include the allocation size of the keys and values.
 **Available since:** 6.0.0
 
 Return the a number between 0 to 1 indicating the amount of memory
-currently used, relative to the Redis "maxmemory" configuration.
+currently used, relative to the Valkey "maxmemory" configuration.
 
 * 0 - No memory limit configured.
 * Between 0 and 1 - The percentage of the memory used normalized in 0-1 range.
@@ -6643,7 +6643,7 @@ The function will return 1 if there are more elements to scan and
 
 It is also possible to restart an existing cursor using [`RedisModule_ScanCursorRestart`](#RedisModule_ScanCursorRestart).
 
-IMPORTANT: This API is very similar to the Redis SCAN command from the
+IMPORTANT: This API is very similar to the Valkey SCAN command from the
 point of view of the guarantees it provides. This means that the API
 may report duplicated keys, but guarantees to report at least one time
 every key that was there from the start to the end of the scanning process.
@@ -6652,7 +6652,7 @@ NOTE: If you do database changes within the callback, you should be aware
 that the internal state of the database may change. For instance it is safe
 to delete or modify the current key, but may not be safe to delete any
 other key.
-Moreover playing with the Redis keyspace while iterating may have the
+Moreover playing with the Valkey keyspace while iterating may have the
 effect of returning more duplicates. A safe pattern is to store the keys
 names you want to modify elsewhere, and perform the actions on the keys
 later when the iteration is complete. However this can cost a lot of
@@ -6734,7 +6734,7 @@ the key you are iterating is not safe.
 Create a background child process with the current frozen snapshot of the
 main process where you can do some processing in the background without
 affecting / freezing the traffic and no need for threads and GIL locking.
-Note that Redis allows for only one concurrent fork.
+Note that Valkey allows for only one concurrent fork.
 When the child wants to exit, it should call [`RedisModule_ExitFromChild`](#RedisModule_ExitFromChild).
 If the parent wants to kill the child it should call [`RedisModule_KillForkChild`](#RedisModule_KillForkChild)
 The done handler callback will be executed on the parent process when the
@@ -6808,7 +6808,7 @@ The callback must be of this type:
                                     uint64_t subevent,
                                     void *data);
 
-The 'ctx' is a normal Redis module context that the callback can use in
+The 'ctx' is a normal Valkey module context that the callback can use in
 order to call other modules APIs. The 'eid' is the event itself, this
 is only useful in the case the module subscribed to multiple events: using
 the 'id' field of this structure it is possible to check if the event
@@ -6931,15 +6931,15 @@ Here is a list of events you can use as 'eid' and related sub events:
     * `REDISMODULE_SUBEVENT_REPLICA_CHANGE_OFFLINE`
 
     No additional information is available so far: future versions
-    of Redis will have an API in order to enumerate the replicas
+    of Valkey will have an API in order to enumerate the replicas
     connected and their state.
 
 * `RedisModuleEvent_CronLoop`
 
-    This event is called every time Redis calls the serverCron()
+    This event is called every time Valkey calls the serverCron()
     function in order to do certain bookkeeping. Modules that are
     required to do operations from time to time may use this callback.
-    Normally Redis calls this function 10 times per second, but
+    Normally Valkey calls this function 10 times per second, but
     this changes depending on the "hz" configuration.
     No sub events are available.
 
@@ -7114,11 +7114,11 @@ subevent is not supported and non-zero otherwise.
 
 **Available since:** 7.0.0
 
-Create a string config that Redis users can interact with via the Redis config file,
+Create a string config that Valkey users can interact with via the Valkey config file,
 `CONFIG SET`, `CONFIG GET`, and `CONFIG REWRITE` commands.
 
 The actual config value is owned by the module, and the `getfn`, `setfn` and optional
-`applyfn` callbacks that are provided to Redis in order to access or manipulate the
+`applyfn` callbacks that are provided to Valkey in order to access or manipulate the
 value. The `getfn` callback retrieves the value from the module, while the `setfn`
 callback provides a value to be stored into the module config.
 The optional `applyfn` callback is called after a `CONFIG SET` command modified one or
@@ -7129,7 +7129,7 @@ command, they will be deduplicated if their `applyfn` function and `privdata` po
 are identical, and the callback will only be run once.
 Both the `setfn` and `applyfn` can return an error if the provided value is invalid or
 cannot be used.
-The config also declares a type for the value that is validated by Redis and
+The config also declares a type for the value that is validated by Valkey and
 provided to the module. The config system provides the following types:
 
 * String: Binary safe string data.
@@ -7231,7 +7231,7 @@ Create a bool config that server clients can interact with via the
 Create an enum config that server clients can interact with via the 
 `CONFIG SET`, `CONFIG GET`, and `CONFIG REWRITE` commands. 
 Enum configs are a set of string tokens to corresponding integer values, where 
-the string value is exposed to Redis clients but the value passed Redis and the
+the string value is exposed to Valkey clients but the value passed Valkey and the
 module is the integer value. These values are defined in `enum_values`, an array
 of null-terminated c strings, and `int_vals`, an array of enum values who has an
 index partner in `enum_values`.
@@ -7570,7 +7570,7 @@ as follows:
 * ENOENT: Specified command does not exist.
 * EINVAL: Invalid command arity specified.
 
-NOTE: The returned array is not a Redis Module object so it does not
+NOTE: The returned array is not a Valkey Module object so it does not
 get automatically freed even when auto-memory is used. The caller
 must explicitly call [`RedisModule_Free()`](#RedisModule_Free) to free it, same as the `out_flags` pointer if
 used.
@@ -7718,7 +7718,7 @@ NOTE: It is only possible to defrag strings that have a single reference.
 Typically this means strings retained with [`RedisModule_RetainString`](#RedisModule_RetainString) or [`RedisModule_HoldString`](#RedisModule_HoldString)
 may not be defragmentable. One exception is command argvs which, if retained
 by the module, will end up with a single reference (because the reference
-on the Redis side is dropped as soon as the command callback returns).
+on the Valkey side is dropped as soon as the command callback returns).
 
 <span id="RedisModule_GetKeyNameFromDefragCtx"></span>
 

--- a/docs/reference/modules/modules-api-ref.md
+++ b/docs/reference/modules/modules-api-ref.md
@@ -6368,7 +6368,7 @@ filter applies in all execution paths including:
 
 1. Invocation by a client.
 2. Invocation through [`RedisModule_Call()`](#RedisModule_Call) by any module.
-3. Invocation through Lua `redis.call()`.
+3. Invocation through Lua `server.call()`.
 4. Replication of a command from a master.
 
 The filter executes in a special filter context, which is different and more

--- a/docs/reference/modules/modules-api-ref.md
+++ b/docs/reference/modules/modules-api-ref.md
@@ -4964,7 +4964,7 @@ Notification callback gets executed with a redis context that can not be
 used to send anything to the client, and has the db number where the event
 occurred as its selected db number.
 
-Notice that it is not necessary to enable notifications in redis.conf for
+Notice that it is not necessary to enable notifications in valkey.conf for
 module notifications to work.
 
 Warning: the notification callbacks are performed in a synchronous manner,
@@ -7511,7 +7511,7 @@ Example for 6.0.7 the return value will be 0x00060007.
 **Available since:** 6.2.0
 
 
-Return the current redis-server runtime value of `REDISMODULE_TYPE_METHOD_VERSION`.
+Return the current valkey-server runtime value of `REDISMODULE_TYPE_METHOD_VERSION`.
 You can use that when calling [`RedisModule_CreateDataType`](#RedisModule_CreateDataType) to know which fields of
 `RedisModuleTypeMethods` are gonna be supported and which will be ignored.
 

--- a/docs/reference/modules/modules-api-ref.md
+++ b/docs/reference/modules/modules-api-ref.md
@@ -317,7 +317,7 @@ example "write deny-oom". The set of flags are:
 * **"pubsub"**:    The command publishes things on Pub/Sub channels.
 * **"random"**:    The command may have different outputs even starting
                    from the same input arguments and key values.
-                   Starting from Redis 7.0 this flag has been deprecated.
+                   Starting from Redis OSS 7.0 this flag has been deprecated.
                    Declaring a command as "random" can be done using
                    command tips, see https://valkey.io/topics/command-tips.
 * **"allow-stale"**: The command is allowed to run on slaves that don't
@@ -486,7 +486,7 @@ only be set once for each command and has the following structure:
 
 All fields except `version` are optional. Explanation of the fields:
 
-- `version`: This field enables compatibility with different Redis versions.
+- `version`: This field enables compatibility with different Redis OSS versions.
   Always set this field to `REDISMODULE_COMMAND_INFO_VERSION`.
 
 - `summary`: A short description of the command (optional).
@@ -494,7 +494,7 @@ All fields except `version` are optional. Explanation of the fields:
 - `complexity`: Complexity description (optional).
 
 - `since`: The version where the command was introduced (optional).
-  Note: The version specified should be the module's, not Redis version.
+  Note: The version specified should be the module's, not Redis OSS version.
 
 - `history`: An array of `RedisModuleCommandHistoryEntry` (optional), which is
   a struct with the following fields:
@@ -2568,7 +2568,7 @@ follows:
 - ENOTSUP if the key is of another type than list.
 - EBADF if the key is not opened for writing.
 
-Note: Before Redis 7.0, `errno` was not set by this function.
+Note: Before Redis OSS 7.0, `errno` was not set by this function.
 
 <span id="RedisModule_ListPop"></span>
 
@@ -2589,7 +2589,7 @@ popped from the beginning or the end of the list (`REDISMODULE_LIST_HEAD` or
 - ENOTSUP if the key is empty or of another type than list.
 - EBADF if the key is not opened for writing.
 
-Note: Before Redis 7.0, `errno` was not set by this function.
+Note: Before Redis OSS 7.0, `errno` was not set by this function.
 
 <span id="RedisModule_ListGet"></span>
 
@@ -3014,7 +3014,7 @@ updated (its old value has been replaced by a new value) or deleted. If the
 flag `REDISMODULE_HASH_COUNT_ALL` is set, inserted fields not previously
 existing in the hash are also counted.
 
-If the return value is zero, `errno` is set (since Redis 6.2) as follows:
+If the return value is zero, `errno` is set (since Redis OSS 6.2) as follows:
 
 - EINVAL if any unknown flags are set or if key is NULL.
 - ENOTSUP if the key is associated with a non Hash value.
@@ -3025,8 +3025,8 @@ If the return value is zero, `errno` is set (since Redis 6.2) as follows:
   back due to the NX and XX flags.
 
 NOTICE: The return value semantics of this function are very different
-between Redis 6.2 and older versions. Modules that use it should determine
-the Redis version and handle it accordingly.
+between Redis OSS 6.2 and older versions. Modules that use it should determine
+the Redis OSS version and handle it accordingly.
 
 <span id="RedisModule_HashGet"></span>
 
@@ -7004,7 +7004,7 @@ Here is a list of events you can use as 'eid' and related sub events:
 
 * `RedisModuleEvent_ReplBackup`
 
-    WARNING: Replication Backup events are deprecated since Redis 7.0 and are never fired.
+    WARNING: Replication Backup events are deprecated since Redis OSS 7.0 and are never fired.
     See RedisModuleEvent_ReplAsyncLoad for understanding how Async Replication Loading events
     are now triggered when repl-diskless-load is set to swapdb.
 

--- a/docs/reference/modules/modules-api-ref.md
+++ b/docs/reference/modules/modules-api-ref.md
@@ -160,7 +160,7 @@ The function returns NULL if `bytes` is 0.
 
 These functions are used to implement custom Redis commands.
 
-For examples, see [https://redis.io/topics/modules-intro](https://redis.io/topics/modules-intro).
+For examples, see [https://valkey.io/topics/modules-intro](https://valkey.io/topics/modules-intro).
 
 <span id="RedisModule_IsKeysPositionRequest"></span>
 
@@ -319,7 +319,7 @@ example "write deny-oom". The set of flags are:
                    from the same input arguments and key values.
                    Starting from Redis 7.0 this flag has been deprecated.
                    Declaring a command as "random" can be done using
-                   command tips, see https://redis.io/topics/command-tips.
+                   command tips, see https://valkey.io/topics/command-tips.
 * **"allow-stale"**: The command is allowed to run on slaves that don't
                      serve stale data. Don't use if you don't know what
                      this means.
@@ -507,7 +507,7 @@ All fields except `version` are optional. Explanation of the fields:
     both strings set to NULL.
 
 - `tips`: A string of space-separated tips regarding this command, meant for
-  clients and proxies. See [https://redis.io/topics/command-tips](https://redis.io/topics/command-tips).
+  clients and proxies. See [https://valkey.io/topics/command-tips](https://valkey.io/topics/command-tips).
 
 - `arity`: Number of arguments, including the command name itself. A positive
   number specifies an exact number of arguments and a negative number
@@ -3081,7 +3081,7 @@ The returned `RedisModuleString` objects should be released with
 
 ## Key API for Stream type
 
-For an introduction to streams, see [https://redis.io/topics/streams-intro](https://redis.io/topics/streams-intro).
+For an introduction to streams, see [https://valkey.io/topics/streams-intro](https://valkey.io/topics/streams-intro).
 
 The type `RedisModuleStreamID`, which is used in stream functions, is a struct
 with two 64-bit fields and is defined as
@@ -3737,7 +3737,7 @@ Example code fragment:
        // Do something with myval.
      }
 
-This API is documented here: [https://redis.io/topics/modules-intro](https://redis.io/topics/modules-intro)
+This API is documented here: [https://valkey.io/topics/modules-intro](https://valkey.io/topics/modules-intro)
 
 <span id="RedisModule_CallReplyProto"></span>
 
@@ -3774,7 +3774,7 @@ AOF rewrite, and so forth). In this section we define this API.
 
 Register a new data type exported by the module. The parameters are the
 following. Please for in depth documentation check the modules API
-documentation, especially [https://redis.io/topics/modules-native-types](https://redis.io/topics/modules-native-types).
+documentation, especially [https://valkey.io/topics/modules-native-types](https://valkey.io/topics/modules-native-types).
 
 * **name**: A 9 characters data type name that MUST be unique in the Redis
   Modules ecosystem. Be creative... and there will be no collisions. Use
@@ -4423,7 +4423,7 @@ latency-monitor-threshold.
 ## Blocking clients from modules
 
 For a guide about blocking commands in modules, see
-[https://redis.io/topics/modules-blocking-ops](https://redis.io/topics/modules-blocking-ops).
+[https://valkey.io/topics/modules-blocking-ops](https://valkey.io/topics/modules-blocking-ops).
 
 <span id="RedisModule_RegisterAuthCallback"></span>
 
@@ -4977,7 +4977,7 @@ that the notification code will be executed in the middle on Redis logic
 runs is dangerous and discouraged. In order to react to key space events with
 write actions, please refer to [`RedisModule_AddPostNotificationJob`](#RedisModule_AddPostNotificationJob).
 
-See [https://redis.io/topics/notifications](https://redis.io/topics/notifications) for more information.
+See [https://valkey.io/topics/notifications](https://valkey.io/topics/notifications) for more information.
 
 <span id="RedisModule_AddPostNotificationJob"></span>
 

--- a/docs/reference/modules/modules-blocking-ops.md
+++ b/docs/reference/modules/modules-blocking-ops.md
@@ -270,4 +270,4 @@ to be called in a safe way from threads, so that the threaded command
 can access the data space and do incremental operations.
 
 There is no ETA for this feature but it may appear in the course of the
-Redis 4.0 release at some point.
+Redis OSS 4.0 release at some point.

--- a/docs/reference/modules/modules-blocking-ops.md
+++ b/docs/reference/modules/modules-blocking-ops.md
@@ -1,25 +1,25 @@
 ---
-title: "Redis modules and blocking commands"
+title: "Valkey modules and blocking commands"
 linkTitle: "Blocking commands"
 weight: 1
 description: >
-    How to implement blocking commands in a Redis module
+    How to implement blocking commands in a Valkey module
 aliases:
     - /topics/modules-blocking-ops
 ---
 
-Redis has a few blocking commands among the built-in set of commands.
+Valkey has a few blocking commands among the built-in set of commands.
 One of the most used is `BLPOP` (or the symmetric `BRPOP`) which blocks
 waiting for elements arriving in a list.
 
 The interesting fact about blocking commands is that they do not block
 the whole server, but just the client calling them. Usually the reason to
 block is that we expect some external event to happen: this can be
-some change in the Redis data structures like in the `BLPOP` case, a
+some change in the Valkey data structures like in the `BLPOP` case, a
 long computation happening in a thread, to receive some data from the
 network, and so forth.
 
-Redis modules have the ability to implement blocking commands as well,
+Valkey modules have the ability to implement blocking commands as well,
 this documentation shows how the API works and describes a few patterns
 that can be used in order to model blocking commands.
 
@@ -27,12 +27,12 @@ that can be used in order to model blocking commands.
 How blocking and resuming works.
 ---
 
-_Note: You may want to check the `helloblock.c` example in the Redis source tree
+_Note: You may want to check the `helloblock.c` example in the Valkey source tree
 inside the `src/modules` directory, for a simple to understand example
 on how the blocking API is applied._
 
-In Redis modules, commands are implemented by callback functions that
-are invoked by the Redis core when the specific command is called
+In Valkey modules, commands are implemented by callback functions that
+are invoked by the Valkey core when the specific command is called
 by the user. Normally the callback terminates its execution sending
 some reply to the client. Using the following function instead, the
 function implementing the module command may request that the client
@@ -117,7 +117,7 @@ The important bit here is that the reply callback is called when the
 client is unblocked from the thread.
 
 The timeout command returns `NULL`, as it often happens with actual
-Redis blocking commands timing out.
+Valkey blocking commands timing out.
 
 Passing reply data when unblocking
 ---
@@ -258,14 +258,14 @@ the old version. However when the thread terminated its work, the
 representations are swapped and the new, processed version, is used.
 
 An example of this approach is the
-[Neural Redis module](https://github.com/antirez/neural-redis)
+[Neural Valkey module](https://github.com/antirez/neural-redis)
 where neural networks are trained in different threads while the
 user can still execute and inspect their older versions.
 
 Future work
 ---
 
-An API is work in progress right now in order to allow Redis modules APIs
+An API is work in progress right now in order to allow Valkey modules APIs
 to be called in a safe way from threads, so that the threaded command
 can access the data space and do incremental operations.
 

--- a/docs/reference/modules/modules-native-types.md
+++ b/docs/reference/modules/modules-native-types.md
@@ -3,25 +3,25 @@ title: "Modules API for native types"
 linkTitle: "Native types API"
 weight: 1
 description: >
-    How to use native types in a Redis module
+    How to use native types in a Valkey module
 aliases:
     - /topics/modules-native-types
 ---
 
-Redis modules can access Redis built-in data structures both at high level,
-by calling Redis commands, and at low level, by manipulating the data structures
+Valkey modules can access Valkey built-in data structures both at high level,
+by calling Valkey commands, and at low level, by manipulating the data structures
 directly.
 
 By using these capabilities in order to build new abstractions on top of existing
-Redis data structures, or by using strings DMA in order to encode modules
+Valkey data structures, or by using strings DMA in order to encode modules
 data structures into Strings, it is possible to create modules that
 *feel like* they are exporting new data types. However, for more complex
 problems, this is not enough, and the implementation of new data structures
 inside the module is needed.
 
-We call the ability of Redis modules to implement new data structures that
-feel like native Redis ones **native types support**. This document describes
-the API exported by the Redis modules system in order to create new data
+We call the ability of Valkey modules to implement new data structures that
+feel like native Valkey ones **native types support**. This document describes
+the API exported by the Valkey modules system in order to create new data
 structures and handle the serialization in RDB files, the rewriting process
 in AOF, the type reporting via the `TYPE` command, and so forth.
 
@@ -35,17 +35,17 @@ A module exporting a native type is composed of the following main parts:
 * A 9 characters name that is unique to each module native data type.
 * An encoding version, used to persist into RDB files a module-specific data version, so that a module will be able to load older representations from RDB files.
 
-While to handle RDB loading, saving and AOF rewriting may look complex as a first glance, the modules API provide very high level function for handling all this, without requiring the user to handle read/write errors, so in practical terms, writing a new data structure for Redis is a simple task.
+While to handle RDB loading, saving and AOF rewriting may look complex as a first glance, the modules API provide very high level function for handling all this, without requiring the user to handle read/write errors, so in practical terms, writing a new data structure for Valkey is a simple task.
 
 A **very easy** to understand but complete example of native type implementation
-is available inside the Redis distribution in the `/modules/hellotype.c` file.
+is available inside the Valkey distribution in the `/modules/hellotype.c` file.
 The reader is encouraged to read the documentation by looking at this example
 implementation to see how things are applied in the practice.
 
 Registering a new data type
 ===
 
-In order to register a new native type into the Redis core, the module needs
+In order to register a new native type into the Valkey core, the module needs
 to declare a global variable that will hold a reference to the data type.
 The API to register the data type will return a data type reference that will
 be stored in the global variable.
@@ -78,7 +78,7 @@ The `ctx` argument is the context that we receive in the `OnLoad` function.
 The type `name` is a 9 character name in the character set that includes
 from `A-Z`, `a-z`, `0-9`, plus the underscore `_` and minus `-` characters.
 
-Note that **this name must be unique** for each data type in the Redis
+Note that **this name must be unique** for each data type in the Valkey
 ecosystem, so be creative, use both lower-case and upper case if it makes
 sense, and try to use the convention of mixing the type name with the name
 of the author of the module, to create a 9 character unique name.
@@ -89,7 +89,7 @@ registration of the type will fail. Read more to understand why.
 For example if I'm building a *b-tree* data structure and my name is *antirez*
 I'll call my type **btree1-az**. The name, converted to a 64 bit integer,
 is stored inside the RDB file when saving the type, and will be used when the
-RDB data is loaded in order to resolve what module can load the data. If Redis
+RDB data is loaded in order to resolve what module can load the data. If Valkey
 finds no matching module, the integer is converted back to a name in order to
 provide some clue to the user about what module is missing in order to load
 the data.
@@ -120,7 +120,7 @@ registration function: `rdb_load`, `rdb_save`, `aof_rewrite`, `digest` and
 
 * `rdb_load` is called when loading data from the RDB file. It loads data in the same format as `rdb_save` produces.
 * `rdb_save` is called when saving data to the RDB file.
-* `aof_rewrite` is called when the AOF is being rewritten, and the module needs to tell Redis what is the sequence of commands to recreate the content of a given key.
+* `aof_rewrite` is called when the AOF is being rewritten, and the module needs to tell Valkey what is the sequence of commands to recreate the content of a given key.
 * `digest` is called when `DEBUG DIGEST` is executed and a key holding this module type is found. Currently this is not yet implemented so the function ca be left empty.
 * `mem_usage` is called when the `MEMORY` command asks for the total memory consumed by a specific key, and is used in order to get the amount of bytes used by the module value.
 * `free` is called when a key with the module native type is deleted via `DEL` or in any other mean, in order to let the module reclaim the memory associated with such a value.
@@ -131,7 +131,7 @@ Ok, but *why* modules types require a 9 characters name?
 Oh, I understand you need to understand this, so here is a very specific
 explanation.
 
-When Redis persists to RDB files, modules specific data types require to
+When Valkey persists to RDB files, modules specific data types require to
 be persisted as well. Now RDB files are sequences of key-value pairs
 like the following:
 
@@ -181,7 +181,7 @@ Setting and getting keys
 ---
 
 After registering our new data type in the `RedisModule_OnLoad()` function,
-we also need to be able to set Redis keys having as value our native type.
+we also need to be able to set Valkey keys having as value our native type.
 
 This normally happens in the context of commands that write data to a key.
 The native types API allow to set and get keys to module native data types,
@@ -190,7 +190,7 @@ type.
 
 The API uses the normal modules `RedisModule_OpenKey()` low level key access
 interface in order to deal with this. This is an example of setting a
-native type private data structure to a Redis key:
+native type private data structure to a Valkey key:
 
     RedisModuleKey *key = RedisModule_OpenKey(ctx,keyname,REDISMODULE_WRITE);
     struct some_private_struct *data = createMyDataStructure();
@@ -201,7 +201,7 @@ for writing, and gets three arguments: the key handle, the reference to the
 native type, as obtained during the type registration, and finally a `void*`
 pointer that contains the private data implementing the module native type.
 
-Note that Redis has no clues at all about what your data contains. It will
+Note that Valkey has no clues at all about what your data contains. It will
 just call the callbacks you provided during the method registration in order
 to perform operations on the type.
 
@@ -248,7 +248,7 @@ key if there is already one:
 Free method
 ---
 
-As already mentioned, when Redis needs to free a key holding a native type
+As already mentioned, when Valkey needs to free a key holding a native type
 value, it needs help from the module in order to release the memory. This
 is the reason why we pass a `free` callback during the type registration:
 
@@ -269,7 +269,7 @@ RDB load and save methods
 ---
 
 The RDB saving and loading callbacks need to create (and load back) a
-representation of the data type on disk. Redis offers a high level API
+representation of the data type on disk. Valkey offers a high level API
 that can automatically store inside the RDB file the following types:
 
 * Unsigned 64 bit integers.
@@ -341,7 +341,7 @@ we stored in the RDB file.
 
 Note that while there is no error handling on the API that writes and reads
 from disk, still the load callback can return NULL on errors in case what
-it reads does not look correct. Redis will just panic in that case.
+it reads does not look correct. Valkey will just panic in that case.
 
 AOF rewriting
 ---
@@ -357,11 +357,11 @@ Allocating memory
 ---
 
 Modules data types should try to use `RedisModule_Alloc()` functions family
-in order to allocate, reallocate and release heap memory used to implement the native data structures (see the other Redis Modules documentation for detailed information).
+in order to allocate, reallocate and release heap memory used to implement the native data structures (see the other Valkey Modules documentation for detailed information).
 
-This is not just useful in order for Redis to be able to account for the memory used by the module, but there are also more advantages:
+This is not just useful in order for Valkey to be able to account for the memory used by the module, but there are also more advantages:
 
-* Redis uses the `jemalloc` allocator, that often prevents fragmentation problems that could be caused by using the libc allocator.
+* Valkey uses the `jemalloc` allocator, that often prevents fragmentation problems that could be caused by using the libc allocator.
 * When loading strings from the RDB file, the native types API is able to return strings allocated directly with `RedisModule_Alloc()`, so that the module can directly link this memory into the data structure representation, avoiding a useless copy of the data.
 
 Even if you are using external libraries implementing your data structures, the
@@ -370,16 +370,16 @@ allocation functions provided by the module API is exactly compatible with
 in order to use these functions should be trivial.
 
 In case you have an external library that uses libc `malloc()`, and you want
-to avoid replacing manually all the calls with the Redis Modules API calls,
+to avoid replacing manually all the calls with the Valkey Modules API calls,
 an approach could be to use simple macros in order to replace the libc calls
-with the Redis API calls. Something like this could work:
+with the Valkey API calls. Something like this could work:
 
     #define malloc RedisModule_Alloc
     #define realloc RedisModule_Realloc
     #define free RedisModule_Free
     #define strdup RedisModule_Strdup
 
-However take in mind that mixing libc calls with Redis API calls will result
+However take in mind that mixing libc calls with Valkey API calls will result
 into troubles and crashes, so if you replace calls using macros, you need to
 make sure that all the calls are correctly replaced, and that the code with
 the substituted calls will never, for example, attempt to call

--- a/docs/reference/protocol-spec.md
+++ b/docs/reference/protocol-spec.md
@@ -35,13 +35,13 @@ The protocol outlined here is used only for client-server communication.
 Support for the first version of the RESP protocol was introduced in Redis 1.2.
 Using RESP with Redis 1.2 was optional and had mainly served the purpose of working the kinks out of the protocol.
 
-In Redis 2.0, the protocol's next version, a.k.a RESP2, became the standard communication method for clients with the Redis server.
+In Redis OSS 2.0, the protocol's next version, a.k.a RESP2, became the standard communication method for clients with the Redis server.
 
 [RESP3](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md) is a superset of RESP2 that mainly aims to make a client author's life a little bit easier.
-Redis 6.0 introduced experimental opt-in support of RESP3's features (excluding streaming strings and streaming aggregates).
+Redis OSS 6.0 introduced experimental opt-in support of RESP3's features (excluding streaming strings and streaming aggregates).
 In addition, the introduction of the `HELLO` command allows clients to handshake and upgrade the connection's protocol version (see [Client handshake](#client-handshake)).
 
-Up to and including Redis 7, both RESP2 and RESP3 clients can invoke all core commands.
+Up to and including Redis OSS 7, both RESP2 and RESP3 clients can invoke all core commands.
 However, commands may return differently typed replies for different protocol versions.
 
 Future versions of Redis may change the default protocol version, but it is unlikely that RESP2 will become entirely deprecated.

--- a/docs/reference/protocol-spec.md
+++ b/docs/reference/protocol-spec.md
@@ -472,11 +472,11 @@ Example:
 (The raw RESP encoding is split into multiple lines for readability).
 
 Some client libraries may ignore the difference between this type and the string type and return a native string in both cases.
-However, interactive clients, such as command line interfaces (e.g., [`redis-cli`](/docs/manual/cli)), can use this type and know that their output should be presented to the human user as is and without quoting the string.
+However, interactive clients, such as command line interfaces (e.g., [`valkey-cli`](/docs/manual/cli)), can use this type and know that their output should be presented to the human user as is and without quoting the string.
 
 For example, the Valkey command `INFO` outputs a report that includes newlines.
-When using RESP3, `redis-cli` displays it correctly because it is sent as a Verbatim String reply (with its three bytes being "txt").
-When using RESP2, however, the `redis-cli` is hard-coded to look for the `INFO` command to ensure its correct display to the user.
+When using RESP3, `valkey-cli` displays it correctly because it is sent as a Verbatim String reply (with its three bytes being "txt").
+When using RESP2, however, the `valkey-cli` is hard-coded to look for the `INFO` command to ensure its correct display to the user.
 
 <a name="map-reply"></a>
 
@@ -639,7 +639,7 @@ For more information, see [Pipelining](/topics/pipelining).
 
 ## Inline commands
 Sometimes you may need to send a command to the Valkey server but only have `telnet` available.
-While the Valkey protocol is simple to implement, it is not ideal for interactive sessions, and `redis-cli` may not always be available.
+While the Valkey protocol is simple to implement, it is not ideal for interactive sessions, and `valkey-cli` may not always be available.
 For this reason, Valkey also accepts commands in the _inline command_ format.
 
 The following example demonstrates a server/client exchange using an inline command (the server chat starts with `S:`, the client chat with `C:`):

--- a/docs/reference/protocol-spec.md
+++ b/docs/reference/protocol-spec.md
@@ -1,14 +1,14 @@
 ---
-title: "Redis serialization protocol specification"
+title: "Valkey serialization protocol specification"
 linkTitle: "Protocol spec"
 weight: 4
-description: Redis serialization protocol (RESP) is the wire protocol that clients implement
+description: Valkey serialization protocol (RESP) is the wire protocol that clients implement
 aliases:
     - /topics/protocol
 ---
 
-To communicate with the Redis server, Redis clients use a protocol called REdis Serialization Protocol (RESP).
-While the protocol was designed specifically for Redis, you can use it for other client-server software projects.
+To communicate with the Valkey server, Valkey clients use a protocol called REdis Serialization Protocol (RESP).
+While the protocol was designed specifically for Valkey, you can use it for other client-server software projects.
 
 RESP is a compromise among the following considerations:
 
@@ -18,24 +18,24 @@ RESP is a compromise among the following considerations:
 
 RESP can serialize different data types including integers, strings, and arrays.
 It also features an error-specific type.
-A client sends a request to the Redis server as an array of strings.
+A client sends a request to the Valkey server as an array of strings.
 The array's contents are the command and its arguments that the server should execute.
 The server's reply type is command-specific.
 
 RESP is binary-safe and uses prefixed length to transfer bulk data so it does not require processing bulk data transferred from one process to another.
 
-RESP is the protocol you should implement in your Redis client.
+RESP is the protocol you should implement in your Valkey client.
 
 {{% alert title="Note" color="info" %}}
 The protocol outlined here is used only for client-server communication.
-[Redis Cluster](/docs/reference/cluster-spec) uses a different binary protocol for exchanging messages between nodes.
+[Valkey Cluster](/docs/reference/cluster-spec) uses a different binary protocol for exchanging messages between nodes.
 {{% /alert %}}
 
 ## RESP versions
-Support for the first version of the RESP protocol was introduced in Redis 1.2.
-Using RESP with Redis 1.2 was optional and had mainly served the purpose of working the kinks out of the protocol.
+Support for the first version of the RESP protocol was introduced in Valkey 1.2.
+Using RESP with Valkey 1.2 was optional and had mainly served the purpose of working the kinks out of the protocol.
 
-In Redis OSS 2.0, the protocol's next version, a.k.a RESP2, became the standard communication method for clients with the Redis server.
+In Redis OSS 2.0, the protocol's next version, a.k.a RESP2, became the standard communication method for clients with the Valkey server.
 
 [RESP3](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md) is a superset of RESP2 that mainly aims to make a client author's life a little bit easier.
 Redis OSS 6.0 introduced experimental opt-in support of RESP3's features (excluding streaming strings and streaming aggregates).
@@ -44,21 +44,21 @@ In addition, the introduction of the `HELLO` command allows clients to handshake
 Up to and including Redis OSS 7, both RESP2 and RESP3 clients can invoke all core commands.
 However, commands may return differently typed replies for different protocol versions.
 
-Future versions of Redis may change the default protocol version, but it is unlikely that RESP2 will become entirely deprecated.
+Future versions of Valkey may change the default protocol version, but it is unlikely that RESP2 will become entirely deprecated.
 It is possible, however, that new features in upcoming versions will require the use of RESP3.
 
 ## Network layer
-A client connects to a Redis server by creating a TCP connection to its port (the default is 6379).
+A client connects to a Valkey server by creating a TCP connection to its port (the default is 6379).
 
-While RESP is technically non-TCP specific, the protocol is used exclusively with TCP connections (or equivalent stream-oriented connections like Unix sockets) in the context of Redis.
+While RESP is technically non-TCP specific, the protocol is used exclusively with TCP connections (or equivalent stream-oriented connections like Unix sockets) in the context of Valkey.
 
 ## Request-Response model
-The Redis server accepts commands composed of different arguments.
+The Valkey server accepts commands composed of different arguments.
 Then, the server processes the command and sends the reply back to the client.
 
 This is the simplest model possible; however, there are some exceptions:
 
-* Redis requests can be [pipelined](#multiple-commands-and-pipelining).
+* Valkey requests can be [pipelined](#multiple-commands-and-pipelining).
   Pipelining enables clients to send multiple commands at once and wait for replies later.
 * When a RESP2 connection subscribes to a [Pub/Sub](/docs/manual/pubsub) channel, the protocol changes semantics and becomes a *push* protocol.
   The client no longer requires sending commands because the server will automatically send new messages to the client (for the channels the client is subscribed to) as soon as they are received.
@@ -66,21 +66,21 @@ This is the simplest model possible; however, there are some exceptions:
   Invoking the `MONITOR` command switches the connection to an ad-hoc push mode.
   The protocol of this mode is not specified but is obvious to parse.
 * [Protected mode](/docs/management/security/#protected-mode).
-  Connections opened from a non-loopback address to a Redis while in protected mode are denied and terminated by the server.
-  Before terminating the connection, Redis unconditionally sends a `-DENIED` reply, regardless of whether the client writes to the socket.
+  Connections opened from a non-loopback address to a Valkey while in protected mode are denied and terminated by the server.
+  Before terminating the connection, Valkey unconditionally sends a `-DENIED` reply, regardless of whether the client writes to the socket.
 * The [RESP3 Push type](#resp3-pushes).
   As the name suggests, a push type allows the server to send out-of-band data to the connection.
   The server may push data at any time, and the data isn't necessarily related to specific commands executed by the client.
   
-Excluding these exceptions, the Redis protocol is a simple request-response protocol.
+Excluding these exceptions, the Valkey protocol is a simple request-response protocol.
 
 ## RESP protocol description
 RESP is essentially a serialization protocol that supports several data types.
 In RESP, the first byte of data determines its type.
 
-Redis generally uses RESP as a [request-response](#request-response-model) protocol in the following way:
+Valkey generally uses RESP as a [request-response](#request-response-model) protocol in the following way:
 
-* Clients send commands to a Redis server as an [array](#arrays) of [bulk strings](#bulk-strings).
+* Clients send commands to a Valkey server as an [array](#arrays) of [bulk strings](#bulk-strings).
   The first (and sometimes also the second) bulk string in the array is the command's name.
   Subsequent elements of the array are the arguments for the command.
 * The server replies with a RESP type.
@@ -106,7 +106,7 @@ Note that bulk strings may be further encoded and decoded, e.g. with a wide mult
 
 Aggregates, such as Arrays and Maps, can have varying numbers of sub-elements and nesting levels.
 
-The following table summarizes the RESP data types that Redis supports:
+The following table summarizes the RESP data types that Valkey supports:
 
 | RESP data type | Minimal protocol version | Category | First byte |
 | --- | --- | --- | --- |
@@ -132,12 +132,12 @@ Simple strings are encoded as a plus (`+`) character, followed by a string.
 The string mustn't contain a CR (`\r`) or LF (`\n`) character and is terminated by CRLF (i.e., `\r\n`).
 
 Simple strings transmit short, non-binary strings with minimal overhead.
-For example, many Redis commands reply with just "OK" on success.
+For example, many Valkey commands reply with just "OK" on success.
 The encoding of this Simple String is the following 5 bytes:
 
     +OK\r\n
 
-When Redis replies with a simple string, a client library should return to the caller a string value composed of the first character after the `+` up to the end of the string, excluding the final CRLF bytes.
+When Valkey replies with a simple string, a client library should return to the caller a string value composed of the first character after the `+` up to the end of the string, excluding the final CRLF bytes.
 
 To send binary strings, use [bulk strings](#bulk-strings) instead.
 
@@ -152,7 +152,7 @@ The basic format is:
 
     -Error message\r\n
 
-Redis replies with an error only when something goes wrong, for example, when you try to operate against the wrong data type, or when the command does not exist.
+Valkey replies with an error only when something goes wrong, for example, when you try to operate against the wrong data type, or when the command does not exist.
 The client should raise an exception when it receives an Error reply.
 
 The following are examples of error replies:
@@ -162,9 +162,9 @@ The following are examples of error replies:
 
 The first upper-case word after the `-`, up to the first space or newline, represents the kind of error returned.
 This word is called an _error prefix_.
-Note that the error prefix is a convention used by Redis rather than part of the RESP error type.
+Note that the error prefix is a convention used by Valkey rather than part of the RESP error type.
 
-For example, in Redis, `ERR` is a generic error, whereas `WRONGTYPE` is a more specific error that implies that the client attempted an operation against the wrong data type.
+For example, in Valkey, `ERR` is a generic error, whereas `WRONGTYPE` is a more specific error that implies that the client attempted an operation against the wrong data type.
 The error prefix allows the client to understand the type of error returned by the server without checking the exact error message.
 
 A client implementation can return different types of exceptions for various errors, or provide a generic way for trapping errors by directly providing the error name to the caller as a string.
@@ -188,7 +188,7 @@ RESP encodes integers in the following way:
 
 For example, `:0\r\n` and `:1000\r\n` are integer replies (of zero and one thousand, respectively).
 
-Many Redis commands return RESP integers, including `INCR`, `LLEN`, and `LASTSAVE`.
+Many Valkey commands return RESP integers, including `INCR`, `LLEN`, and `LASTSAVE`.
 An integer, by itself, has no special meaning other than in the context of the command that returned it.
 For example, it is an incremental number for `INCR`, a UNIX timestamp for `LASTSAVE`, and so forth.
 However, the returned integer is guaranteed to be in the range of a signed 64-bit integer.
@@ -202,7 +202,7 @@ Other commands, including `SADD`, `SREM`, and `SETNX`, return 1 when the data ch
 
 ### Bulk strings
 A bulk string represents a single binary string.
-The string can be of any size, but by default, Redis limits it to 512 MB (see the `proto-max-bulk-len` configuration directive).
+The string can be of any size, but by default, Valkey limits it to 512 MB (see the `proto-max-bulk-len` configuration directive).
 
 RESP encodes bulk strings in the following way:
 
@@ -235,14 +235,14 @@ It is encoded as a bulk string with the length of negative one (-1), like so:
 
     $-1\r\n
 
-A Redis client should return a nil object when the server replies with a null bulk string rather than the empty string.
+A Valkey client should return a nil object when the server replies with a null bulk string rather than the empty string.
 For example, a Ruby library should return `nil` while a C library should return `NULL` (or set a special flag in the reply object).
 
 <a name="array-reply"></a>
 
 ### Arrays
-Clients send commands to the Redis server as RESP arrays.
-Similarly, some Redis commands that return collections of elements use arrays as their replies. 
+Clients send commands to the Valkey server as RESP arrays.
+Similarly, some Valkey commands that return collections of elements use arrays as their replies. 
 An example is the `LRANGE` command that returns elements of a list.
 
 RESP Arrays' encoding uses the following format:
@@ -319,12 +319,12 @@ The encoding of a null array is that of an array with the length of -1, i.e.:
 
     *-1\r\n
 
-When Redis replies with a null array, the client should return a null object rather than an empty array.
+When Valkey replies with a null array, the client should return a null object rather than an empty array.
 This is necessary to distinguish between an empty list and a different condition (for instance, the timeout condition of the `BLPOP` command).
 
 #### Null elements in arrays
 Single elements of an array may be [null bulk string](#null-bulk-strings).
-This is used in Redis replies to signal that these elements are missing and not empty strings. This can happen, for example, with the `SORT` command when used with the `GET pattern` option
+This is used in Valkey replies to signal that these elements are missing and not empty strings. This can happen, for example, with the `SORT` command when used with the `GET pattern` option
 if the specified key is missing.
 
 Here's an example of an array reply containing a null element:
@@ -393,7 +393,7 @@ Because the fractional part is optional, the integer value of ten (10) can, ther
     :10\r\n
     ,10\r\n
 
-In such cases, the Redis client should return native integer and double values, respectively, providing that these types are supported by the language of its implementation.
+In such cases, the Valkey client should return native integer and double values, respectively, providing that these types are supported by the language of its implementation.
 
 The positive infinity, negative infinity and NaN values are encoded as follows:
 
@@ -474,7 +474,7 @@ Example:
 Some client libraries may ignore the difference between this type and the string type and return a native string in both cases.
 However, interactive clients, such as command line interfaces (e.g., [`redis-cli`](/docs/manual/cli)), can use this type and know that their output should be presented to the human user as is and without quoting the string.
 
-For example, the Redis command `INFO` outputs a report that includes newlines.
+For example, the Valkey command `INFO` outputs a report that includes newlines.
 When using RESP3, `redis-cli` displays it correctly because it is sent as a Verbatim String reply (with its three bytes being "txt").
 When using RESP2, however, the `redis-cli` is hard-coded to look for the `INFO` command to ensure its correct display to the user.
 
@@ -511,7 +511,7 @@ Can be encoded in RESP like so:
 
 Both map keys and values can be any of RESP's types.
 
-Redis clients should return the idiomatic dictionary type that their language provides.
+Valkey clients should return the idiomatic dictionary type that their language provides.
 However, low-level programming languages (such as C, for example) will likely return an array along with type information that indicates to the caller that it is a dictionary.
 
 {{% alert title="Map pattern in RESP2" color="info" %}}
@@ -564,7 +564,7 @@ New RESP connections should begin the session by calling the `HELLO` command.
 This practice accomplishes two things:
 
 1. It allows servers to be backward compatible with RESP2 versions.
-  This is needed in Redis to make the transition to version 3 of the protocol gentler.
+  This is needed in Valkey to make the transition to version 3 of the protocol gentler.
 2. The `HELLO` command returns information about the server and the protocol that the client can use for different goals.
 
 The `HELLO` command has the following high-level syntax:
@@ -600,19 +600,19 @@ The information in the reply is partly server-dependent, but certain fields are 
 * **version**: the server's version.
 * **proto**: the highest supported version of the RESP protocol.
 
-In Redis' RESP3 implementation, the following fields are also emitted:
+In Valkey' RESP3 implementation, the following fields are also emitted:
 
 * **id**: the connection's identifier (ID).
 * **mode**: "standalone", "sentinel" or "cluster".
 * **role**: "master" or "replica".
 * **modules**: list of loaded modules as an Array of Bulk Strings.
 
-## Sending commands to a Redis server
-Now that you are familiar with the RESP serialization format, you can use it to help write a Redis client library.
+## Sending commands to a Valkey server
+Now that you are familiar with the RESP serialization format, you can use it to help write a Valkey client library.
 We can further specify how the interaction between the client and the server works:
 
-* A client sends the Redis server an [array](#arrays) consisting of only bulk strings.
-* A Redis server replies to clients, sending any valid RESP data type as a reply.
+* A client sends the Valkey server an [array](#arrays) consisting of only bulk strings.
+* A Valkey server replies to clients, sending any valid RESP data type as a reply.
 
 So, for example, a typical interaction could be the following.
 
@@ -638,9 +638,9 @@ All the replies can be read at the end.
 For more information, see [Pipelining](/topics/pipelining).
 
 ## Inline commands
-Sometimes you may need to send a command to the Redis server but only have `telnet` available.
-While the Redis protocol is simple to implement, it is not ideal for interactive sessions, and `redis-cli` may not always be available.
-For this reason, Redis also accepts commands in the _inline command_ format.
+Sometimes you may need to send a command to the Valkey server but only have `telnet` available.
+While the Valkey protocol is simple to implement, it is not ideal for interactive sessions, and `redis-cli` may not always be available.
+For this reason, Valkey also accepts commands in the _inline command_ format.
 
 The following example demonstrates a server/client exchange using an inline command (the server chat starts with `S:`, the client chat with `C:`):
 
@@ -653,11 +653,11 @@ Here's another example of an inline command where the server returns an integer:
     S: :0
 
 Basically, to issue an inline command, you write space-separated arguments in a telnet session.
-Since no command starts with `*` (the identifying byte of RESP Arrays), Redis detects this condition and parses your command inline.
+Since no command starts with `*` (the identifying byte of RESP Arrays), Valkey detects this condition and parses your command inline.
 
-## High-performance parser for the Redis protocol
+## High-performance parser for the Valkey protocol
 
-While the Redis protocol is human-readable and easy to implement, its implementation can exhibit performance similar to that of a binary protocol.
+While the Valkey protocol is human-readable and easy to implement, its implementation can exhibit performance similar to that of a binary protocol.
 
 RESP uses prefixed lengths to transfer bulk data.
 That makes scanning the payload for special characters unnecessary (unlike parsing JSON, for example).
@@ -690,11 +690,11 @@ After the first CR is identified, it can be skipped along with the following LF 
 Then, the bulk data can be read with a single read operation that doesn't inspect the payload in any way.
 Finally, the remaining CR and LF characters are discarded without additional processing.
 
-While comparable in performance to a binary protocol, the Redis protocol is significantly more straightforward to implement in most high-level languages, reducing the number of bugs in client software.
+While comparable in performance to a binary protocol, the Valkey protocol is significantly more straightforward to implement in most high-level languages, reducing the number of bugs in client software.
 
-## Tips for Redis client authors
+## Tips for Valkey client authors
 
-* For testing purposes, use [Lua's type conversions](/topics/lua-api#lua-to-resp3-type-conversion) to have Redis reply with any RESP2/RESP3 needed.
+* For testing purposes, use [Lua's type conversions](/topics/lua-api#lua-to-resp3-type-conversion) to have Valkey reply with any RESP2/RESP3 needed.
   As an example, a RESP3 double can be generated like so:
   ```
   EVAL "return { double = tonumber(ARGV[1]) }" 0 1e0

--- a/docs/reference/protocol-spec.md
+++ b/docs/reference/protocol-spec.md
@@ -32,8 +32,8 @@ The protocol outlined here is used only for client-server communication.
 {{% /alert %}}
 
 ## RESP versions
-Support for the first version of the RESP protocol was introduced in Valkey 1.2.
-Using RESP with Valkey 1.2 was optional and had mainly served the purpose of working the kinks out of the protocol.
+Support for the first version of the RESP protocol was introduced in Redis OSS 1.2.
+Using RESP with Redis OSS 1.2 was optional and had mainly served the purpose of working the kinks out of the protocol.
 
 In Redis OSS 2.0, the protocol's next version, a.k.a RESP2, became the standard communication method for clients with the Valkey server.
 

--- a/docs/reference/sentinel-clients.md
+++ b/docs/reference/sentinel-clients.md
@@ -70,7 +70,7 @@ Once the client discovered the address of the master instance, it should
 attempt a connection with the master, and call the `ROLE` command in order
 to verify the role of the instance is actually a master.
 
-If the `ROLE` commands is not available (it was introduced in Redis 2.8.12), a client may resort to the `INFO replication` command parsing the `role:` field of the output.
+If the `ROLE` commands is not available (it was introduced in Redis OSS 2.8.12), a client may resort to the `INFO replication` command parsing the `role:` field of the output.
 
 If the instance is not a master as expected, the client should wait a short amount of time (a few hundreds of milliseconds) and should try again starting from Step 1.
 
@@ -87,7 +87,7 @@ In the above cases and any other case where the client lost the connection with 
 Sentinel failover disconnection
 ===
 
-Starting with Redis 2.8.12, when Redis Sentinel changes the configuration of
+Starting with Redis OSS 2.8.12, when Redis Sentinel changes the configuration of
 an instance, for example promoting a replica to a master, demoting a master to
 replicate to the new master after a failover, or simply changing the master
 address of a stale replica instance, it sends a `CLIENT KILL type normal`

--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -1,19 +1,19 @@
 ---
-title: "Redis signal handling"
+title: "Valkey signal handling"
 linkTitle: "Signal handling"
 weight: 8
-description: How Redis handles common Unix signals
+description: How Valkey handles common Unix signals
 aliases:
     - /topics/signals
 ---
 
-This document provides information about how Redis reacts to different POSIX signals such as `SIGTERM` and `SIGSEGV`.
+This document provides information about how Valkey reacts to different POSIX signals such as `SIGTERM` and `SIGSEGV`.
 
 The information in this document **only applies to Redis OSS version 2.6 or greater**.
 
 ## SIGTERM and SIGINT
 
-The `SIGTERM` and `SIGINT` signals tell Redis to shut down gracefully. When the server receives this signal,
+The `SIGTERM` and `SIGINT` signals tell Valkey to shut down gracefully. When the server receives this signal,
 it does not immediately exit. Instead, it schedules
 a shutdown similar to the one performed by the `SHUTDOWN` command. The scheduled shutdown starts as soon as possible, specifically as long as the
 current command in execution terminates (if any), with a possible additional
@@ -29,8 +29,8 @@ This shutdown process includes the following actions:
   * Pause clients attempting to write with `CLIENT PAUSE` and the `WRITE` option.
   * Wait up to the configured `shutdown-timeout` (default 10 seconds) for replicas to catch up with the master's replication offset.
 * If a background child is saving the RDB file or performing an AOF rewrite, the child process is killed.
-* If the AOF is active, Redis calls the `fsync` system call on the AOF file descriptor to flush the buffers on disk.
-* If Redis is configured to persist on disk using RDB files, a synchronous (blocking) save is performed. Since the save is synchronous, it doesn't use any additional memory.
+* If the AOF is active, Valkey calls the `fsync` system call on the AOF file descriptor to flush the buffers on disk.
+* If Valkey is configured to persist on disk using RDB files, a synchronous (blocking) save is performed. Since the save is synchronous, it doesn't use any additional memory.
 * If the server is daemonized, the PID file is removed.
 * If the Unix domain socket is enabled, it gets removed.
 * The server exits with an exit code of zero.
@@ -46,14 +46,14 @@ To minimize the risk of data loss in such setups, trigger a manual `FAILOVER` (o
 
 ## SIGSEGV, SIGBUS, SIGFPE and SIGILL
 
-The following signals are handled as a Redis crash:
+The following signals are handled as a Valkey crash:
 
 * SIGSEGV
 * SIGBUS
 * SIGFPE
 * SIGILL
 
-Once one of these signals is trapped, Redis stops any current operation and performs the following actions:
+Once one of these signals is trapped, Valkey stops any current operation and performs the following actions:
 
 * Adds a bug report to the log file. This includes a stack trace, dump of registers, and information about the state of clients.
 * Since Redis OSS 2.8, a fast memory test is performed as a first check of the reliability of the crashing system.
@@ -63,20 +63,20 @@ Once one of these signals is trapped, Redis stops any current operation and perf
 ## What happens when a child process gets killed
 
 When the child performing the Append Only File rewrite gets killed by a signal,
-Redis handles this as an error and discards the (probably partial or corrupted)
+Valkey handles this as an error and discards the (probably partial or corrupted)
 AOF file. It will attempt the rewrite again later.
 
-When the child performing an RDB save is killed, Redis handles the
+When the child performing an RDB save is killed, Valkey handles the
 condition as a more severe error. While the failure of an
 AOF file rewrite can cause AOF file enlargement, failed RDB file
 creation reduces durability.
 
 As a result of the child producing the RDB file being killed by a signal,
-or when the child exits with an error (non zero exit code), Redis enters
+or when the child exits with an error (non zero exit code), Valkey enters
 a special error condition where no further write command is accepted.
 
-* Redis will continue to reply to read commands.
-* Redis will reply to all write commands with a `MISCONFIG` error.
+* Valkey will continue to reply to read commands.
+* Valkey will reply to all write commands with a `MISCONFIG` error.
 
 This error condition will persist until it becomes possible to create an RDB file successfully.
 

--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -9,7 +9,7 @@ aliases:
 
 This document provides information about how Redis reacts to different POSIX signals such as `SIGTERM` and `SIGSEGV`.
 
-The information in this document **only applies to Redis version 2.6 or greater**.
+The information in this document **only applies to Redis OSS version 2.6 or greater**.
 
 ## SIGTERM and SIGINT
 
@@ -37,9 +37,9 @@ This shutdown process includes the following actions:
 
 IF the RDB file can't be saved, the shutdown fails, and the server continues to run in order to ensure no data loss.
 Likewise, if the user just turned on AOF, and the server triggered the first AOF rewrite in order to create the initial AOF file but this file can't be saved, the shutdown fails and the server continues to run.
-Since Redis 2.6.11, no further attempt to shut down will be made unless a new `SIGTERM` is received or the `SHUTDOWN` command is issued.
+Since Redis OSS 2.6.11, no further attempt to shut down will be made unless a new `SIGTERM` is received or the `SHUTDOWN` command is issued.
 
-Since Redis 7.0, the server waits for lagging replicas up to a configurable `shutdown-timeout`, 10 seconds by default, before shutting down.
+Since Redis OSS 7.0, the server waits for lagging replicas up to a configurable `shutdown-timeout`, 10 seconds by default, before shutting down.
 This provides a best effort to minimize the risk of data loss in a situation where no save points are configured and AOF is deactivated.
 Before version 7.0, shutting down a heavily loaded master node in a diskless setup was more likely to result in data loss.
 To minimize the risk of data loss in such setups, trigger a manual `FAILOVER` (or `CLUSTER FAILOVER`) to demote the master to a replica and promote one of the replicas to a new master before shutting down a master node.
@@ -56,7 +56,7 @@ The following signals are handled as a Redis crash:
 Once one of these signals is trapped, Redis stops any current operation and performs the following actions:
 
 * Adds a bug report to the log file. This includes a stack trace, dump of registers, and information about the state of clients.
-* Since Redis 2.8, a fast memory test is performed as a first check of the reliability of the crashing system.
+* Since Redis OSS 2.8, a fast memory test is performed as a first check of the reliability of the crashing system.
 * If the server was daemonized, the PID file is removed.
 * Finally the server unregisters its own signal handler for the received signal and resends the same signal to itself to make sure that the default action is performed, such as dumping the core on the file system.
 
@@ -83,7 +83,7 @@ This error condition will persist until it becomes possible to create an RDB fil
 ## Kill the RDB file without errors
 
 Sometimes the user may want to kill the RDB-saving child process without
-generating an error. Since Redis version 2.6.10, this can be done using the signal `SIGUSR1`. This signal is handled in a special way:
+generating an error. Since Redis OSS version 2.6.10, this can be done using the signal `SIGUSR1`. This signal is handled in a special way:
 it kills the child process like any other signal, but the parent process will
 not detect this as a critical error and will continue to serve write
 requests.


### PR DESCRIPTION
Commands used:

```
git grep-replace -P '^redis 127.0.0.1:6379>' '127.0.0.1:6379>'
git grep-replace -F 'https://redis.io/topics/' 'https://valkey.io/topics/'
git grep-replace -P 'redis(?=\.call|\.pcall|\.regis|\.set_repl)' server
git grep-replace -F 'non-clustered Redis version' 'non-clustered Valkey deployment'
git grep-replace -P 'Redis(?= compatibility| v?[2-7]| version| < [2-7])' 'Redis OSS'
git grep-replace -P 'Redis(?! compatibility| v?[2-7]| version| < [2-7]| OSS|\.[a-z]|\w)' Valkey
git grep-replace -P 'redis(?=-cli|-server|-benchmark|.conf)' valkey
```

One per commit. References to old Redis versions are kept as "Redis OSS". We can go through them later.

Changes to `docs/reference/modules/modules-api-ref.md` can be ignored since it's generated from module.c in the code repo, but OTOH it doesn't harm to apply the changes to this too, and overwrite it later.