### PR TITLE
Delete links to source-available modules

### DIFF
--- a/modules/community/github.com/FalkorDB/FalkorDB.json
+++ b/modules/community/github.com/FalkorDB/FalkorDB.json
@@ -1,8 +1,0 @@
-{
-    "name": "FalkorDB",
-    "license": "SSPL",
-    "description": "A graph database with a Cypher-based querying language using sparse adjacency matrices",
-    "github": [
-        "FalkorDB"
-    ]
-}

--- a/modules/community/github.com/RediSearch/RediSearch.json
+++ b/modules/community/github.com/RediSearch/RediSearch.json
@@ -1,9 +1,0 @@
-{
-    "name": "RediSearch",
-    "license": "Redis Source Available License",
-    "description": "Full-Text search over Redis",
-    "github": [
-        "dvirsky",
-        "RedisLabs"
-    ]
-}

--- a/modules/community/github.com/RedisAI/RedisAI.json
+++ b/modules/community/github.com/RedisAI/RedisAI.json
@@ -1,9 +1,0 @@
-{
-    "name": "RedisAI",
-    "license": "Redis Source Available License",
-    "description": "A Redis module for serving tensors and executing deep learning graphs",
-    "github": [
-        "lantiga",
-        "RedisLabs"
-    ]
-}

--- a/modules/community/github.com/RedisBloom/RedisBloom.json
+++ b/modules/community/github.com/RedisBloom/RedisBloom.json
@@ -1,9 +1,0 @@
-{
-    "name": "RedisBloom",
-    "license": "Redis Source Available License",
-    "description": "Scalable Bloom filters",
-    "github": [
-        "mnunberg",
-        "RedisLabs"
-    ]
-}

--- a/modules/community/github.com/RedisGears/RedisGears.json
+++ b/modules/community/github.com/RedisGears/RedisGears.json
@@ -1,9 +1,0 @@
-{
-    "name": "RedisGears",
-    "license": "Redis Source Available License",
-    "description": "Dynamic execution framework for your Redis data.",
-    "github": [
-        "MeirShpilraien",
-        "RedisLabs"
-    ]
-}

--- a/modules/community/github.com/RedisGraph/RedisGraph.json
+++ b/modules/community/github.com/RedisGraph/RedisGraph.json
@@ -1,9 +1,0 @@
-{
-    "name": "RedisGraph",
-    "license": "Redis Source Available License",
-    "description": "A graph database with a Cypher-based querying language using sparse adjacency matrices",
-    "github": [
-        "swilly22",
-        "RedisLabs"
-    ]
-}

--- a/modules/community/github.com/RedisJSON/RedisJSON.json
+++ b/modules/community/github.com/RedisJSON/RedisJSON.json
@@ -1,9 +1,0 @@
-{
-    "name": "RedisJSON",
-    "license": "Redis Source Available License",
-    "description": "A JSON data type for Redis",
-    "github": [
-        "itamarhaber",
-        "RedisLabs"
-    ]
-}

--- a/modules/community/github.com/RedisLabsModules/redis-state-machine.json
+++ b/modules/community/github.com/RedisLabsModules/redis-state-machine.json
@@ -1,9 +1,0 @@
-{
-    "name": "RedisStateMachine",
-    "license": "Redis Source Available License",
-    "description": "A module for storing state machines, and transitioning them in Redis",
-    "github": [
-        "chayim",
-        "RedisLabs"
-    ]
-}

--- a/modules/community/github.com/RedisTimeSeries/RedisTimeSeries.json
+++ b/modules/community/github.com/RedisTimeSeries/RedisTimeSeries.json
@@ -1,9 +1,0 @@
-{
-    "name": "RedisTimeSeries",
-    "license": "Redis Source Available License",
-    "description": "Time-series data structure for redis",
-    "github": [
-        "danni-m",
-        "RedisLabs"
-    ]
-}

--- a/modules/community/github.com/starkdg/Redis-AudioScout.json
+++ b/modules/community/github.com/starkdg/Redis-AudioScout.json
@@ -1,8 +1,0 @@
-{
-    "name": "Redis-AudioScout",
-    "license": "pHash Source Available License",
-    "description": "Redis module for Audio Track Recognition",
-    "github": [
-        "starkdg"
-    ]
-}

--- a/modules/community/github.com/starkdg/Redis-ImageScout.git.json
+++ b/modules/community/github.com/starkdg/Redis-ImageScout.git.json
@@ -1,8 +1,0 @@
-{
-    "name": "Redis-ImageScout",
-    "license": "pHash Redis Source Available License",
-    "description": "Redis module for Indexing of pHash Image fingerprints for Near-Duplicate Detection",
-    "github": [
-        "starkdg"
-    ]
-}

--- a/modules/community/github.com/starkdg/reventis.json
+++ b/modules/community/github.com/starkdg/reventis.json
@@ -1,8 +1,0 @@
-{
-    "name": "Reventis",
-    "license": "Redis Source Available License",
-    "description": "Redis module for storing and querying spatio-temporal event data",
-    "github": [
-        "starkdg"
-    ]
-}


### PR DESCRIPTION
These modules are source-available, i.e. not open source, so I'm deleting them.

```sh
~/repos/valkey-doc/modules$ git grep -i source.avail
community/github.com/RediSearch/RediSearch.json:    "license": "Redis Source Available License",
community/github.com/RedisAI/RedisAI.json:    "license": "Redis Source Available License",
community/github.com/RedisBloom/RedisBloom.json:    "license": "Redis Source Available License",
community/github.com/RedisGears/RedisGears.json:    "license": "Redis Source Available License",
community/github.com/RedisGraph/RedisGraph.json:    "license": "Redis Source Available License",
community/github.com/RedisJSON/RedisJSON.json:    "license": "Redis Source Available License",
community/github.com/RedisLabsModules/redis-state-machine.json:    "license": "Redis Source Available License",
community/github.com/RedisTimeSeries/RedisTimeSeries.json:    "license": "Redis Source Available License",
community/github.com/starkdg/Redis-AudioScout.json:    "license": "pHash Source Available License",
community/github.com/starkdg/Redis-ImageScout.git.json:    "license": "pHash Redis Source Available License",
community/github.com/starkdg/reventis.json:    "license": "Redis Source Available License",
```