### PR TITLE
Rebranding docs/data-types/

### DIFF
--- a/docs/data-types/_index.md
+++ b/docs/data-types/_index.md
@@ -1,7 +1,7 @@
 ---
-title: "Understand Redis data types"
+title: "Understand Valkey data types"
 linkTitle: "Understand data types"
-description: Overview of data types supported by Redis
+description: Overview of data types supported by Valkey
 weight: 35
 aliases:
     - /docs/manual/data-types
@@ -9,8 +9,8 @@ aliases:
     - /docs/data-types/tutorial
 ---
 
-Redis is a data structure server.
-At its core, Redis provides a collection of native data types that help you solve a wide variety of problems, from [caching](/docs/manual/client-side-caching/) to [queuing](/docs/data-types/lists/) to [event processing](/docs/data-types/streams/).
+Valkey is a data structure server.
+At its core, Valkey provides a collection of native data types that help you solve a wide variety of problems, from [caching](/docs/manual/client-side-caching/) to [queuing](/docs/data-types/lists/) to [event processing](/docs/data-types/streams/).
 Below is a short description of each data type, with links to broader overviews and command references.
 
 If you'd like to try a comprehensive tutorial for each data structure, see their overview pages below.
@@ -20,7 +20,7 @@ If you'd like to try a comprehensive tutorial for each data structure, see their
 
 ### Strings 
 
-[Strings](/docs/data-types/strings) are the most basic Redis data type, representing a sequence of bytes.
+[Strings](/docs/data-types/strings) are the most basic Valkey data type, representing a sequence of bytes.
 For more information, see:
 
 * [Overview of Strings](/docs/data-types/strings/)
@@ -106,6 +106,6 @@ The [HyperLogLog](/docs/data-types/hyperloglogs) data structures provide probabi
 To extend the features provided by the included data types, use one of these options:
 
 1. Write your own custom [server-side functions in Lua](/docs/manual/programmability/).
-1. Write your own Redis module using the [modules API](/docs/reference/modules/) or check out the [community-supported modules](/docs/modules/).
+1. Write your own Valkey module using the [modules API](/docs/reference/modules/) or check out the [community-supported modules](/docs/modules/).
 
 <hr>

--- a/docs/data-types/bitmaps.md
+++ b/docs/data-types/bitmaps.md
@@ -22,7 +22,7 @@ Some examples of bitmap use cases include:
 * `SETBIT` sets a bit at the provided offset to 0 or 1.
 * `GETBIT` returns the value of a bit at a given offset.
 
-See the [complete list of bitmap commands](https://redis.io/commands/?group=bitmap).
+See the [complete list of bitmap commands](/commands/?group=bitmap).
 
 
 ## Example

--- a/docs/data-types/geospatial.md
+++ b/docs/data-types/geospatial.md
@@ -14,7 +14,7 @@ This data structure is useful for finding nearby points within a given radius or
 * `GEOADD` adds a location to a given geospatial index (note that longitude comes before latitude with this command).
 * `GEOSEARCH` returns locations with a given radius or a bounding box.
 
-See the [complete list of geospatial index commands](https://redis.io/commands/?group=geo).
+See the [complete list of geospatial index commands](/commands/?group=geo).
 
 
 ## Examples

--- a/docs/data-types/geospatial.md
+++ b/docs/data-types/geospatial.md
@@ -1,9 +1,9 @@
 ﻿---
-title: "Redis geospatial"
+title: "Valkey geospatial"
 linkTitle: "Geospatial"
 weight: 80
 description: >
-    Introduction to the Redis Geospatial data type
+    Introduction to the Valkey Geospatial data type
 ---
 
 Geospatial indexes let you store coordinates and search for them.

--- a/docs/data-types/hashes.md
+++ b/docs/data-types/hashes.md
@@ -64,7 +64,7 @@ encoded in special way in memory that make them very memory efficient.
 * `HMGET` returns the values at one or more given fields.
 * `HINCRBY` increments the value at a given field by the integer provided.
 
-See the [complete list of hash commands](https://redis.io/commands/?group=hash).
+See the [complete list of hash commands](/commands/?group=hash).
 
 
 ## Examples

--- a/docs/data-types/hashes.md
+++ b/docs/data-types/hashes.md
@@ -98,4 +98,4 @@ A few commands - such as `HKEYS`, `HVALS`, and `HGETALL` - are O(n), where _n_ i
 ## Limits
 
 Every hash can store up to 4,294,967,295 (2^32 - 1) field-value pairs.
-In practice, your hashes are limited only by the overall memory on the VMs hosting your Redis deployment.
+In practice, your hashes are limited only by the overall memory on the VMs hosting your Valkey deployment.

--- a/docs/data-types/lists.md
+++ b/docs/data-types/lists.md
@@ -30,7 +30,7 @@ For example:
 * `BLMOVE` atomically moves elements from a source list to a target list.
   If the source list is empty, the command will block until a new element becomes available.
 
-See the [complete series of list commands](https://redis.io/commands/?group=list).
+See the [complete series of list commands](/commands/?group=list).
 
 ## Examples
 

--- a/docs/data-types/lists.md
+++ b/docs/data-types/lists.md
@@ -144,7 +144,7 @@ element into a list, on the right (at the tail). Finally the
 {{< /clients-example >}}
 
 Note that `LRANGE` takes two indexes, the first and the last
-element of the range to return. Both the indexes can be negative, telling Redis
+element of the range to return. Both the indexes can be negative, telling Valkey
 to start counting from the end: so -1 is the last element, -2 is the
 penultimate element of the list, and so forth.
 
@@ -187,7 +187,7 @@ pop:
 (nil)
 {{< /clients-example >}}
 
-Redis returned a NULL value to signal that there are no elements in the
+Valkey returned a NULL value to signal that there are no elements in the
 list.
 
 ### Common use cases for lists
@@ -196,7 +196,7 @@ Lists are useful for a number of tasks, two very representative use cases
 are the following:
 
 * Remember the latest updates posted by users into a social network.
-* Communication between processes, using a consumer-producer pattern where the producer pushes items into a list, and a consumer (usually a *worker*) consumes those items and executes actions. Redis has special list commands to make this use case both more reliable and efficient.
+* Communication between processes, using a consumer-producer pattern where the producer pushes items into a list, and a consumer (usually a *worker*) consumes those items and executes actions. Valkey has special list commands to make this use case both more reliable and efficient.
 
 For example both the popular Ruby libraries [resque](https://github.com/resque/resque) and
 [sidekiq](https://github.com/mperham/sidekiq) use Lists under the hood in order to
@@ -216,7 +216,7 @@ photos published in a photo sharing social network and you want to speedup acces
 In many use cases we just want to use lists to store the *latest items*,
 whatever they are: social network updates, logs, or anything else.
 
-Redis allows us to use lists as a capped collection, only remembering the latest
+Valkey allows us to use lists as a capped collection, only remembering the latest
 N items and discarding all the oldest items using the `LTRIM` command.
 
 The `LTRIM` command is similar to `LRANGE`, but **instead of displaying the
@@ -237,7 +237,7 @@ OK
 3) "bike:3"
 {{< /clients-example >}}
 
-The above `LTRIM` command tells Redis to keep just list elements from index
+The above `LTRIM` command tells Valkey to keep just list elements from index
 0 to 2, everything else will be discarded. This allows for a very simple but
 useful pattern: doing a List push operation + a List trim operation together 
 to add a new element and discard elements exceeding a limit. Using 
@@ -281,10 +281,10 @@ to process, so `RPOP` just returns NULL. In this case a consumer is forced to wa
 some time and retry again with `RPOP`. This is called *polling*, and is not
 a good idea in this context because it has several drawbacks:
 
-1. Forces Redis and clients to process useless commands (all the requests when the list is empty will get no actual work done, they'll just return NULL).
-2. Adds a delay to the processing of items, since after a worker receives a NULL, it waits some time. To make the delay smaller, we could wait less between calls to `RPOP`, with the effect of amplifying problem number 1, i.e. more useless calls to Redis.
+1. Forces Valkey and clients to process useless commands (all the requests when the list is empty will get no actual work done, they'll just return NULL).
+2. Adds a delay to the processing of items, since after a worker receives a NULL, it waits some time. To make the delay smaller, we could wait less between calls to `RPOP`, with the effect of amplifying problem number 1, i.e. more useless calls to Valkey.
 
-So Redis implements commands called `BRPOP` and `BLPOP` which are versions
+So Valkey implements commands called `BRPOP` and `BLPOP` which are versions
 of `RPOP` and `LPOP` able to block if the list is empty: they'll return to
 the caller only when a new element is added to the list, or when a user-specified
 timeout is reached.
@@ -329,11 +329,11 @@ suggest that you read more on the following:
 
 So far in our examples we never had to create empty lists before pushing
 elements, or removing empty lists when they no longer have elements inside.
-It is Redis' responsibility to delete keys when lists are left empty, or to create
+It is Valkey' responsibility to delete keys when lists are left empty, or to create
 an empty list if the key does not exist and we are trying to add elements
 to it, for example, with `LPUSH`.
 
-This is not specific to lists, it applies to all the Redis data types
+This is not specific to lists, it applies to all the Valkey data types
 composed of multiple elements -- Streams, Sets, Sorted Sets and Hashes.
 
 Basically we can summarize the behavior with three rules:

--- a/docs/data-types/probabilistic/hyperloglogs.md
+++ b/docs/data-types/probabilistic/hyperloglogs.md
@@ -82,7 +82,7 @@ One HyperLogLog is created per page (video/song) per period, and every IP/identi
 * `PFCOUNT` returns an estimate of the number of items in the set.
 * `PFMERGE` combines two or more HyperLogLogs into one.
 
-See the [complete list of HyperLogLog commands](https://redis.io/commands/?group=hyperloglog).
+See the [complete list of HyperLogLog commands](/commands/?group=hyperloglog).
 
 ## Performance
 

--- a/docs/data-types/probabilistic/hyperloglogs.md
+++ b/docs/data-types/probabilistic/hyperloglogs.md
@@ -17,13 +17,13 @@ proportional to the number of items you want to count, because you need
 to remember the elements you have already seen in the past in order to avoid
 counting them multiple times. However, a set of algorithms exist that trade 
 memory for precision: they return an estimated measure with a standard error, 
-which, in the case of the Redis implementation for HyperLogLog, is less than 1%.
+which, in the case of the Valkey implementation for HyperLogLog, is less than 1%.
 The magic of this algorithm is that you no longer need to use an amount of memory
 proportional to the number of items counted, and instead can use a
 constant amount of memory; 12k bytes in the worst case, or a lot less if your
 HyperLogLog (We'll just call them HLL from now) has seen very few elements.
 
-HLLs in Redis, while technically a different data structure, are encoded
+HLLs in Valkey, while technically a different data structure, are encoded
 as a String, so you can call `GET` to serialize a HLL, and `SET`
 to deserialize it back to the server.
 
@@ -55,7 +55,7 @@ OK
 Some examples of use cases for this data structure is counting unique queries
 performed by users in a search form every day, number of unique visitors to a web page and other similar cases.
 
-Redis is also able to perform the union of HLLs, please check the
+Valkey is also able to perform the union of HLLs, please check the
 [full documentation](/commands#hyperloglog) for more information.
 
 ## Use cases
@@ -95,4 +95,4 @@ The HyperLogLog can estimate the cardinality of sets with up to 18,446,744,073,7
 
 ## Learn more
 
-* [Redis new data structure: the HyperLogLog](http://antirez.com/news/75) has a lot of details about the data structure and its implementation in Redis.
+* [Valkey new data structure: the HyperLogLog](http://antirez.com/news/75) has a lot of details about the data structure and its implementation in Valkey.

--- a/docs/data-types/sets.md
+++ b/docs/data-types/sets.md
@@ -73,11 +73,11 @@ multiple sets, and so forth.
 3) bike:2
 {{< /clients-example >}}
 
-Here I've added three elements to my set and told Redis to return all the
-elements. There is no order guarantee with a set. Redis is free to return the
+Here I've added three elements to my set and told Valkey to return all the
+elements. There is no order guarantee with a set. Valkey is free to return the
 elements in any order at every call.
 
-Redis has commands to test for set membership. These commands can be used on single as well as multiple items:
+Valkey has commands to test for set membership. These commands can be used on single as well as multiple items:
 
 {{< clients-example sets_tutorial smismember >}}
 > SISMEMBER bikes:racing:france bike:1
@@ -100,7 +100,7 @@ to know which bikes are racing in France but not in the USA:
 {{< /clients-example >}}
 
 There are other non trivial operations that are still easy to implement
-using the right Redis commands. For instance we may want a list of all the
+using the right Valkey commands. For instance we may want a list of all the
 bikes racing in France, the USA, and some other races. We can do this using
 the `SINTER` command, which performs the intersection between different
 sets. In addition to intersection you can also perform

--- a/docs/data-types/sets.md
+++ b/docs/data-types/sets.md
@@ -21,7 +21,7 @@ You can use Sets to efficiently:
 * `SINTER` returns the set of members that two or more sets have in common (i.e., the intersection).
 * `SCARD` returns the size (a.k.a. cardinality) of a set.
 
-See the [complete list of set commands](https://redis.io/commands/?group=set).
+See the [complete list of set commands](/commands/?group=set).
 
 ## Examples
 

--- a/docs/data-types/sorted-sets.md
+++ b/docs/data-types/sorted-sets.md
@@ -223,7 +223,7 @@ You'll see that `ZADD` returns 0 when the member already exists (the score is up
 * `ZRANK` returns the rank of the provided member, assuming the sorted is in ascending order.
 * `ZREVRANK` returns the rank of the provided member, assuming the sorted set is in descending order.
  
-See the [complete list of sorted set commands](https://redis.io/commands/?group=sorted-set).
+See the [complete list of sorted set commands](/commands/?group=sorted-set).
 
 ## Performance
 

--- a/docs/data-types/sorted-sets.md
+++ b/docs/data-types/sorted-sets.md
@@ -183,9 +183,6 @@ endian, when ordered lexicographically (in raw bytes order) are actually
 ordered numerically as well, you can ask for ranges in the 128 bit space,
 and get the element's value discarding the prefix.
 
-If you want to see the feature in the context of a more serious demo,
-check the [Valkey autocomplete demo](http://autocomplete.redis.io).
-
 Updating the score: leaderboards
 ---
 

--- a/docs/data-types/sorted-sets.md
+++ b/docs/data-types/sorted-sets.md
@@ -51,8 +51,8 @@ birth year because actually *they are already sorted*.
 
 Implementation note: Sorted sets are implemented via a
 dual-ported data structure containing both a skip list and a hash table, so
-every time we add an element Redis performs an O(log(N)) operation. That's
-good, but when we ask for sorted elements Redis does not have to do any work at
+every time we add an element Valkey performs an O(log(N)) operation. That's
+good, but when we ask for sorted elements Valkey does not have to do any work at
 all, it's already sorted. Note that the `ZRANGE` order is low to high, while the `ZREVRANGE` order is high to low:
 
 {{< clients-example ss_tutorial zrange >}}
@@ -107,7 +107,7 @@ use the `ZRANGEBYSCORE` command to do it:
 4) "Royce"
 {{< /clients-example >}}
 
-We asked Redis to return all the elements with a score between negative
+We asked Valkey to return all the elements with a score between negative
 infinity and 10 (both extremes are included).
 
 To remove an element we'd simply call `ZREM` with the racer's name. 
@@ -143,11 +143,11 @@ the elements sorted in a descending way.
 
 ### Lexicographical scores
 
-In version Redis 2.8, a new feature was introduced that allows
+In version Redis OSS 2.8, a new feature was introduced that allows
 getting ranges lexicographically, assuming elements in a sorted set are all
 inserted with the same identical score (elements are compared with the C
 `memcmp` function, so it is guaranteed that there is no collation, and every
-Redis instance will reply with the same output).
+Valkey instance will reply with the same output).
 
 The main commands to operate with lexicographical ranges are `ZRANGEBYLEX`,
 `ZREVRANGEBYLEX`, `ZREMRANGEBYLEX` and `ZLEXCOUNT`.
@@ -184,7 +184,7 @@ ordered numerically as well, you can ask for ranges in the 128 bit space,
 and get the element's value discarding the prefix.
 
 If you want to see the feature in the context of a more serious demo,
-check the [Redis autocomplete demo](http://autocomplete.redis.io).
+check the [Valkey autocomplete demo](http://autocomplete.redis.io).
 
 Updating the score: leaderboards
 ---

--- a/docs/data-types/streams.md
+++ b/docs/data-types/streams.md
@@ -29,7 +29,7 @@ Streams support several trimming strategies (to prevent streams from growing unb
 * `XRANGE` returns a range of entries between two supplied entry IDs.
 * `XLEN` returns the length of a stream.
  
-See the [complete list of stream commands](https://redis.io/commands/?group=stream).
+See the [complete list of stream commands](/commands/?group=stream).
 
 
 ## Examples

--- a/docs/data-types/strings.md
+++ b/docs/data-types/strings.md
@@ -8,10 +8,10 @@ description: >
 
 Strings store sequences of bytes, including text, serialized objects, and binary arrays.
 As such, strings are the simplest type of value you can associate with
-a Redis key.
+a Valkey key.
 They're often used for caching, but they support additional functionality that lets you implement counters and perform bitwise operations, too.
 
-Since Redis keys are strings, when we use the string type as a value too,
+Since Valkey keys are strings, when we use the string type as a value too,
 we are mapping a string to another string. The string data type is useful
 for a number of use cases, like caching HTML fragments or pages.
 
@@ -44,7 +44,7 @@ or the opposite, that it only succeed if the key already exists:
 There are a number of other commands for operating on strings. For example
 the `GETSET` command sets a key to a new value, returning the old value as the
 result. You can use this command, for example, if you have a
-system that increments a Redis key using `INCR`
+system that increments a Valkey key using `INCR`
 every time your web site receives a new visitor. You may want to collect this
 information once every hour, without losing a single increment.
 You can `GETSET` the key, assigning it the new value of "0" and reading the
@@ -63,10 +63,10 @@ the `MSET` and `MGET` commands:
     3) "Vanth"
 {{< /clients-example >}}
 
-When `MGET` is used, Redis returns an array of values.
+When `MGET` is used, Valkey returns an array of values.
 
 ### Strings as counters
-Even if strings are the basic values of Redis, there are interesting operations
+Even if strings are the basic values of Valkey, there are interesting operations
 you can perform with them. For instance, one is atomic increment:
 
 {{< clients-example set_tutorial incr >}}
@@ -125,4 +125,4 @@ These random-access string commands may cause performance issues when dealing wi
 
 ## Alternatives
 
-If you're storing structured data as a serialized string, you may also want to consider Redis [hashes](/docs/data-types/hashes).
+If you're storing structured data as a serialized string, you may also want to consider Valkey [hashes](/docs/data-types/hashes).


### PR DESCRIPTION
Replace "Redis" with "Valkey" where appropriate.

No other changes seem to be necessay in this directory.

Part of #18.