### PR TITLE
Rebranding docs/install/

### DIFF
--- a/docs/install/_index.md
+++ b/docs/install/_index.md
@@ -8,8 +8,6 @@ aliases:
   - /docs/getting-started
 ---
 
-You can install [Valkey](https://valkey.io/docs/about/) locally on your machine. Valkey is available on Linux, macOS, and Windows.
-
 Here are the installation instructions:
 
 * [Install Valkey](/docs/install/install-redis)

--- a/docs/install/_index.md
+++ b/docs/install/_index.md
@@ -8,7 +8,7 @@ aliases:
   - /docs/getting-started
 ---
 
-You can install [Valkey](https://redis.io/docs/about/) locally on your machine. Valkey is available on Linux, macOS, and Windows.
+You can install [Valkey](https://valkey.io/docs/about/) locally on your machine. Valkey is available on Linux, macOS, and Windows.
 
 Here are the installation instructions:
 

--- a/docs/install/_index.md
+++ b/docs/install/_index.md
@@ -1,15 +1,15 @@
 ---
-title: "Install Redis"
+title: "Install Valkey"
 linkTitle: "Install"
 weight: 30
 hideListLinks: true
-description: How to install your preferred Redis flavor on your target platform
+description: How to install your preferred Valkey flavor on your target platform
 aliases:
   - /docs/getting-started
 ---
 
-You can install [Redis](https://redis.io/docs/about/) locally on your machine. Redis is available on Linux, macOS, and Windows.
+You can install [Valkey](https://redis.io/docs/about/) locally on your machine. Valkey is available on Linux, macOS, and Windows.
 
 Here are the installation instructions:
 
-* [Install Redis](/docs/install/install-redis)
+* [Install Valkey](/docs/install/install-redis)

--- a/docs/install/install-redis/_index.md
+++ b/docs/install/install-redis/_index.md
@@ -26,23 +26,23 @@ Refer to [Valkey Administration](/docs/management/admin/) for detailed setup tip
 
 ## Test if you can connect using the CLI
 
-After you have Valkey up and running, you can connect using `redis-cli`.
+After you have Valkey up and running, you can connect using `valkey-cli`.
 
-External programs talk to Valkey using a TCP socket and a Valkey specific protocol. This protocol is implemented in the Valkey client libraries for the different programming languages. However, to make hacking with Valkey simpler, Valkey provides a command line utility that can be used to send commands to Valkey. This program is called **redis-cli**.
+External programs talk to Valkey using a TCP socket and a Valkey specific protocol. This protocol is implemented in the Valkey client libraries for the different programming languages. However, to make hacking with Valkey simpler, Valkey provides a command line utility that can be used to send commands to Valkey. This program is called **valkey-cli**.
 
-The first thing to do to check if Valkey is working properly is sending a **PING** command using redis-cli:
+The first thing to do to check if Valkey is working properly is sending a **PING** command using valkey-cli:
 
 ```
-$ redis-cli ping
+$ valkey-cli ping
 PONG
 ```
 
-Running **redis-cli** followed by a command name and its arguments will send this command to the Valkey instance running on localhost at port 6379. You can change the host and port used by `redis-cli` - just try the `--help` option to check the usage information.
+Running **valkey-cli** followed by a command name and its arguments will send this command to the Valkey instance running on localhost at port 6379. You can change the host and port used by `valkey-cli` - just try the `--help` option to check the usage information.
 
-Another interesting way to run `redis-cli` is without arguments: the program will start in interactive mode. You can type different commands and see their replies.
+Another interesting way to run `valkey-cli` is without arguments: the program will start in interactive mode. You can type different commands and see their replies.
 
 ```
-$ redis-cli
+$ valkey-cli
 127.0.0.1:6379> ping
 PONG
 ```
@@ -56,7 +56,7 @@ By default Valkey binds to **all the interfaces** and has no authentication at a
 3. Use the `requirepass` option to add an additional layer of security so that clients will be required to authenticate using the `AUTH` command.
 4. Use [spiped](http://www.tarsnap.com/spiped.html) or another SSL tunneling software to encrypt traffic between Valkey servers and Valkey clients if your environment requires encryption.
 
-Note that a Valkey instance exposed to the internet without any security [is very simple to exploit](http://antirez.com/news/96), so make sure you understand the above and apply **at least** a firewall layer. After the firewall is in place, try to connect with `redis-cli` from an external host to confirm that the instance is not reachable.
+Note that a Valkey instance exposed to the internet without any security [is very simple to exploit](http://antirez.com/news/96), so make sure you understand the above and apply **at least** a firewall layer. After the firewall is in place, try to connect with `valkey-cli` from an external host to confirm that the instance is not reachable.
 
 ## Use Valkey from your application
 
@@ -70,7 +70,7 @@ You'll find a [full list of clients for different languages in this page](/clien
 You can learn [how Valkey persistence works on this page](/docs/management/persistence/). It is important to understand that, if you start Valkey with the default configuration, Valkey will spontaneously save the dataset only from time to time. For example, after at least five minutes if you have at least 100 changes in your data. If you want your database to persist and be reloaded after a restart make sure to call the **SAVE** command manually every time you want to force a data set snapshot. Alternatively, you can save the data on disk before quitting by using the **SHUTDOWN** command:
 
 ```
-$ redis-cli shutdown
+$ valkey-cli shutdown
 ```
 
 This way, Valkey will save the data on disk before quitting. Reading the [persistence page](/docs/management/persistence/) is strongly suggested to better understand how Valkey persistence works.
@@ -88,7 +88,7 @@ A proper install using an init script is strongly recommended.
 The available packages for supported Linux distributions already include the capability of starting the Valkey server from `/etc/init`.
 {{% /alert  %}}
 
-If you have not yet run `make install` after building the Valkey source, you will need to do so before continuing. By default, `make install` will copy the `redis-server` and `redis-cli` binaries to `/usr/local/bin`.
+If you have not yet run `make install` after building the Valkey source, you will need to do so before continuing. By default, `make install` will copy the `valkey-server` and `valkey-cli` binaries to `/usr/local/bin`.
 
 * Create a directory in which to store your Valkey config files and your data:
 
@@ -115,7 +115,7 @@ Both the pid file path and the configuration file name depend on the port number
 * Copy the template configuration file you'll find in the root directory of the Valkey distribution into `/etc/redis/` using the port number as the name, for instance:
 
     ```
-    sudo cp redis.conf /etc/redis/6379.conf
+    sudo cp valkey.conf /etc/redis/6379.conf
     ```
 
 * Create a directory inside `/var/redis` that will work as both data and working directory for this Valkey instance:
@@ -145,8 +145,8 @@ sudo /etc/init.d/redis_6379 start
 
 Make sure that everything is working as expected:
 
-1. Try pinging your instance within a `redis-cli` session using the `PING` command.
-2. Do a test save with `redis-cli save` and check that a dump file is correctly saved to `/var/redis/6379/dump.rdb`.
+1. Try pinging your instance within a `valkey-cli` session using the `PING` command.
+2. Do a test save with `valkey-cli save` and check that a dump file is correctly saved to `/var/redis/6379/dump.rdb`.
 3. Check that your Valkey instance is logging to the `/var/log/redis_6379.log` file.
 4. If it's a new machine where you can try it without problems, make sure that after a reboot everything is still working.
 
@@ -154,6 +154,6 @@ Make sure that everything is working as expected:
 The above instructions don't include all of the Valkey configuration parameters that you could change. For example, to use AOF persistence instead of RDB persistence, or to set up replication, and so forth.
 {{% /alert  %}}
 
-You should also read the example [redis.conf](/docs/management/config-file/) file, which is heavily annotated to help guide you on making changes. Further details can also be found in the [configuration article on this site](/docs/management/config/).
+You should also read the example [valkey.conf](/docs/management/config-file/) file, which is heavily annotated to help guide you on making changes. Further details can also be found in the [configuration article on this site](/docs/management/config/).
 
 <hr>

--- a/docs/install/install-redis/_index.md
+++ b/docs/install/install-redis/_index.md
@@ -100,13 +100,13 @@ If you have not yet run `make install` after building the Valkey source, you wil
 * Copy the init script that you'll find in the Valkey distribution under the **utils** directory into `/etc/init.d`. We suggest calling it with the name of the port where you are running this instance of Valkey. Make sure the resulting file has `0755` permissions.
     
     ```
-    sudo cp utils/redis_init_script /etc/init.d/redis_6379
+    sudo cp utils/redis_init_script /etc/init.d/valkey_6379
     ```
 
 * Edit the init script.
 
     ```
-    sudo vi /etc/init.d/redis_6379
+    sudo vi /etc/init.d/valkey_6379
     ```
 
 Make sure to set the **REDISPORT** variable to the port you are using.
@@ -126,28 +126,28 @@ Both the pid file path and the configuration file name depend on the port number
 
 * Edit the configuration file, making sure to perform the following changes:
     * Set **daemonize** to yes (by default it is set to no).
-    * Set the **pidfile** to `/var/run/redis_6379.pid`, modifying the port as necessary.
+    * Set the **pidfile** to `/var/run/valkey_6379.pid`, modifying the port as necessary.
     * Change the **port** accordingly. In our example it is not needed as the default port is already `6379`.
     * Set your preferred **loglevel**.
-    * Set the **logfile** to `/var/log/redis_6379.log`.
+    * Set the **logfile** to `/var/log/valkey_6379.log`.
     * Set the **dir** to `/var/valkey/6379` (very important step!).
 * Finally, add the new Valkey init script to all the default runlevels using the following command:
 
     ```
-    sudo update-rc.d redis_6379 defaults
+    sudo update-rc.d valkey_6379 defaults
     ```
 
 You are done! Now you can try running your instance with:
 
 ```
-sudo /etc/init.d/redis_6379 start
+sudo /etc/init.d/valkey_6379 start
 ```
 
 Make sure that everything is working as expected:
 
 1. Try pinging your instance within a `valkey-cli` session using the `PING` command.
 2. Do a test save with `valkey-cli save` and check that a dump file is correctly saved to `/var/valkey/6379/dump.rdb`.
-3. Check that your Valkey instance is logging to the `/var/log/redis_6379.log` file.
+3. Check that your Valkey instance is logging to the `/var/log/valkey_6379.log` file.
 4. If it's a new machine where you can try it without problems, make sure that after a reboot everything is still working.
 
 {{% alert title="Note" color="warning" %}}

--- a/docs/install/install-redis/_index.md
+++ b/docs/install/install-redis/_index.md
@@ -11,8 +11,6 @@ aliases:
 
 This is a an installation guide. You'll learn how to install, run, and experiment with the Valkey server process.
 
-While you can install Valkey on any of the platforms listed below, you might also consider using Valkey Cloud by creating a [free account](https://redis.com/try-free?utm_source=redisio&utm_medium=referral&utm_campaign=2023-09-try_free&utm_content=cu-redis_cloud_users).
-
 ## Install Valkey
 
 See the guide below that best fits your needs:

--- a/docs/install/install-redis/_index.md
+++ b/docs/install/install-redis/_index.md
@@ -1,43 +1,43 @@
 ---
-title: "Install Redis"
-linkTitle: "Install Redis"
+title: "Install Valkey"
+linkTitle: "Install Valkey"
 weight: 1
 description: >
-    Install Redis on Linux, macOS, and Windows
+    Install Valkey on Linux, macOS, and Windows
 aliases:
 - /docs/getting-started/installation
 - /docs/getting-started/tutorial
 ---
 
-This is a an installation guide. You'll learn how to install, run, and experiment with the Redis server process.
+This is a an installation guide. You'll learn how to install, run, and experiment with the Valkey server process.
 
-While you can install Redis on any of the platforms listed below, you might also consider using Redis Cloud by creating a [free account](https://redis.com/try-free?utm_source=redisio&utm_medium=referral&utm_campaign=2023-09-try_free&utm_content=cu-redis_cloud_users).
+While you can install Valkey on any of the platforms listed below, you might also consider using Valkey Cloud by creating a [free account](https://redis.com/try-free?utm_source=redisio&utm_medium=referral&utm_campaign=2023-09-try_free&utm_content=cu-redis_cloud_users).
 
-## Install Redis
+## Install Valkey
 
 See the guide below that best fits your needs:
 
-* [Install Redis from Source](/docs/install/install-redis/install-redis-from-source)
-* [Install Redis on Linux](/docs/install/install-redis/install-redis-on-linux)
-* [Install Redis on macOS](/docs/install/install-redis/install-redis-on-mac-os)
-* [Install Redis on Windows](/docs/install/install-redis/install-redis-on-windows)
+* [Install Valkey from Source](/docs/install/install-redis/install-redis-from-source)
+* [Install Valkey on Linux](/docs/install/install-redis/install-redis-on-linux)
+* [Install Valkey on macOS](/docs/install/install-redis/install-redis-on-mac-os)
+* [Install Valkey on Windows](/docs/install/install-redis/install-redis-on-windows)
 
-Refer to [Redis Administration](/docs/management/admin/) for detailed setup tips.
+Refer to [Valkey Administration](/docs/management/admin/) for detailed setup tips.
 
 ## Test if you can connect using the CLI
 
-After you have Redis up and running, you can connect using `redis-cli`.
+After you have Valkey up and running, you can connect using `redis-cli`.
 
-External programs talk to Redis using a TCP socket and a Redis specific protocol. This protocol is implemented in the Redis client libraries for the different programming languages. However, to make hacking with Redis simpler, Redis provides a command line utility that can be used to send commands to Redis. This program is called **redis-cli**.
+External programs talk to Valkey using a TCP socket and a Valkey specific protocol. This protocol is implemented in the Valkey client libraries for the different programming languages. However, to make hacking with Valkey simpler, Valkey provides a command line utility that can be used to send commands to Valkey. This program is called **redis-cli**.
 
-The first thing to do to check if Redis is working properly is sending a **PING** command using redis-cli:
+The first thing to do to check if Valkey is working properly is sending a **PING** command using redis-cli:
 
 ```
 $ redis-cli ping
 PONG
 ```
 
-Running **redis-cli** followed by a command name and its arguments will send this command to the Redis instance running on localhost at port 6379. You can change the host and port used by `redis-cli` - just try the `--help` option to check the usage information.
+Running **redis-cli** followed by a command name and its arguments will send this command to the Valkey instance running on localhost at port 6379. You can change the host and port used by `redis-cli` - just try the `--help` option to check the usage information.
 
 Another interesting way to run `redis-cli` is without arguments: the program will start in interactive mode. You can type different commands and see their replies.
 
@@ -47,57 +47,57 @@ $ redis-cli
 PONG
 ```
 
-## Securing Redis
+## Securing Valkey
 
-By default Redis binds to **all the interfaces** and has no authentication at all. If you use Redis in a very controlled environment, separated from the external internet and in general from attackers, that's fine. However, if an unhardened Redis is exposed to the internet, it is a big security concern. If you are not 100% sure your environment is secured properly, please check the following steps in order to make Redis more secure:
+By default Valkey binds to **all the interfaces** and has no authentication at all. If you use Valkey in a very controlled environment, separated from the external internet and in general from attackers, that's fine. However, if an unhardened Valkey is exposed to the internet, it is a big security concern. If you are not 100% sure your environment is secured properly, please check the following steps in order to make Valkey more secure:
 
-1. Make sure the port Redis uses to listen for connections (by default 6379 and additionally 16379 if you run Redis in cluster mode, plus 26379 for Sentinel) is firewalled, so that it is not possible to contact Redis from the outside world.
-2. Use a configuration file where the `bind` directive is set in order to guarantee that Redis listens on only the network interfaces you are using. For example, only the loopback interface (127.0.0.1) if you are accessing Redis locally from the same computer.
+1. Make sure the port Valkey uses to listen for connections (by default 6379 and additionally 16379 if you run Valkey in cluster mode, plus 26379 for Sentinel) is firewalled, so that it is not possible to contact Valkey from the outside world.
+2. Use a configuration file where the `bind` directive is set in order to guarantee that Valkey listens on only the network interfaces you are using. For example, only the loopback interface (127.0.0.1) if you are accessing Valkey locally from the same computer.
 3. Use the `requirepass` option to add an additional layer of security so that clients will be required to authenticate using the `AUTH` command.
-4. Use [spiped](http://www.tarsnap.com/spiped.html) or another SSL tunneling software to encrypt traffic between Redis servers and Redis clients if your environment requires encryption.
+4. Use [spiped](http://www.tarsnap.com/spiped.html) or another SSL tunneling software to encrypt traffic between Valkey servers and Valkey clients if your environment requires encryption.
 
-Note that a Redis instance exposed to the internet without any security [is very simple to exploit](http://antirez.com/news/96), so make sure you understand the above and apply **at least** a firewall layer. After the firewall is in place, try to connect with `redis-cli` from an external host to confirm that the instance is not reachable.
+Note that a Valkey instance exposed to the internet without any security [is very simple to exploit](http://antirez.com/news/96), so make sure you understand the above and apply **at least** a firewall layer. After the firewall is in place, try to connect with `redis-cli` from an external host to confirm that the instance is not reachable.
 
-## Use Redis from your application
+## Use Valkey from your application
 
-Of course using Redis just from the command line interface is not enough as the goal is to use it from your application. To do so, you need to download and install a Redis client library for your programming language.
+Of course using Valkey just from the command line interface is not enough as the goal is to use it from your application. To do so, you need to download and install a Valkey client library for your programming language.
 
 You'll find a [full list of clients for different languages in this page](/clients).
 
 
-## Redis persistence
+## Valkey persistence
 
-You can learn [how Redis persistence works on this page](/docs/management/persistence/). It is important to understand that, if you start Redis with the default configuration, Redis will spontaneously save the dataset only from time to time. For example, after at least five minutes if you have at least 100 changes in your data. If you want your database to persist and be reloaded after a restart make sure to call the **SAVE** command manually every time you want to force a data set snapshot. Alternatively, you can save the data on disk before quitting by using the **SHUTDOWN** command:
+You can learn [how Valkey persistence works on this page](/docs/management/persistence/). It is important to understand that, if you start Valkey with the default configuration, Valkey will spontaneously save the dataset only from time to time. For example, after at least five minutes if you have at least 100 changes in your data. If you want your database to persist and be reloaded after a restart make sure to call the **SAVE** command manually every time you want to force a data set snapshot. Alternatively, you can save the data on disk before quitting by using the **SHUTDOWN** command:
 
 ```
 $ redis-cli shutdown
 ```
 
-This way, Redis will save the data on disk before quitting. Reading the [persistence page](/docs/management/persistence/) is strongly suggested to better understand how Redis persistence works.
+This way, Valkey will save the data on disk before quitting. Reading the [persistence page](/docs/management/persistence/) is strongly suggested to better understand how Valkey persistence works.
 
-## Install Redis properly
+## Install Valkey properly
 
-Running Redis from the command line is fine just to hack a bit or for development. However, at some point you'll have some actual application to run on a real server. For this kind of usage you have two different choices:
+Running Valkey from the command line is fine just to hack a bit or for development. However, at some point you'll have some actual application to run on a real server. For this kind of usage you have two different choices:
 
-* Run Redis using screen.
-* Install Redis in your Linux box in a proper way using an init script, so that after a restart everything will start again properly.
+* Run Valkey using screen.
+* Install Valkey in your Linux box in a proper way using an init script, so that after a restart everything will start again properly.
 
 A proper install using an init script is strongly recommended. 
 
 {{% alert title="Note" color="warning" %}}
-The available packages for supported Linux distributions already include the capability of starting the Redis server from `/etc/init`.
+The available packages for supported Linux distributions already include the capability of starting the Valkey server from `/etc/init`.
 {{% /alert  %}}
 
-If you have not yet run `make install` after building the Redis source, you will need to do so before continuing. By default, `make install` will copy the `redis-server` and `redis-cli` binaries to `/usr/local/bin`.
+If you have not yet run `make install` after building the Valkey source, you will need to do so before continuing. By default, `make install` will copy the `redis-server` and `redis-cli` binaries to `/usr/local/bin`.
 
-* Create a directory in which to store your Redis config files and your data:
+* Create a directory in which to store your Valkey config files and your data:
 
     ```
     sudo mkdir /etc/redis
     sudo mkdir /var/redis
     ```
 
-* Copy the init script that you'll find in the Redis distribution under the **utils** directory into `/etc/init.d`. We suggest calling it with the name of the port where you are running this instance of Redis. Make sure the resulting file has `0755` permissions.
+* Copy the init script that you'll find in the Valkey distribution under the **utils** directory into `/etc/init.d`. We suggest calling it with the name of the port where you are running this instance of Valkey. Make sure the resulting file has `0755` permissions.
     
     ```
     sudo cp utils/redis_init_script /etc/init.d/redis_6379
@@ -112,13 +112,13 @@ If you have not yet run `make install` after building the Redis source, you will
 Make sure to set the **REDISPORT** variable to the port you are using.
 Both the pid file path and the configuration file name depend on the port number.
 
-* Copy the template configuration file you'll find in the root directory of the Redis distribution into `/etc/redis/` using the port number as the name, for instance:
+* Copy the template configuration file you'll find in the root directory of the Valkey distribution into `/etc/redis/` using the port number as the name, for instance:
 
     ```
     sudo cp redis.conf /etc/redis/6379.conf
     ```
 
-* Create a directory inside `/var/redis` that will work as both data and working directory for this Redis instance:
+* Create a directory inside `/var/redis` that will work as both data and working directory for this Valkey instance:
 
     ```
     sudo mkdir /var/redis/6379
@@ -131,7 +131,7 @@ Both the pid file path and the configuration file name depend on the port number
     * Set your preferred **loglevel**.
     * Set the **logfile** to `/var/log/redis_6379.log`.
     * Set the **dir** to `/var/redis/6379` (very important step!).
-* Finally, add the new Redis init script to all the default runlevels using the following command:
+* Finally, add the new Valkey init script to all the default runlevels using the following command:
 
     ```
     sudo update-rc.d redis_6379 defaults
@@ -147,11 +147,11 @@ Make sure that everything is working as expected:
 
 1. Try pinging your instance within a `redis-cli` session using the `PING` command.
 2. Do a test save with `redis-cli save` and check that a dump file is correctly saved to `/var/redis/6379/dump.rdb`.
-3. Check that your Redis instance is logging to the `/var/log/redis_6379.log` file.
+3. Check that your Valkey instance is logging to the `/var/log/redis_6379.log` file.
 4. If it's a new machine where you can try it without problems, make sure that after a reboot everything is still working.
 
 {{% alert title="Note" color="warning" %}}
-The above instructions don't include all of the Redis configuration parameters that you could change. For example, to use AOF persistence instead of RDB persistence, or to set up replication, and so forth.
+The above instructions don't include all of the Valkey configuration parameters that you could change. For example, to use AOF persistence instead of RDB persistence, or to set up replication, and so forth.
 {{% /alert  %}}
 
 You should also read the example [redis.conf](/docs/management/config-file/) file, which is heavily annotated to help guide you on making changes. Further details can also be found in the [configuration article on this site](/docs/management/config/).

--- a/docs/install/install-redis/_index.md
+++ b/docs/install/install-redis/_index.md
@@ -43,7 +43,7 @@ Another interesting way to run `redis-cli` is without arguments: the program wil
 
 ```
 $ redis-cli
-redis 127.0.0.1:6379> ping
+127.0.0.1:6379> ping
 PONG
 ```
 

--- a/docs/install/install-redis/_index.md
+++ b/docs/install/install-redis/_index.md
@@ -93,8 +93,8 @@ If you have not yet run `make install` after building the Valkey source, you wil
 * Create a directory in which to store your Valkey config files and your data:
 
     ```
-    sudo mkdir /etc/redis
-    sudo mkdir /var/redis
+    sudo mkdir /etc/valkey
+    sudo mkdir /var/valkey
     ```
 
 * Copy the init script that you'll find in the Valkey distribution under the **utils** directory into `/etc/init.d`. We suggest calling it with the name of the port where you are running this instance of Valkey. Make sure the resulting file has `0755` permissions.
@@ -112,16 +112,16 @@ If you have not yet run `make install` after building the Valkey source, you wil
 Make sure to set the **REDISPORT** variable to the port you are using.
 Both the pid file path and the configuration file name depend on the port number.
 
-* Copy the template configuration file you'll find in the root directory of the Valkey distribution into `/etc/redis/` using the port number as the name, for instance:
+* Copy the template configuration file you'll find in the root directory of the Valkey distribution into `/etc/valkey/` using the port number as the name, for instance:
 
     ```
-    sudo cp valkey.conf /etc/redis/6379.conf
+    sudo cp valkey.conf /etc/valkey/6379.conf
     ```
 
-* Create a directory inside `/var/redis` that will work as both data and working directory for this Valkey instance:
+* Create a directory inside `/var/valkey` that will work as both data and working directory for this Valkey instance:
 
     ```
-    sudo mkdir /var/redis/6379
+    sudo mkdir /var/valkey/6379
     ```
 
 * Edit the configuration file, making sure to perform the following changes:
@@ -130,7 +130,7 @@ Both the pid file path and the configuration file name depend on the port number
     * Change the **port** accordingly. In our example it is not needed as the default port is already `6379`.
     * Set your preferred **loglevel**.
     * Set the **logfile** to `/var/log/redis_6379.log`.
-    * Set the **dir** to `/var/redis/6379` (very important step!).
+    * Set the **dir** to `/var/valkey/6379` (very important step!).
 * Finally, add the new Valkey init script to all the default runlevels using the following command:
 
     ```
@@ -146,7 +146,7 @@ sudo /etc/init.d/redis_6379 start
 Make sure that everything is working as expected:
 
 1. Try pinging your instance within a `valkey-cli` session using the `PING` command.
-2. Do a test save with `valkey-cli save` and check that a dump file is correctly saved to `/var/redis/6379/dump.rdb`.
+2. Do a test save with `valkey-cli save` and check that a dump file is correctly saved to `/var/valkey/6379/dump.rdb`.
 3. Check that your Valkey instance is logging to the `/var/log/redis_6379.log` file.
 4. If it's a new machine where you can try it without problems, make sure that after a reboot everything is still working.
 

--- a/docs/install/install-redis/install-redis-from-source.md
+++ b/docs/install/install-redis/install-redis-from-source.md
@@ -12,29 +12,23 @@ You can compile and install Valkey from source on variety of platforms and opera
 
 ## Downloading the source files
 
-The Valkey source files are available from the [Download](/download) page. You can verify the integrity of these downloads by checking them against the digests in the [redis-hashes git repository](https://github.com/redis/redis-hashes).
-
-To obtain the source files for the latest stable version of Valkey from the Valkey downloads site, run:
-
-{{< highlight bash >}}
-wget https://download.redis.io/redis-stable.tar.gz
-{{< / highlight >}}
+The Valkey source releases are available from the GitHub [Releases](https://github.com/valkey-io/valkey/releases) page.
 
 ## Compiling Valkey
 
 To compile Valkey, first extract the tarball, change to the root directory, and then run `make`:
 
-{{< highlight bash >}}
-tar -xzvf redis-stable.tar.gz
+```sh
+tar -xzvf valkey-7.2.5.tar.gz
 cd redis-stable
 make
-{{< / highlight >}}
+```
 
 To build with TLS support, you'll need to install OpenSSL development libraries (e.g., libssl-dev on Debian/Ubuntu) and then run:
 
-{{< highlight bash >}}
+```sh
 make BUILD_TLS=yes
-{{< / highlight >}}
+```
 
 If the compile succeeds, you'll find several Valkey binaries in the `src` directory, including:
 
@@ -43,20 +37,18 @@ If the compile succeeds, you'll find several Valkey binaries in the `src` direct
 
 To install these binaries in `/usr/local/bin`, run:
 
-{{< highlight bash  >}}
+```sh
 sudo make install
-{{< / highlight >}}
+```
 
 ### Starting and stopping Valkey in the foreground
 
 Once installed, you can start Valkey by running
 
-{{< highlight bash  >}}
+```sh
 valkey-server
-{{< / highlight >}}
+```
 
 If successful, you'll see the startup logs for Valkey, and Valkey will be running in the foreground.
 
 To stop Valkey, enter `Ctrl-C`.
-
-For a more complete installation, continue with [these instructions](/docs/install/#install-redis-more-properly).

--- a/docs/install/install-redis/install-redis-from-source.md
+++ b/docs/install/install-redis/install-redis-from-source.md
@@ -20,7 +20,7 @@ To compile Valkey, first extract the tarball, change to the root directory, and 
 
 ```sh
 tar -xzvf valkey-7.2.5.tar.gz
-cd redis-stable
+cd valkey-7.2.5
 make
 ```
 

--- a/docs/install/install-redis/install-redis-from-source.md
+++ b/docs/install/install-redis/install-redis-from-source.md
@@ -38,8 +38,8 @@ make BUILD_TLS=yes
 
 If the compile succeeds, you'll find several Valkey binaries in the `src` directory, including:
 
-* **redis-server**: the Valkey Server itself
-* **redis-cli** is the command line interface utility to talk with Valkey.
+* **valkey-server**: the Valkey Server itself
+* **valkey-cli** is the command line interface utility to talk with Valkey.
 
 To install these binaries in `/usr/local/bin`, run:
 
@@ -52,7 +52,7 @@ sudo make install
 Once installed, you can start Valkey by running
 
 {{< highlight bash  >}}
-redis-server
+valkey-server
 {{< / highlight >}}
 
 If successful, you'll see the startup logs for Valkey, and Valkey will be running in the foreground.

--- a/docs/install/install-redis/install-redis-from-source.md
+++ b/docs/install/install-redis/install-redis-from-source.md
@@ -1,28 +1,28 @@
 ---
-title: "Install Redis from Source"
+title: "Install Valkey from Source"
 linkTitle: "Source code"
 weight: 5
 description: >
-    Compile and install Redis from source
+    Compile and install Valkey from source
 aliases:
 - /docs/getting-started/installation/install-redis-from-source
 ---
 
-You can compile and install Redis from source on variety of platforms and operating systems including Linux and macOS. Redis has no dependencies other than a C  compiler and `libc`.
+You can compile and install Valkey from source on variety of platforms and operating systems including Linux and macOS. Valkey has no dependencies other than a C  compiler and `libc`.
 
 ## Downloading the source files
 
-The Redis source files are available from the [Download](/download) page. You can verify the integrity of these downloads by checking them against the digests in the [redis-hashes git repository](https://github.com/redis/redis-hashes).
+The Valkey source files are available from the [Download](/download) page. You can verify the integrity of these downloads by checking them against the digests in the [redis-hashes git repository](https://github.com/redis/redis-hashes).
 
-To obtain the source files for the latest stable version of Redis from the Redis downloads site, run:
+To obtain the source files for the latest stable version of Valkey from the Valkey downloads site, run:
 
 {{< highlight bash >}}
 wget https://download.redis.io/redis-stable.tar.gz
 {{< / highlight >}}
 
-## Compiling Redis
+## Compiling Valkey
 
-To compile Redis, first extract the tarball, change to the root directory, and then run `make`:
+To compile Valkey, first extract the tarball, change to the root directory, and then run `make`:
 
 {{< highlight bash >}}
 tar -xzvf redis-stable.tar.gz
@@ -36,10 +36,10 @@ To build with TLS support, you'll need to install OpenSSL development libraries 
 make BUILD_TLS=yes
 {{< / highlight >}}
 
-If the compile succeeds, you'll find several Redis binaries in the `src` directory, including:
+If the compile succeeds, you'll find several Valkey binaries in the `src` directory, including:
 
-* **redis-server**: the Redis Server itself
-* **redis-cli** is the command line interface utility to talk with Redis.
+* **redis-server**: the Valkey Server itself
+* **redis-cli** is the command line interface utility to talk with Valkey.
 
 To install these binaries in `/usr/local/bin`, run:
 
@@ -47,16 +47,16 @@ To install these binaries in `/usr/local/bin`, run:
 sudo make install
 {{< / highlight >}}
 
-### Starting and stopping Redis in the foreground
+### Starting and stopping Valkey in the foreground
 
-Once installed, you can start Redis by running
+Once installed, you can start Valkey by running
 
 {{< highlight bash  >}}
 redis-server
 {{< / highlight >}}
 
-If successful, you'll see the startup logs for Redis, and Redis will be running in the foreground.
+If successful, you'll see the startup logs for Valkey, and Valkey will be running in the foreground.
 
-To stop Redis, enter `Ctrl-C`.
+To stop Valkey, enter `Ctrl-C`.
 
 For a more complete installation, continue with [these instructions](/docs/install/#install-redis-more-properly).

--- a/docs/install/install-redis/install-redis-on-linux.md
+++ b/docs/install/install-redis/install-redis-on-linux.md
@@ -1,18 +1,18 @@
 ---
-title: "Install Redis on Linux"
+title: "Install Valkey on Linux"
 linkTitle: "Linux"
 weight: 1
 description: >
-    How to install Redis on Linux
+    How to install Valkey on Linux
 aliases:
 - /docs/getting-started/installation/install-redis-on-linux
 ---
 
-Most major Linux distributions provide packages for Redis.
+Most major Linux distributions provide packages for Valkey.
 
 ## Install on Ubuntu/Debian
 
-You can install recent stable versions of Redis from the official `packages.redis.io` APT repository.
+You can install recent stable versions of Valkey from the official `packages.redis.io` APT repository.
 
 {{% alert title="Prerequisites" color="warning" %}}
 If you're running a very minimal distribution (such as a Docker container) you may need to install `lsb-release`, `curl` and `gpg` first:
@@ -35,7 +35,7 @@ sudo apt-get install redis
 
 ## Install from Snapcraft
 
-The [Snapcraft store](https://snapcraft.io/store) provides [Redis packages](https://snapcraft.io/redis) that can be installed on platforms that support snap.
+The [Snapcraft store](https://snapcraft.io/store) provides [Valkey packages](https://snapcraft.io/redis) that can be installed on platforms that support snap.
 Snap is supported and available on most major Linux distributions.
 
 To install via snap, run:

--- a/docs/install/install-redis/install-redis-on-linux.md
+++ b/docs/install/install-redis/install-redis-on-linux.md
@@ -8,40 +8,9 @@ aliases:
 - /docs/getting-started/installation/install-redis-on-linux
 ---
 
-Most major Linux distributions provide packages for Valkey.
+Packages for major Linux distributions are not yet available.
+They will be added on this page when they are available.
 
-## Install on Ubuntu/Debian
+## Docker containers
 
-You can install recent stable versions of Valkey from the official `packages.redis.io` APT repository.
-
-{{% alert title="Prerequisites" color="warning" %}}
-If you're running a very minimal distribution (such as a Docker container) you may need to install `lsb-release`, `curl` and `gpg` first:
-
-{{< highlight bash  >}}
-sudo apt install lsb-release curl gpg
-{{< / highlight  >}}
-{{% /alert  %}}
-
-Add the repository to the <code>apt</code> index, update it, and then install:
-
-{{< highlight bash  >}}
-curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-
-echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
-
-sudo apt-get update
-sudo apt-get install redis
-{{< / highlight  >}}
-
-## Install from Snapcraft
-
-The [Snapcraft store](https://snapcraft.io/store) provides [Valkey packages](https://snapcraft.io/redis) that can be installed on platforms that support snap.
-Snap is supported and available on most major Linux distributions.
-
-To install via snap, run:
-
-{{< highlight bash  >}}
-sudo snap install redis
-{{< / highlight  >}}
-
-If your Linux does not currently have snap installed, install it using the instructions described in [Installing snapd](https://snapcraft.io/docs/installing-snapd).
+We have official [Dockcer containers](https://hub.docker.com/r/valkey/valkey/).

--- a/docs/install/install-redis/install-redis-on-mac-os.md
+++ b/docs/install/install-redis/install-redis-on-mac-os.md
@@ -1,13 +1,13 @@
 ---
-title: "Install Redis on macOS"
+title: "Install Valkey on macOS"
 linkTitle: "MacOS"
 weight: 1
-description: Use Homebrew to install and start Redis on macOS
+description: Use Homebrew to install and start Valkey on macOS
 aliases:
 - /docs/getting-started/installation/install-redis-on-mac-os
 ---
 
-This guide shows you how to install Redis on macOS using Homebrew. Homebrew is the easiest way to install Redis on macOS. If you'd prefer to build Redis from the source files on macOS, see [Installing Redis from Source](/docs/install/install-redis/install-redis-from-source).
+This guide shows you how to install Valkey on macOS using Homebrew. Homebrew is the easiest way to install Valkey on macOS. If you'd prefer to build Valkey from the source files on macOS, see [Installing Valkey from Source](/docs/install/install-redis/install-redis-from-source).
 
 ## Prerequisites
 
@@ -27,29 +27,29 @@ From the terminal, run:
 brew install redis
 {{< / highlight >}}
 
-This will install Redis on your system.
+This will install Valkey on your system.
 
-## Starting and stopping Redis in the foreground
+## Starting and stopping Valkey in the foreground
 
-To test your Redis installation, you can run the `redis-server` executable from the command line:
+To test your Valkey installation, you can run the `redis-server` executable from the command line:
 
 {{< highlight bash  >}}
 redis-server
 {{< / highlight >}}
 
-If successful, you'll see the startup logs for Redis, and Redis will be running in the foreground.
+If successful, you'll see the startup logs for Valkey, and Valkey will be running in the foreground.
 
-To stop Redis, enter `Ctrl-C`.
+To stop Valkey, enter `Ctrl-C`.
 
-### Starting and stopping Redis using launchd
+### Starting and stopping Valkey using launchd
 
-As an alternative to running Redis in the foreground, you can also use `launchd` to start the process in the background:
+As an alternative to running Valkey in the foreground, you can also use `launchd` to start the process in the background:
 
 {{< highlight bash  >}}
 brew services start redis
 {{< / highlight >}}
 
-This launches Redis and restarts it at login. You can check the status of a `launchd` managed Redis by running the following:
+This launches Valkey and restarts it at login. You can check the status of a `launchd` managed Valkey by running the following:
 
 {{< highlight bash  >}}
 brew services info redis
@@ -71,15 +71,15 @@ To stop the service, run:
 brew services stop redis
 {{< / highlight >}}
 
-## Connect to Redis
+## Connect to Valkey
 
-Once Redis is running, you can test it by running `redis-cli`:
+Once Valkey is running, you can test it by running `redis-cli`:
 
 {{< highlight bash  >}}
 redis-cli
 {{< / highlight >}}
 
-This will open the Redis REPL. Try running some commands:
+This will open the Valkey REPL. Try running some commands:
 
 {{< highlight bash >}}
 127.0.0.1:6379> lpush demos redis-macOS-demo
@@ -90,7 +90,7 @@ OK
 
 ## Next steps
 
-Once you have a running Redis instance, you may want to:
+Once you have a running Valkey instance, you may want to:
 
-* Try the Redis CLI tutorial
-* Connect using one of the Redis clients
+* Try the Valkey CLI tutorial
+* Connect using one of the Valkey clients

--- a/docs/install/install-redis/install-redis-on-mac-os.md
+++ b/docs/install/install-redis/install-redis-on-mac-os.md
@@ -31,10 +31,10 @@ This will install Valkey on your system.
 
 ## Starting and stopping Valkey in the foreground
 
-To test your Valkey installation, you can run the `redis-server` executable from the command line:
+To test your Valkey installation, you can run the `valkey-server` executable from the command line:
 
 {{< highlight bash  >}}
-redis-server
+valkey-server
 {{< / highlight >}}
 
 If successful, you'll see the startup logs for Valkey, and Valkey will be running in the foreground.
@@ -73,10 +73,10 @@ brew services stop redis
 
 ## Connect to Valkey
 
-Once Valkey is running, you can test it by running `redis-cli`:
+Once Valkey is running, you can test it by running `valkey-cli`:
 
 {{< highlight bash  >}}
-redis-cli
+valkey-cli
 {{< / highlight >}}
 
 This will open the Valkey REPL. Try running some commands:

--- a/docs/install/install-redis/install-redis-on-mac-os.md
+++ b/docs/install/install-redis/install-redis-on-mac-os.md
@@ -24,7 +24,7 @@ If this command fails, you'll need to [follow the Homebrew installation instruct
 From the terminal, run:
 
 {{< highlight bash  >}}
-brew install redis
+brew install valkey
 {{< / highlight >}}
 
 This will install Valkey on your system.
@@ -46,19 +46,19 @@ To stop Valkey, enter `Ctrl-C`.
 As an alternative to running Valkey in the foreground, you can also use `launchd` to start the process in the background:
 
 {{< highlight bash  >}}
-brew services start redis
+brew services start valkey
 {{< / highlight >}}
 
 This launches Valkey and restarts it at login. You can check the status of a `launchd` managed Valkey by running the following:
 
 {{< highlight bash  >}}
-brew services info redis
+brew services info valkey
 {{< / highlight >}}
 
 If the service is running, you'll see output like the following:
 
 {{< highlight bash  >}}
-redis (homebrew.mxcl.redis)
+valkey (homebrew.mxcl.valkey)
 Running: ✔
 Loaded: ✔
 User: miranda
@@ -68,7 +68,7 @@ PID: 67975
 To stop the service, run:
 
 {{< highlight bash  >}}
-brew services stop redis
+brew services stop valkey
 {{< / highlight >}}
 
 ## Connect to Valkey
@@ -82,10 +82,10 @@ valkey-cli
 This will open the Valkey REPL. Try running some commands:
 
 {{< highlight bash >}}
-127.0.0.1:6379> lpush demos redis-macOS-demo
+127.0.0.1:6379> lpush demos valkey-macOS-demo
 OK
 127.0.0.1:6379> rpop demos
-"redis-macOS-demo"
+"valkey-macOS-demo"
 {{< / highlight >}}
 
 ## Next steps

--- a/docs/install/install-redis/install-redis-on-windows.md
+++ b/docs/install/install-redis/install-redis-on-windows.md
@@ -32,7 +32,7 @@ sudo apt-get install redis
 Lastly, start the Valkey server like so:
 
 {{< highlight bash  >}}
-sudo service redis-server start
+sudo service valkey-server start
 {{< / highlight  >}}
 
 ## Connect to Valkey
@@ -40,7 +40,7 @@ sudo service redis-server start
 You can test that your Valkey server is running by connecting with the Valkey CLI:
 
 {{< highlight bash  >}}
-redis-cli 
+valkey-cli 
 127.0.0.1:6379> ping
 PONG
 {{< / highlight >}}

--- a/docs/install/install-redis/install-redis-on-windows.md
+++ b/docs/install/install-redis/install-redis-on-windows.md
@@ -17,30 +17,6 @@ Microsoft provides [detailed instructions for installing WSL](https://docs.micro
 
 ## Install Valkey
 
-Once you're running Ubuntu on Windows, you can follow the steps detailed at [Install on Ubuntu/Debian](/docs/install/install-redis/install-redis-on-linux#install-on-ubuntu-debian) to install recent stable versions of Valkey from the official `packages.redis.io` APT repository.
-Add the repository to the <code>apt</code> index, update it, and then install:
+You can build Valkey from source or use a docker container.
 
-{{< highlight bash  >}}
-curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-
-echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
-
-sudo apt-get update
-sudo apt-get install redis
-{{< / highlight  >}}
-
-Lastly, start the Valkey server like so:
-
-{{< highlight bash  >}}
-sudo service valkey-server start
-{{< / highlight  >}}
-
-## Connect to Valkey
-
-You can test that your Valkey server is running by connecting with the Valkey CLI:
-
-{{< highlight bash  >}}
-valkey-cli 
-127.0.0.1:6379> ping
-PONG
-{{< / highlight >}}
+This section needs to be improved. Thanks for your patience.

--- a/docs/install/install-redis/install-redis-on-windows.md
+++ b/docs/install/install-redis/install-redis-on-windows.md
@@ -1,23 +1,23 @@
 ---
-title: "Install Redis on Windows"
+title: "Install Valkey on Windows"
 linkTitle: "Windows"
 weight: 1
-description: Use Redis on Windows for development
+description: Use Valkey on Windows for development
 aliases:
 - /docs/getting-started/installation/install-redis-on-windows/
 ---
 
-Redis is not officially supported on Windows. However, you can install Redis on Windows for development by following the instructions below.
+Valkey is not officially supported on Windows. However, you can install Valkey on Windows for development by following the instructions below.
 
-To install Redis on Windows, you'll first need to enable [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install) (Windows Subsystem for Linux). WSL2 lets you run Linux binaries natively on Windows. For this method to work, you'll need to be running Windows 10 version 2004 and higher or Windows 11.
+To install Valkey on Windows, you'll first need to enable [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install) (Windows Subsystem for Linux). WSL2 lets you run Linux binaries natively on Windows. For this method to work, you'll need to be running Windows 10 version 2004 and higher or Windows 11.
 
 ## Install or enable WSL2
 
 Microsoft provides [detailed instructions for installing WSL](https://docs.microsoft.com/en-us/windows/wsl/install). Follow these instructions, and take note of the default Linux distribution it installs. This guide assumes Ubuntu.
 
-## Install Redis
+## Install Valkey
 
-Once you're running Ubuntu on Windows, you can follow the steps detailed at [Install on Ubuntu/Debian](/docs/install/install-redis/install-redis-on-linux#install-on-ubuntu-debian) to install recent stable versions of Redis from the official `packages.redis.io` APT repository.
+Once you're running Ubuntu on Windows, you can follow the steps detailed at [Install on Ubuntu/Debian](/docs/install/install-redis/install-redis-on-linux#install-on-ubuntu-debian) to install recent stable versions of Valkey from the official `packages.redis.io` APT repository.
 Add the repository to the <code>apt</code> index, update it, and then install:
 
 {{< highlight bash  >}}
@@ -29,15 +29,15 @@ sudo apt-get update
 sudo apt-get install redis
 {{< / highlight  >}}
 
-Lastly, start the Redis server like so:
+Lastly, start the Valkey server like so:
 
 {{< highlight bash  >}}
 sudo service redis-server start
 {{< / highlight  >}}
 
-## Connect to Redis
+## Connect to Valkey
 
-You can test that your Redis server is running by connecting with the Redis CLI:
+You can test that your Valkey server is running by connecting with the Valkey CLI:
 
 {{< highlight bash  >}}
 redis-cli 


### PR DESCRIPTION
This PR does the bulk of renaming:

* Remove "redis" in CLI prompt "redis 127.0.0.1:6379>"
* Change "Redis" to "Valkey" using Perl regex `Redis(?! compatibility| v?[1-7]| version| < [1-7]| OSS|\.[a-z]|\w)`
* Replace filenames redis(-cli|-server|-benchmark|.conf) with valkey equivalents
* Replace /etc/redis and /var/redis with valkey equivalent paths
* "redis_6379" -> "valkey_6379"

Part of #18