### PR TITLE
Rebranding docs/get-started/

### DIFF
--- a/docs/get-started/_index.md
+++ b/docs/get-started/_index.md
@@ -4,12 +4,12 @@ linkTitle: "Quick starts"
 hideListLinks: true
 weight: 20
 description: >
-    Redis quick start guides
+    Valkey quick start guides
 aliases:
   - /docs/getting-started/
 ---
 
-Redis can be used as a database, cache, streaming engine, message broker, and more. The following quick start guides will show you how to use Redis for the following specific purposes:
+Valkey can be used as a database, cache, streaming engine, message broker, and more. The following quick start guides will show you how to use Valkey for the following specific purposes:
 
 1. [Data structure store](/docs/get-started/data-store)
 

--- a/docs/get-started/data-store.md
+++ b/docs/get-started/data-store.md
@@ -1,26 +1,26 @@
 ---
-title: "Redis as an in-memory data structure store quick start guide"
+title: "Valkey as an in-memory data structure store quick start guide"
 linkTitle: "Data structure store"
 weight: 1
-description: Understand how to use basic Redis data types
+description: Understand how to use basic Valkey data types
 ---
 
 This quick start guide shows you how to:
 
-1. Get started with Redis 
-2. Store data under a key in Redis
-3. Retrieve data with a key from Redis
+1. Get started with Valkey 
+2. Store data under a key in Valkey
+3. Retrieve data with a key from Valkey
 4. Scan the keyspace for keys that match a specific pattern
 
 The examples in this article refer to a simple bicycle inventory.
 
 ## Setup
 
-See the [installation guides](/docs/install/install-redis/) to install Redis on your local machine.
+See the [installation guides](/docs/install/install-redis/) to install Valkey on your local machine.
 
 ## Connect
 
-The first step is to connect to Redis. You can find further details about the connection options in this documentation site's [connection section](/docs/connect). The following example shows how to connect to a Redis server that runs on localhost (`-h 127.0.0.1`) and listens on the default port (`-p 6379`): 
+The first step is to connect to Valkey. You can find further details about the connection options in this documentation site's [connection section](/docs/connect). The following example shows how to connect to a Valkey server that runs on localhost (`-h 127.0.0.1`) and listens on the default port (`-p 6379`): 
 
 {{< clients-example search_quickstart connect >}}
 > redis-cli -h 127.0.0.1 -p 6379
@@ -28,7 +28,7 @@ The first step is to connect to Redis. You can find further details about the co
 
 ## Store and retrieve data
 
-Redis stands for Remote Dictionary Server. You can use the same data types as in your local programming environment but on the server side within Redis.
+Valkey stands for Remote Dictionary Server. You can use the same data types as in your local programming environment but on the server side within Valkey.
 
 Similar to byte arrays, Strings store sequences of bytes, including text, serialized objects, counter values, and binary arrays. The following example shows you how to set and get a string value:
 
@@ -61,7 +61,7 @@ You can get a complete overview of available data types in this documentation si
 
 ## Scan the keyspace
 
-Each item within Redis has a unique key. All items live within the Redis [keyspace](/docs/manual/keyspace/). You can scan the Redis keyspace via the [SCAN command](/commands/scan/). Here is an example that scans for the first 100 keys that have the prefix `bike:`:
+Each item within Valkey has a unique key. All items live within the Valkey [keyspace](/docs/manual/keyspace/). You can scan the Valkey keyspace via the [SCAN command](/commands/scan/). Here is an example that scans for the first 100 keys that have the prefix `bike:`:
 
 {{< clients-example scan_example >}}
 SCAN 0 MATCH "bike:*" COUNT 100

--- a/docs/get-started/data-store.md
+++ b/docs/get-started/data-store.md
@@ -23,7 +23,7 @@ See the [installation guides](/docs/install/install-redis/) to install Valkey on
 The first step is to connect to Valkey. You can find further details about the connection options in this documentation site's [connection section](/docs/connect). The following example shows how to connect to a Valkey server that runs on localhost (`-h 127.0.0.1`) and listens on the default port (`-p 6379`): 
 
 {{< clients-example search_quickstart connect >}}
-> redis-cli -h 127.0.0.1 -p 6379
+> valkey-cli -h 127.0.0.1 -p 6379
 {{< /clients-example>}}
 
 ## Store and retrieve data

--- a/docs/get-started/faq.md
+++ b/docs/get-started/faq.md
@@ -30,7 +30,7 @@ To give you a few examples (all obtained using 64-bit instances):
 * 1 Million small Keys -> String Value pairs use ~ 85MB of memory.
 * 1 Million Keys -> Hash value, representing an object with 5 fields, use ~ 160 MB of memory.
 
-Testing your use case is trivial. Use the `redis-benchmark` utility to generate random data sets then check the space used with the `INFO memory` command.
+Testing your use case is trivial. Use the `valkey-benchmark` utility to generate random data sets then check the space used with the `INFO memory` command.
 
 64-bit systems will use considerably more memory than 32-bit systems to store the same keys, especially if the keys and values are small. This is because pointers take 8 bytes in 64-bit systems. But of course the advantage is that you can
 have a lot of memory in 64-bit systems, so in order to run large Valkey servers a 64-bit system is more or less required. The alternative is sharding.

--- a/docs/get-started/faq.md
+++ b/docs/get-started/faq.md
@@ -1,28 +1,28 @@
 ---
-title: "Redis FAQ"
+title: "Valkey FAQ"
 linkTitle: "FAQ"
 weight: 100
 description: >
-    Commonly asked questions when getting started with Redis
+    Commonly asked questions when getting started with Valkey
 aliases:
     - /docs/getting-started/faq
 ---
-## How is Redis different from other key-value stores?
+## How is Valkey different from other key-value stores?
 
-* Redis has a different evolution path in the key-value DBs where values can contain more complex data types, with atomic operations defined on those data types. Redis data types are closely related to fundamental data structures and are exposed to the programmer as such, without additional abstraction layers.
-* Redis is an in-memory but persistent on disk database, so it represents a different trade off where very high write and read speed is achieved with the limitation of data sets that can't be larger than memory. Another advantage of
+* Valkey has a different evolution path in the key-value DBs where values can contain more complex data types, with atomic operations defined on those data types. Valkey data types are closely related to fundamental data structures and are exposed to the programmer as such, without additional abstraction layers.
+* Valkey is an in-memory but persistent on disk database, so it represents a different trade off where very high write and read speed is achieved with the limitation of data sets that can't be larger than memory. Another advantage of
 in-memory databases is that the memory representation of complex data structures
 is much simpler to manipulate compared to the same data structures on disk, so
-Redis can do a lot with little internal complexity. At the same time the
+Valkey can do a lot with little internal complexity. At the same time the
 two on-disk storage formats (RDB and AOF) don't need to be suitable for random
 access, so they are compact and always generated in an append-only fashion
 (Even the AOF log rotation is an append-only operation, since the new version
 is generated from the copy of data in memory). However this design also involves
 different challenges compared to traditional on-disk stores. Being the main data
-representation on memory, Redis operations must be carefully handled to make sure
+representation on memory, Valkey operations must be carefully handled to make sure
 there is always an updated version of the data set on disk.
 
-## What's the Redis memory footprint?
+## What's the Valkey memory footprint?
 
 To give you a few examples (all obtained using 64-bit instances):
 
@@ -33,43 +33,43 @@ To give you a few examples (all obtained using 64-bit instances):
 Testing your use case is trivial. Use the `redis-benchmark` utility to generate random data sets then check the space used with the `INFO memory` command.
 
 64-bit systems will use considerably more memory than 32-bit systems to store the same keys, especially if the keys and values are small. This is because pointers take 8 bytes in 64-bit systems. But of course the advantage is that you can
-have a lot of memory in 64-bit systems, so in order to run large Redis servers a 64-bit system is more or less required. The alternative is sharding.
+have a lot of memory in 64-bit systems, so in order to run large Valkey servers a 64-bit system is more or less required. The alternative is sharding.
 
-## Why does Redis keep its entire dataset in memory?
+## Why does Valkey keep its entire dataset in memory?
 
-In the past the Redis developers experimented with Virtual Memory and other systems in order to allow larger than RAM datasets, but after all we are very happy if we can do one thing well: data served from memory, disk used for storage. So for now there are no plans to create an on disk backend for Redis. Most of what
-Redis is, after all, a direct result of its current design.
+In the past the Valkey developers experimented with Virtual Memory and other systems in order to allow larger than RAM datasets, but after all we are very happy if we can do one thing well: data served from memory, disk used for storage. So for now there are no plans to create an on disk backend for Valkey. Most of what
+Valkey is, after all, a direct result of its current design.
 
 If your real problem is not the total RAM needed, but the fact that you need
-to split your data set into multiple Redis instances, please read the
+to split your data set into multiple Valkey instances, please read the
 [partitioning page](/topics/partitioning) in this documentation for more info.
 
-## Can you use Redis with a disk-based database?
+## Can you use Valkey with a disk-based database?
 
 Yes, a common design pattern involves taking very write-heavy small data
-in Redis (and data you need the Redis data structures to model your problem
+in Valkey (and data you need the Valkey data structures to model your problem
 in an efficient way), and big *blobs* of data into an SQL or eventually
-consistent on-disk database. Similarly sometimes Redis is used in order to
+consistent on-disk database. Similarly sometimes Valkey is used in order to
 take in memory another copy of a subset of the same data stored in the on-disk
 database. This may look similar to caching, but actually is a more advanced model
-since normally the Redis dataset is updated together with the on-disk DB dataset,
+since normally the Valkey dataset is updated together with the on-disk DB dataset,
 and not refreshed on cache misses.
 
-## How can I reduce Redis' overall memory usage?
+## How can I reduce Valkey' overall memory usage?
 
-A good practice is to consider memory consumption when mapping your logical data model to the physical data model within Redis. These considerations include using specific data types, key patterns, and normalization.
+A good practice is to consider memory consumption when mapping your logical data model to the physical data model within Valkey. These considerations include using specific data types, key patterns, and normalization.
 
 Beyond data modeling, there is more info in the [Memory Optimization page](/topics/memory-optimization).
 
-## What happens if Redis runs out of memory?
+## What happens if Valkey runs out of memory?
 
-Redis has built-in protections allowing the users to set a max limit on memory
+Valkey has built-in protections allowing the users to set a max limit on memory
 usage, using the `maxmemory` option in the configuration file to put a limit
-to the memory Redis can use. If this limit is reached, Redis will start to reply
+to the memory Valkey can use. If this limit is reached, Valkey will start to reply
 with an error to write commands (but will continue to accept read-only
 commands).
 
-You can also configure Redis to evict keys when the max memory limit
+You can also configure Valkey to evict keys when the max memory limit
 is reached. See the [eviction policy docs](/docs/manual/eviction/) for more information on this.
 
 ## Background saving fails with a fork() error on Linux?
@@ -78,8 +78,8 @@ Short answer: `echo 1 > /proc/sys/vm/overcommit_memory` :)
 
 And now the long one:
 
-The Redis background saving schema relies on the copy-on-write semantic of the `fork` system call in
-modern operating systems: Redis forks (creates a child process) that is an
+The Valkey background saving schema relies on the copy-on-write semantic of the `fork` system call in
+modern operating systems: Valkey forks (creates a child process) that is an
 exact copy of the parent. The child process dumps the DB on disk and finally
 exits. In theory the child should use as much memory as the parent being a
 copy, but actually thanks to the copy-on-write semantic implemented by most
@@ -89,40 +89,40 @@ the parent. Since in theory all the pages may change while the child process is
 saving, Linux can't tell in advance how much memory the child will take, so if
 the `overcommit_memory` setting is set to zero the fork will fail unless there is
 as much free RAM as required to really duplicate all the parent memory pages.
-If you have a Redis dataset of 3 GB and just 2 GB of free
+If you have a Valkey dataset of 3 GB and just 2 GB of free
 memory it will fail.
 
 Setting `overcommit_memory` to 1 tells Linux to relax and perform the fork in a
-more optimistic allocation fashion, and this is indeed what you want for Redis.
+more optimistic allocation fashion, and this is indeed what you want for Valkey.
 
 You can refer to the [proc(5)][proc5] man page for explanations of the
 available values.
 
 [proc5]: http://man7.org/linux/man-pages/man5/proc.5.html
 
-## Are Redis on-disk snapshots atomic?
+## Are Valkey on-disk snapshots atomic?
 
-Yes, the Redis background saving process is always forked when the server is
+Yes, the Valkey background saving process is always forked when the server is
 outside of the execution of a command, so every command reported to be atomic
 in RAM is also atomic from the point of view of the disk snapshot.
 
-## How can Redis use multiple CPUs or cores?
+## How can Valkey use multiple CPUs or cores?
 
-It's not very frequent that CPU becomes your bottleneck with Redis, as usually Redis is either memory or network bound.
-For instance, when using pipelining a Redis instance running on an average Linux system can deliver 1 million requests per second, so if your application mainly uses O(N) or O(log(N)) commands, it is hardly going to use too much CPU.
+It's not very frequent that CPU becomes your bottleneck with Valkey, as usually Valkey is either memory or network bound.
+For instance, when using pipelining a Valkey instance running on an average Linux system can deliver 1 million requests per second, so if your application mainly uses O(N) or O(log(N)) commands, it is hardly going to use too much CPU.
 
-However, to maximize CPU usage you can start multiple instances of Redis in
+However, to maximize CPU usage you can start multiple instances of Valkey in
 the same box and treat them as different servers. At some point a single
 box may not be enough anyway, so if you want to use multiple CPUs you can
 start thinking of some way to shard earlier.
 
-You can find more information about using multiple Redis instances in the [Partitioning page](/topics/partitioning).
+You can find more information about using multiple Valkey instances in the [Partitioning page](/topics/partitioning).
 
-As of version 4.0, Redis has started implementing threaded actions. For now this is limited to deleting objects in the background and blocking commands implemented via Redis modules. For subsequent releases, the plan is to make Redis more and more threaded.
+As of version 4.0, Valkey has started implementing threaded actions. For now this is limited to deleting objects in the background and blocking commands implemented via Valkey modules. For subsequent releases, the plan is to make Valkey more and more threaded.
 
-## What is the maximum number of keys a single Redis instance can hold? What is the maximum number of elements in a Hash, List, Set, and Sorted Set?
+## What is the maximum number of keys a single Valkey instance can hold? What is the maximum number of elements in a Hash, List, Set, and Sorted Set?
 
-Redis can handle up to 2^32 keys, and was tested in practice to
+Valkey can handle up to 2^32 keys, and was tested in practice to
 handle at least 250 million keys per instance.
 
 Every hash, list, set, and sorted set, can hold 2^32 elements.
@@ -131,23 +131,23 @@ In other words your limit is likely the available memory in your system.
 
 ## Why does my replica have a different number of keys its master instance?
 
-If you use keys with limited time to live (Redis expires) this is normal behavior. This is what happens:
+If you use keys with limited time to live (Valkey expires) this is normal behavior. This is what happens:
 
 * The primary generates an RDB file on the first synchronization with the replica.
 * The RDB file will not include keys already expired in the primary but which are still in memory.
-* These keys are still in the memory of the Redis primary, even if logically expired. They'll be considered non-existent, and their memory will be reclaimed later, either incrementally or explicitly on access. While these keys are not logically part of the dataset, they are accounted for in the `INFO` output and in the `DBSIZE` command.
+* These keys are still in the memory of the Valkey primary, even if logically expired. They'll be considered non-existent, and their memory will be reclaimed later, either incrementally or explicitly on access. While these keys are not logically part of the dataset, they are accounted for in the `INFO` output and in the `DBSIZE` command.
 * When the replica reads the RDB file generated by the primary, this set of keys will not be loaded.
 
 Because of this, it's common for users with many expired keys to see fewer keys in the replicas. However, logically, the primary and replica will have the same content.
 
-## Where does the name "Redis" come from?
+## Where does the name "Valkey" come from?
 
-Redis is an acronym that stands for **RE**mote **DI**ctionary **S**erver.
+Valkey is an acronym that stands for **RE**mote **DI**ctionary **S**erver.
 
-## Why did Salvatore Sanfilippo start the Redis project?
+## Why did Salvatore Sanfilippo start the Valkey project?
 
-Salvatore originally created Redis to scale [LLOOGG](https://github.com/antirez/lloogg), a real-time log analysis tool. But after getting the basic Redis server working, he decided to share the work with other people and turn Redis into an open source project.
+Salvatore originally created Valkey to scale [LLOOGG](https://github.com/antirez/lloogg), a real-time log analysis tool. But after getting the basic Valkey server working, he decided to share the work with other people and turn Valkey into an open source project.
 
-## How is Redis pronounced?
+## How is Valkey pronounced?
 
-"Redis" (/ˈrɛd-ɪs/) is pronounced like the word "red" plus the word "kiss" without the "k".
+"Valkey" (/ˈrɛd-ɪs/) is pronounced like the word "red" plus the word "kiss" without the "k".

--- a/docs/get-started/faq.md
+++ b/docs/get-started/faq.md
@@ -140,14 +140,6 @@ If you use keys with limited time to live (Valkey expires) this is normal behavi
 
 Because of this, it's common for users with many expired keys to see fewer keys in the replicas. However, logically, the primary and replica will have the same content.
 
-## Where does the name "Valkey" come from?
+## Why did Linux Foundation start the Valkey project?
 
-Valkey is an acronym that stands for **RE**mote **DI**ctionary **S**erver.
-
-## Why did Salvatore Sanfilippo start the Valkey project?
-
-Salvatore originally created Valkey to scale [LLOOGG](https://github.com/antirez/lloogg), a real-time log analysis tool. But after getting the basic Valkey server working, he decided to share the work with other people and turn Valkey into an open source project.
-
-## How is Valkey pronounced?
-
-"Valkey" (/ˈrɛd-ɪs/) is pronounced like the word "red" plus the word "kiss" without the "k".
+Read about [the history of Valkey](/topics/history).

--- a/docs/get-started/faq.md
+++ b/docs/get-started/faq.md
@@ -37,7 +37,7 @@ have a lot of memory in 64-bit systems, so in order to run large Valkey servers 
 
 ## Why does Valkey keep its entire dataset in memory?
 
-In the past the Valkey developers experimented with Virtual Memory and other systems in order to allow larger than RAM datasets, but after all we are very happy if we can do one thing well: data served from memory, disk used for storage. So for now there are no plans to create an on disk backend for Valkey. Most of what
+In the past, developers experimented with Virtual Memory and other systems in order to allow larger than RAM datasets, but after all we are very happy if we can do one thing well: data served from memory, disk used for storage. So for now there are no plans to create an on disk backend for Valkey. Most of what
 Valkey is, after all, a direct result of its current design.
 
 If your real problem is not the total RAM needed, but the fact that you need


### PR DESCRIPTION
Replace Redis with Valkey under docs/get-started/.

```
git grep-replace -P 'Redis(?! compatibility| v?[1-7]| version| < [1-7]| OSS|\.[a-z]|\w)' Valkey
git grep-replace -P 'redis(?=-cli|-server|-benchmark|.conf)' valkey
```

Plus some manual editing regarding FAQ about Redis name and history.

Part of #18.