### PR TITLE
Replace code blocks in Hugo syntax

### DIFF
--- a/topics/bitfields.md
+++ b/topics/bitfields.md
@@ -19,27 +19,25 @@ Bitfields support atomic read, write and increment operations, making them a goo
 * `BITFIELD_RO` is a read-only variant of `BITFIELD`.
 
 
-## Examples
-
 ## Example
 
 Suppose you want to maintain two metrics for various bicycles: the current price and the number of owners over time. You can represent these counters with a 32-bit wide bitfield per for each bike.
 
 * Bike 1 initially costs 1,000 (counter in offset 0) and has never had an owner. After being sold, it's now considered used and the price instantly drops to reflect its new condition, and it now has an owner (offset 1). After quite some time, the bike becomes a classic. The original owner sells it for a profit, so the price goes up and the number of owners does as well.Finally, you can look at the bike's current price and number of owners.
 
-{{< clients-example bitfield_tutorial bf >}}
-> BITFIELD bike:1:stats SET u32 #0 1000
+```valkey-cli
+127.0.0.1:6379> BITFIELD bike:1:stats SET u32 #0 1000
 1) (integer) 0
-> BITFIELD bike:1:stats INCRBY u32 #0 -50 INCRBY u32 #1 1
+127.0.0.1:6379> BITFIELD bike:1:stats INCRBY u32 #0 -50 INCRBY u32 #1 1
 1) (integer) 950
 2) (integer) 1
-> BITFIELD bike:1:stats INCRBY u32 #0 500 INCRBY u32 #1 1
+127.0.0.1:6379> BITFIELD bike:1:stats INCRBY u32 #0 500 INCRBY u32 #1 1
 1) (integer) 1450
 2) (integer) 2
-> BITFIELD bike:1:stats GET u32 #0 GET u32 #1
+127.0.0.1:6379> BITFIELD bike:1:stats GET u32 #0 GET u32 #1
 1) (integer) 1450
 2) (integer) 2
-{{< /clients-example >}}
+```
 
 
 ## Performance

--- a/topics/bitmaps.md
+++ b/topics/bitmaps.md
@@ -34,14 +34,14 @@ You can represent this scenario using a bitmap whose key references the current 
 
 * Rider 123 pings the server on January 1, 2024 within the 00:00 hour. You can then confirm that rider 123 pinged the server. You can also check to see if rider 456 has pinged the server for that same hour.
 
-{{< clients-example bitmap_tutorial ping >}}
-> SETBIT pings:2024-01-01-00:00 123 1
+```valkey-cli
+127.0.0.1:6379> SETBIT pings:2024-01-01-00:00 123 1
 (integer) 0
-> GETBIT pings:2024-01-01-00:00 123
-1
-> GETBIT pings:2024-01-01-00:00 456
-0
-{{< /clients-example >}}
+127.0.0.1:6379> GETBIT pings:2024-01-01-00:00 123
+(integer) 1
+127.0.0.1:6379> GETBIT pings:2024-01-01-00:00 456
+(integer) 0
+```
 
 
 ## Bit Operations
@@ -75,10 +75,10 @@ There are three commands operating on group of bits:
 Both `BITPOS` and `BITCOUNT` are able to operate with byte ranges of the
 string, instead of running for the whole length of the string. We can trivially see the number of bits that have been set in a bitmap.
 
-{{< clients-example bitmap_tutorial bitcount >}}
-> BITCOUNT pings:2024-01-01-00:00
+```valkey-cli
+127.0.0.1:6379> BITCOUNT pings:2024-01-01-00:00
 (integer) 1
-{{< /clients-example >}}
+```
 
 For example imagine you want to know the longest streak of daily visits of
 your web site users. You start counting days starting from zero, that is the

--- a/topics/data-store.md
+++ b/topics/data-store.md
@@ -22,9 +22,9 @@ See the [installation guides](/docs/install/install-redis/) to install Valkey on
 
 The first step is to connect to Valkey. You can find further details about the connection options in this documentation site's [connection section](/docs/connect/). The following example shows how to connect to a Valkey server that runs on localhost (`-h 127.0.0.1`) and listens on the default port (`-p 6379`): 
 
-{{< clients-example search_quickstart connect >}}
-> valkey-cli -h 127.0.0.1 -p 6379
-{{< /clients-example>}}
+```sh
+$ valkey-cli -h 127.0.0.1 -p 6379
+```
 
 ## Store and retrieve data
 
@@ -32,21 +32,23 @@ Valkey stands for Remote Dictionary Server. You can use the same data types as i
 
 Similar to byte arrays, Strings store sequences of bytes, including text, serialized objects, counter values, and binary arrays. The following example shows you how to set and get a string value:
 
-{{< clients-example set_and_get >}}
-SET bike:1 "Process 134"
-GET bike:1
-{{< /clients-example >}}
+```valkey-cli
+127.0.0.1:6379> SET bike:1 "Process 134"
+OK
+127.0.0.1:6379> GET bike:1
+"Process 134"
+```
 
 Hashes are the equivalent of dictionaries (dicts or hash maps). Among other things, you can use hashes to represent plain objects and to store groupings of counters. The following example explains how to set and access field values of an object:
 
-{{< clients-example hash_tutorial set_get_all >}}
-> HSET bike:1 model Deimos brand Ergonom type 'Enduro bikes' price 4972
+```valkey-cli
+127.0.0.1:6379> HSET bike:1 model Deimos brand Ergonom type 'Enduro bikes' price 4972
 (integer) 4
-> HGET bike:1 model
+127.0.0.1:6379> HGET bike:1 model
 "Deimos"
-> HGET bike:1 price
+127.0.0.1:6379> HGET bike:1 price
 "4972"
-> HGETALL bike:1
+127.0.0.1:6379> HGETALL bike:1
 1) "model"
 2) "Deimos"
 3) "brand"
@@ -55,7 +57,7 @@ Hashes are the equivalent of dictionaries (dicts or hash maps). Among other thin
 6) "Enduro bikes"
 7) "price"
 8) "4972"
-{{< /clients-example >}}
+```
 
 You can get a complete overview of available data types in this documentation site's [data types section](/docs/data-types/). Each data type has commands allowing you to manipulate or retrieve data. The [commands reference](../commands/) provides a sophisticated explanation.
 
@@ -63,8 +65,14 @@ You can get a complete overview of available data types in this documentation si
 
 Each item within Valkey has a unique key. All items live within the Valkey [keyspace](keyspace.md). You can scan the Valkey keyspace via the [SCAN command](../commands/scan.md). Here is an example that scans for the first 100 keys that have the prefix `bike:`:
 
-{{< clients-example scan_example >}}
-SCAN 0 MATCH "bike:*" COUNT 100
-{{< /clients-example >}}
+```valkey-cli
+127.0.0.1:6379> SCAN 0 MATCH "bike:*" COUNT 100
+1) "0"
+2) 1) "bike:4"
+   2) "bike:3"
+   3) "bike:5"
+   4) "bike:1"
+   5) "bike:2"
+```
 
 [SCAN](../commands/scan.md) returns a cursor position, allowing you to scan iteratively for the next batch of keys until you reach the cursor value 0.

--- a/topics/geospatial.md
+++ b/topics/geospatial.md
@@ -22,22 +22,22 @@ See the [complete list of geospatial index commands](../commands/?group=geo).
 Suppose you're building a mobile app that lets you find all of the bike rental stations closest to your current location.
 
 Add several locations to a geospatial index:
-{{< clients-example geo_tutorial geoadd >}}
-> GEOADD bikes:rentable -122.27652 37.805186 station:1
+```valkey-cli
+127.0.0.1:6379> GEOADD bikes:rentable -122.27652 37.805186 station:1
 (integer) 1
-> GEOADD bikes:rentable -122.2674626 37.8062344 station:2
+127.0.0.1:6379> GEOADD bikes:rentable -122.2674626 37.8062344 station:2
 (integer) 1
-> GEOADD bikes:rentable -122.2469854 37.8104049 station:3
+127.0.0.1:6379> GEOADD bikes:rentable -122.2469854 37.8104049 station:3
 (integer) 1
-{{< /clients-example >}}
+```
 
 Find all locations within a 5 kilometer radius of a given location, and return the distance to each location:
-{{< clients-example geo_tutorial geosearch >}}
-> GEOSEARCH bikes:rentable FROMLONLAT -122.2612767 37.7936847 BYRADIUS 5 km WITHDIST
+```valkey-cli
+127.0.0.1:6379> GEOSEARCH bikes:rentable FROMLONLAT -122.2612767 37.7936847 BYRADIUS 5 km WITHDIST
 1) 1) "station:1"
    2) "1.8523"
 2) 1) "station:2"
    2) "1.4979"
 3) 1) "station:3"
    2) "2.2441"
-{{< /clients-example >}}
+```

--- a/topics/hashes.md
+++ b/topics/hashes.md
@@ -9,14 +9,14 @@ description: >
 Hashes are record types structured as collections of field-value pairs.
 You can use hashes to represent basic objects and to store groupings of counters, among other things.
 
-{{< clients-example hash_tutorial set_get_all >}}
-> HSET bike:1 model Deimos brand Ergonom type 'Enduro bikes' price 4972
+```valkey-cli
+127.0.0.1:6379> HSET bike:1 model Deimos brand Ergonom type 'Enduro bikes' price 4972
 (integer) 4
-> HGET bike:1 model
+127.0.0.1:6379> HGET bike:1 model
 "Deimos"
-> HGET bike:1 price
+127.0.0.1:6379> HGET bike:1 price
 "4972"
-> HGETALL bike:1
+127.0.0.1:6379> HGETALL bike:1
 1) "model"
 2) "Deimos"
 3) "brand"
@@ -25,8 +25,7 @@ You can use hashes to represent basic objects and to store groupings of counters
 6) "Enduro bikes"
 7) "price"
 8) "4972"
-
-{{< /clients-example >}}
+```
 
 While hashes are handy to represent *objects*, actually the number of fields you can
 put inside a hash has no practical limits (other than available memory), so you can use
@@ -35,22 +34,22 @@ hashes in many different ways inside your application.
 The command `HSET` sets multiple fields of the hash, while `HGET` retrieves
 a single field. `HMGET` is similar to `HGET` but returns an array of values:
 
-{{< clients-example hash_tutorial hmget >}}
-> HMGET bike:1 model price no-such-field
+```valkey-cli
+127.0.0.1:6379> HMGET bike:1 model price no-such-field
 1) "Deimos"
 2) "4972"
 3) (nil)
-{{< /clients-example >}}
+```
 
 There are commands that are able to perform operations on individual fields
 as well, like `HINCRBY`:
 
-{{< clients-example hash_tutorial hincrby >}}
-> HINCRBY bike:1 price 100
+```valkey-cli
+127.0.0.1:6379> HINCRBY bike:1 price 100
 (integer) 5072
-> HINCRBY bike:1 price -100
+127.0.0.1:6379> HINCRBY bike:1 price -100
 (integer) 4972
-{{< /clients-example >}}
+```
 
 You can find the [full list of hash commands in the documentation](https://redis.io/commands#hash).
 
@@ -70,23 +69,23 @@ See the [complete list of hash commands](../commands/?group=hash).
 ## Examples
 
 * Store counters for the number of times bike:1 has been ridden, has crashed, or has changed owners:
-{{< clients-example hash_tutorial incrby_get_mget >}}
-> HINCRBY bike:1:stats rides 1
+```valkey-cli
+127.0.0.1:6379> HINCRBY bike:1:stats rides 1
 (integer) 1
-> HINCRBY bike:1:stats rides 1
+127.0.0.1:6379> HINCRBY bike:1:stats rides 1
 (integer) 2
-> HINCRBY bike:1:stats rides 1
+127.0.0.1:6379> HINCRBY bike:1:stats rides 1
 (integer) 3
-> HINCRBY bike:1:stats crashes 1
+127.0.0.1:6379> HINCRBY bike:1:stats crashes 1
 (integer) 1
-> HINCRBY bike:1:stats owners 1
+127.0.0.1:6379> HINCRBY bike:1:stats owners 1
 (integer) 1
-> HGET bike:1:stats rides
+127.0.0.1:6379> HGET bike:1:stats rides
 "3"
-> HMGET bike:1:stats owners crashes
+127.0.0.1:6379> HMGET bike:1:stats owners crashes
 1) "1"
 2) "1"
-{{< /clients-example >}}
+```
 
 
 ## Performance

--- a/topics/hyperloglogs.md
+++ b/topics/hyperloglogs.md
@@ -39,18 +39,18 @@ same:
 * Every time you see a new element, you add it to the count with `PFADD`.
 * When you want to retrieve the current approximation of unique elements added using the `PFADD` command, you can use the `PFCOUNT` command. If you need to merge two different HLLs, the `PFMERGE` command is available. Since HLLs provide approximate counts of unique elements, the result of the merge will give you an approximation of the number of unique elements across both source HLLs.
 
-{{< clients-example hll_tutorial pfadd >}}
-> PFADD bikes Hyperion Deimos Phoebe Quaoar
+```valkey-cli
+127.0.0.1:6379> PFADD bikes Hyperion Deimos Phoebe Quaoar
 (integer) 1
-> PFCOUNT bikes
+127.0.0.1:6379> PFCOUNT bikes
 (integer) 4
-> PFADD commuter_bikes Salacia Mimas Quaoar
+127.0.0.1:6379> PFADD commuter_bikes Salacia Mimas Quaoar
 (integer) 1
-> PFMERGE all_bikes bikes commuter_bikes
+127.0.0.1:6379> PFMERGE all_bikes bikes commuter_bikes
 OK
-> PFCOUNT all_bikes
+127.0.0.1:6379> PFCOUNT all_bikes
 (integer) 6
-{{< /clients-example >}}
+```
 
 Some examples of use cases for this data structure is counting unique queries
 performed by users in a search form every day, number of unique visitors to a web page and other similar cases.

--- a/topics/lists.md
+++ b/topics/lists.md
@@ -35,60 +35,60 @@ See the [complete series of list commands](../commands/?group=list).
 ## Examples
 
 * Treat a list like a queue (first in, first out):
-{{< clients-example list_tutorial queue >}}
-> LPUSH bikes:repairs bike:1
+```valkey-cli
+127.0.0.1:6379> LPUSH bikes:repairs bike:1
 (integer) 1
-> LPUSH bikes:repairs bike:2
+127.0.0.1:6379> LPUSH bikes:repairs bike:2
 (integer) 2
-> RPOP bikes:repairs
+127.0.0.1:6379> RPOP bikes:repairs
 "bike:1"
-> RPOP bikes:repairs
+127.0.0.1:6379> RPOP bikes:repairs
 "bike:2"
-{{< /clients-example >}}
+```
 
 * Treat a list like a stack (first in, last out):
-{{< clients-example list_tutorial stack >}}
-> LPUSH bikes:repairs bike:1
+```valkey-cli
+127.0.0.1:6379> LPUSH bikes:repairs bike:1
 (integer) 1
-> LPUSH bikes:repairs bike:2
+127.0.0.1:6379> LPUSH bikes:repairs bike:2
 (integer) 2
-> LPOP bikes:repairs
+127.0.0.1:6379> LPOP bikes:repairs
 "bike:2"
-> LPOP bikes:repairs
+127.0.0.1:6379> LPOP bikes:repairs
 "bike:1"
-{{< /clients-example >}}
+```
 
 * Check the length of a list:
-{{< clients-example list_tutorial llen >}}
-> LLEN bikes:repairs
+```valkey-cli
+127.0.0.1:6379> LLEN bikes:repairs
 (integer) 0
-{{< /clients-example >}}
+```
 
 * Atomically pop an element from one list and push to another:
-{{< clients-example list_tutorial lmove_lrange >}}
-> LPUSH bikes:repairs bike:1
+```valkey-cli
+127.0.0.1:6379> LPUSH bikes:repairs bike:1
 (integer) 1
-> LPUSH bikes:repairs bike:2
+127.0.0.1:6379> LPUSH bikes:repairs bike:2
 (integer) 2
-> LMOVE bikes:repairs bikes:finished LEFT LEFT
+127.0.0.1:6379> LMOVE bikes:repairs bikes:finished LEFT LEFT
 "bike:2"
-> LRANGE bikes:repairs 0 -1
+127.0.0.1:6379> LRANGE bikes:repairs 0 -1
 1) "bike:1"
-> LRANGE bikes:finished 0 -1
+127.0.0.1:6379> LRANGE bikes:finished 0 -1
 1) "bike:2"
-{{< /clients-example >}}
+```
 
 * To limit the length of a list you can call `LTRIM`:
-{{< clients-example list_tutorial ltrim.1 >}}
-> RPUSH bikes:repairs bike:1 bike:2 bike:3 bike:4 bike:5
+```valkey-cli
+127.0.0.1:6379> RPUSH bikes:repairs bike:1 bike:2 bike:3 bike:4 bike:5
 (integer) 5
-> LTRIM bikes:repairs 0 2
+127.0.0.1:6379> LTRIM bikes:repairs 0 2
 OK
-> LRANGE bikes:repairs 0 -1
+127.0.0.1:6379> LRANGE bikes:repairs 0 -1
 1) "bike:1"
 2) "bike:2"
 3) "bike:3"
-{{< /clients-example >}}
+```
 
 ### What are Lists?
 To explain the List data type it's better to start with a little bit of theory,
@@ -130,18 +130,18 @@ left (at the head), while the `RPUSH` command adds a new
 element into a list, on the right (at the tail). Finally the
 `LRANGE` command extracts ranges of elements from lists:
 
-{{< clients-example list_tutorial lpush_rpush >}}
-> RPUSH bikes:repairs bike:1
+```valkey-cli
+127.0.0.1:6379> RPUSH bikes:repairs bike:1
 (integer) 1
-> RPUSH bikes:repairs bike:2
+127.0.0.1:6379> RPUSH bikes:repairs bike:2
 (integer) 2
-> LPUSH bikes:repairs bike:important_bike
+127.0.0.1:6379> LPUSH bikes:repairs bike:important_bike
 (integer) 3
-> LRANGE bikes:repairs 0 -1
+127.0.0.1:6379> LRANGE bikes:repairs 0 -1
 1) "bike:important_bike"
 2) "bike:1"
 3) "bike:2"
-{{< /clients-example >}}
+```
 
 Note that `LRANGE` takes two indexes, the first and the last
 element of the range to return. Both the indexes can be negative, telling Valkey
@@ -154,17 +154,17 @@ the final `LPUSH` appended the element on the left.
 Both commands are *variadic commands*, meaning that you are free to push
 multiple elements into a list in a single call:
 
-{{< clients-example list_tutorial variadic >}}
-> RPUSH bikes:repairs bike:1 bike:2 bike:3
+```valkey-cli
+127.0.0.1:6379> RPUSH bikes:repairs bike:1 bike:2 bike:3
 (integer) 3
-> LPUSH bikes:repairs bike:important_bike bike:very_important_bike
-> LRANGE mylist 0 -1
+127.0.0.1:6379> LPUSH bikes:repairs bike:important_bike bike:very_important_bike
+127.0.0.1:6379> LRANGE mylist 0 -1
 1) "bike:very_important_bike"
 2) "bike:important_bike"
 3) "bike:1"
 4) "bike:2"
 5) "bike:3"
-{{< /clients-example >}}
+```
 
 An important operation defined on Lists is the ability to *pop elements*.
 Popping elements is the operation of both retrieving the element from the list,
@@ -174,18 +174,18 @@ of the list. We'll add three elements and pop three elements, so at the end of t
 sequence of commands the list is empty and there are no more elements to
 pop:
 
-{{< clients-example list_tutorial lpop_rpop >}}
-> RPUSH bikes:repairs bike:1 bike:2 bike:3
+```valkey-cli
+127.0.0.1:6379> RPUSH bikes:repairs bike:1 bike:2 bike:3
 (integer) 3
-> RPOP bikes:repairs
+127.0.0.1:6379> RPOP bikes:repairs
 "bike:3"
-> LPOP bikes:repairs
+127.0.0.1:6379> LPOP bikes:repairs
 "bike:1"
-> RPOP bikes:repairs
+127.0.0.1:6379> RPOP bikes:repairs
 "bike:2"
-> RPOP bikes:repairs
+127.0.0.1:6379> RPOP bikes:repairs
 (nil)
-{{< /clients-example >}}
+```
 
 Valkey returned a NULL value to signal that there are no elements in the
 list.
@@ -226,16 +226,16 @@ the elements outside the given range are removed.
 For example, if you're adding bikes on the end of a list of repairs, but only
 want to worry about the 3 that have been on the list the longest:
 
-{{< clients-example list_tutorial ltrim >}}
-> RPUSH bikes:repairs bike:1 bike:2 bike:3 bike:4 bike:5
+```valkey-cli
+127.0.0.1:6379> RPUSH bikes:repairs bike:1 bike:2 bike:3 bike:4 bike:5
 (integer) 5
-> LTRIM bikes:repairs 0 2
+127.0.0.1:6379> LTRIM bikes:repairs 0 2
 OK
-> LRANGE bikes:repairs 0 -1
+127.0.0.1:6379> LRANGE bikes:repairs 0 -1
 1) "bike:1"
 2) "bike:2"
 3) "bike:3"
-{{< /clients-example >}}
+```
 
 The above `LTRIM` command tells Valkey to keep just list elements from index
 0 to 2, everything else will be discarded. This allows for a very simple but
@@ -243,16 +243,16 @@ useful pattern: doing a List push operation + a List trim operation together
 to add a new element and discard elements exceeding a limit. Using 
 `LTRIM` with negative indexes can then be used to keep only the 3 most recently added:
 
-{{< clients-example list_tutorial ltrim_end_of_list >}}
-> RPUSH bikes:repairs bike:1 bike:2 bike:3 bike:4 bike:5
+```valkey-cli
+127.0.0.1:6379> RPUSH bikes:repairs bike:1 bike:2 bike:3 bike:4 bike:5
 (integer) 5
-> LTRIM bikes:repairs -3 -1
+127.0.0.1:6379> LTRIM bikes:repairs -3 -1
 OK
-> LRANGE bikes:repairs 0 -1
+127.0.0.1:6379> LRANGE bikes:repairs 0 -1
 1) "bike:3"
 2) "bike:4"
 3) "bike:5"
-{{< /clients-example >}}
+```
 
 The above combination adds new elements and keeps only the 3
 newest elements into the list. With `LRANGE` you can access the top items
@@ -291,19 +291,19 @@ timeout is reached.
 
 This is an example of a `BRPOP` call we could use in the worker:
 
-{{< clients-example list_tutorial brpop >}}
-> RPUSH bikes:repairs bike:1 bike:2
+```valkey-cli
+127.0.0.1:6379> RPUSH bikes:repairs bike:1 bike:2
 (integer) 2
-> BRPOP bikes:repairs 1
+127.0.0.1:6379> BRPOP bikes:repairs 1
 1) "bikes:repairs"
 2) "bike:2"
-> BRPOP bikes:repairs 1
+127.0.0.1:6379> BRPOP bikes:repairs 1
 1) "bikes:repairs"
 2) "bike:1"
-> BRPOP bikes:repairs 1
+127.0.0.1:6379> BRPOP bikes:repairs 1
 (nil)
 (2.01s)
-{{< /clients-example >}}
+```
 
 It means: "wait for elements in the list `bikes:repairs`, but return if after 1 second
 no element is available".
@@ -344,53 +344,53 @@ Basically we can summarize the behavior with three rules:
 
 Examples of rule 1:
 
-{{< clients-example list_tutorial rule_1 >}}
-> DEL new_bikes
+```valkey-cli
+127.0.0.1:6379> DEL new_bikes
 (integer) 0
-> LPUSH new_bikes bike:1 bike:2 bike:3
+127.0.0.1:6379> LPUSH new_bikes bike:1 bike:2 bike:3
 (integer) 3
-{{< /clients-example >}}
+```
 
 However we can't perform operations against the wrong type if the key exists:
 
-{{< clients-example list_tutorial rule_1.1 >}}
-> SET new_bikes bike:1
+```valkey-cli
+127.0.0.1:6379> SET new_bikes bike:1
 OK
-> TYPE new_bikes
+127.0.0.1:6379> TYPE new_bikes
 string
-> LPUSH new_bikes bike:2 bike:3
+127.0.0.1:6379> LPUSH new_bikes bike:2 bike:3
 (error) WRONGTYPE Operation against a key holding the wrong kind of value
-{{< /clients-example >}}
+```
 
 Example of rule 2:
 
-{{< clients-example list_tutorial rule_2 >}}
-> RPUSH bikes:repairs bike:1 bike:2 bike:3
+```valkey-cli
+127.0.0.1:6379> RPUSH bikes:repairs bike:1 bike:2 bike:3
 (integer) 3
-> EXISTS bikes:repairs
+127.0.0.1:6379> EXISTS bikes:repairs
 (integer) 1
-> LPOP bikes:repairs
+127.0.0.1:6379> LPOP bikes:repairs
 "bike:3"
-> LPOP bikes:repairs
+127.0.0.1:6379> LPOP bikes:repairs
 "bike:2"
-> LPOP bikes:repairs
+127.0.0.1:6379> LPOP bikes:repairs
 "bike:1"
-> EXISTS bikes:repairs
+127.0.0.1:6379> EXISTS bikes:repairs
 (integer) 0
-{{< /clients-example >}}
+```
 
 The key no longer exists after all the elements are popped.
 
 Example of rule 3:
 
-{{< clients-example list_tutorial rule_3 >}}
-> DEL bikes:repairs
+```valkey-cli
+127.0.0.1:6379> DEL bikes:repairs
 (integer) 0
-> LLEN bikes:repairs
+127.0.0.1:6379> LLEN bikes:repairs
 (integer) 0
-> LPOP bikes:repairs
+127.0.0.1:6379> LPOP bikes:repairs
 (nil)
-{{< /clients-example >}}
+```
 
 
 ## Limits

--- a/topics/sets.md
+++ b/topics/sets.md
@@ -27,36 +27,36 @@ See the [complete list of set commands](../commands/?group=set).
 
 * Store the sets of bikes racing in France and the USA. Note that 
 if you add a member that already exists, it will be ignored. 
-{{< clients-example sets_tutorial sadd >}}
-> SADD bikes:racing:france bike:1
+```valkey-cli
+127.0.0.1:6379> SADD bikes:racing:france bike:1
 (integer) 1
-> SADD bikes:racing:france bike:1
+127.0.0.1:6379> SADD bikes:racing:france bike:1
 (integer) 0
-> SADD bikes:racing:france bike:2 bike:3
+127.0.0.1:6379> SADD bikes:racing:france bike:2 bike:3
 (integer) 2
-> SADD bikes:racing:usa bike:1 bike:4
+127.0.0.1:6379> SADD bikes:racing:usa bike:1 bike:4
 (integer) 2
-{{< /clients-example >}}
+```
 
 * Check whether bike:1 or bike:2 are racing in the US.
-{{< clients-example sets_tutorial sismember >}}
-> SISMEMBER bikes:racing:usa bike:1
+```valkey-cli
+127.0.0.1:6379> SISMEMBER bikes:racing:usa bike:1
 (integer) 1
-> SISMEMBER bikes:racing:usa bike:2
+127.0.0.1:6379> SISMEMBER bikes:racing:usa bike:2
 (integer) 0
-{{< /clients-example >}}
+```
 
 * Which bikes are competing in both races?
-{{< clients-example sets_tutorial sinter >}}
-> SINTER bikes:racing:france bikes:racing:usa
+```valkey-cli
+127.0.0.1:6379> SINTER bikes:racing:france bikes:racing:usa
 1) "bike:1"
-{{< /clients-example >}}
+```
 
 * How many bikes are racing in France?
-{{< clients-example sets_tutorial scard >}}
-> SCARD bikes:racing:france
+```valkey-cli
+127.0.0.1:6379> SCARD bikes:racing:france
 (integer) 3
-{{< /clients-example >}}
+```
 ## Tutorial
 
 The `SADD` command adds new elements to a set. It's also possible
@@ -64,14 +64,14 @@ to do a number of other operations against sets like testing if a given element
 already exists, performing the intersection, union or difference between
 multiple sets, and so forth.
 
-{{< clients-example sets_tutorial sadd_smembers >}}
-> SADD bikes:racing:france bike:1 bike:2 bike:3
+```valkey-cli
+127.0.0.1:6379> SADD bikes:racing:france bike:1 bike:2 bike:3
 (integer) 3
-> SMEMBERS bikes:racing:france
+127.0.0.1:6379> SMEMBERS bikes:racing:france
 1) bike:3
 2) bike:1
 3) bike:2
-{{< /clients-example >}}
+```
 
 Here I've added three elements to my set and told Valkey to return all the
 elements. There is no order guarantee with a set. Valkey is free to return the
@@ -79,25 +79,25 @@ elements in any order at every call.
 
 Valkey has commands to test for set membership. These commands can be used on single as well as multiple items:
 
-{{< clients-example sets_tutorial smismember >}}
-> SISMEMBER bikes:racing:france bike:1
+```valkey-cli
+127.0.0.1:6379> SISMEMBER bikes:racing:france bike:1
 (integer) 1
-> SMISMEMBER bikes:racing:france bike:2 bike:3 bike:4
+127.0.0.1:6379> SMISMEMBER bikes:racing:france bike:2 bike:3 bike:4
 1) (integer) 1
 2) (integer) 1
 3) (integer) 0
-{{< /clients-example >}}
+```
 
 We can also find the difference between two sets. For instance, we may want
 to know which bikes are racing in France but not in the USA:
 
-{{< clients-example sets_tutorial sdiff >}}
-> SADD bikes:racing:usa bike:1 bike:4
+```valkey-cli
+127.0.0.1:6379> SADD bikes:racing:usa bike:1 bike:4
 (integer) 2
-> SDIFF bikes:racing:france bikes:racing:usa
+127.0.0.1:6379> SDIFF bikes:racing:france bikes:racing:usa
 1) "bike:3"
 2) "bike:2"
-{{< /clients-example >}}
+```
 
 There are other non trivial operations that are still easy to implement
 using the right Valkey commands. For instance we may want a list of all the
@@ -107,28 +107,28 @@ sets. In addition to intersection you can also perform
 unions, difference, and more. For example 
 if we add a third race we can see some of these commands in action:
 
-{{< clients-example sets_tutorial multisets >}}
-> SADD bikes:racing:france bike:1 bike:2 bike:3
+```valkey-cli
+127.0.0.1:6379> SADD bikes:racing:france bike:1 bike:2 bike:3
 (integer) 3
-> SADD bikes:racing:usa bike:1 bike:4
+127.0.0.1:6379> SADD bikes:racing:usa bike:1 bike:4
 (integer) 2
-> SADD bikes:racing:italy bike:1 bike:2 bike:3 bike:4
+127.0.0.1:6379> SADD bikes:racing:italy bike:1 bike:2 bike:3 bike:4
 (integer) 4
-> SINTER bikes:racing:france bikes:racing:usa bikes:racing:italy
+127.0.0.1:6379> SINTER bikes:racing:france bikes:racing:usa bikes:racing:italy
 1) "bike:1"
-> SUNION bikes:racing:france bikes:racing:usa bikes:racing:italy
+127.0.0.1:6379> SUNION bikes:racing:france bikes:racing:usa bikes:racing:italy
 1) "bike:2"
 2) "bike:1"
 3) "bike:4"
 4) "bike:3"
-> SDIFF bikes:racing:france bikes:racing:usa bikes:racing:italy
+127.0.0.1:6379> SDIFF bikes:racing:france bikes:racing:usa bikes:racing:italy
 (empty array)
-> SDIFF bikes:racing:france bikes:racing:usa
+127.0.0.1:6379> SDIFF bikes:racing:france bikes:racing:usa
 1) "bike:3"
 2) "bike:2"
-> SDIFF bikes:racing:usa bikes:racing:france
+127.0.0.1:6379> SDIFF bikes:racing:usa bikes:racing:france
 1) "bike:4"
-{{< /clients-example >}}
+```
 
 You'll note that the `SDIFF` command returns an empty array when the
 difference between all sets is empty. You'll also note that the order of sets
@@ -139,20 +139,20 @@ remove one or more items from a set, or you can use the `SPOP` command to
 remove a random item from a set. You can also _return_ a random item from a
 set without removing it using the `SRANDMEMBER` command:
 
-{{< clients-example sets_tutorial srem >}}
-> SADD bikes:racing:france bike:1 bike:2 bike:3 bike:4 bike:5
+```valkey-cli
+127.0.0.1:6379> SADD bikes:racing:france bike:1 bike:2 bike:3 bike:4 bike:5
 (integer) 5
-> SREM bikes:racing:france bike:1
+127.0.0.1:6379> SREM bikes:racing:france bike:1
 (integer) 1
-> SPOP bikes:racing:france
+127.0.0.1:6379> SPOP bikes:racing:france
 "bike:3"
-> SMEMBERS bikes:racing:france
+127.0.0.1:6379> SMEMBERS bikes:racing:france
 1) "bike:2"
 2) "bike:4"
 3) "bike:5"
-> SRANDMEMBER bikes:racing:france
+127.0.0.1:6379> SRANDMEMBER bikes:racing:france
 "bike:2"
-{{< /clients-example >}}
+```
 
 ## Limits
 

--- a/topics/sorted-sets.md
+++ b/topics/sorted-sets.md
@@ -31,14 +31,14 @@ represent sorted sets). They are ordered according to the following rule:
 
 Let's start with a simple example, we'll add all our racers and the score they got in the first race:
 
-{{< clients-example ss_tutorial zadd >}}
-> ZADD racer_scores 10 "Norem"
+```valkey-cli
+127.0.0.1:6379> ZADD racer_scores 10 "Norem"
 (integer) 1
-> ZADD racer_scores 12 "Castilla"
+127.0.0.1:6379> ZADD racer_scores 12 "Castilla"
 (integer) 1
-> ZADD racer_scores 8 "Sam-Bodden" 10 "Royce" 6 "Ford" 14 "Prickett"
+127.0.0.1:6379> ZADD racer_scores 8 "Sam-Bodden" 10 "Royce" 6 "Ford" 14 "Prickett"
 (integer) 4
-{{< /clients-example >}}
+```
 
 
 As you can see `ZADD` is similar to `SADD`, but takes one additional argument
@@ -55,30 +55,30 @@ every time we add an element Valkey performs an O(log(N)) operation. That's
 good, but when we ask for sorted elements Valkey does not have to do any work at
 all, it's already sorted. Note that the `ZRANGE` order is low to high, while the `ZREVRANGE` order is high to low:
 
-{{< clients-example ss_tutorial zrange >}}
-> ZRANGE racer_scores 0 -1
+```valkey-cli
+127.0.0.1:6379> ZRANGE racer_scores 0 -1
 1) "Ford"
 2) "Sam-Bodden"
 3) "Norem"
 4) "Royce"
 5) "Castilla"
 6) "Prickett"
-> ZREVRANGE racer_scores 0 -1
+127.0.0.1:6379> ZREVRANGE racer_scores 0 -1
 1) "Prickett"
 2) "Castilla"
 3) "Royce"
 4) "Norem"
 5) "Sam-Bodden"
 6) "Ford"
-{{< /clients-example >}}
+```
 
 Note: 0 and -1 means from element index 0 to the last element (-1 works
 here just as it does in the case of the `LRANGE` command).
 
 It is possible to return scores as well, using the `WITHSCORES` argument:
 
-{{< clients-example ss_tutorial zrange_withscores >}}
-> ZRANGE racer_scores 0 -1 withscores
+```valkey-cli
+127.0.0.1:6379> ZRANGE racer_scores 0 -1 withscores
  1) "Ford"
  2) "6"
  3) "Sam-Bodden"
@@ -91,7 +91,7 @@ It is possible to return scores as well, using the `WITHSCORES` argument:
 10) "12"
 11) "Prickett"
 12) "14"
-{{< /clients-example >}}
+```
 
 ### Operating on ranges
 
@@ -99,13 +99,13 @@ Sorted sets are more powerful than this. They can operate on ranges.
 Let's get all the racers with 10 or fewer points. We
 use the `ZRANGEBYSCORE` command to do it:
 
-{{< clients-example ss_tutorial zrangebyscore >}}
-> ZRANGEBYSCORE racer_scores -inf 10
+```valkey-cli
+127.0.0.1:6379> ZRANGEBYSCORE racer_scores -inf 10
 1) "Ford"
 2) "Sam-Bodden"
 3) "Norem"
 4) "Royce"
-{{< /clients-example >}}
+```
 
 We asked Valkey to return all the elements with a score between negative
 infinity and 10 (both extremes are included).
@@ -114,16 +114,16 @@ To remove an element we'd simply call `ZREM` with the racer's name.
 It's also possible to remove ranges of elements. Let's remove racer Castilla along with all
 the racers with strictly fewer than 10 points:
 
-{{< clients-example ss_tutorial zremrangebyscore >}}
-> ZREM racer_scores "Castilla"
+```valkey-cli
+127.0.0.1:6379> ZREM racer_scores "Castilla"
 (integer) 1
-> ZREMRANGEBYSCORE racer_scores -inf 9
+127.0.0.1:6379> ZREMRANGEBYSCORE racer_scores -inf 9
 (integer) 2
-> ZRANGE racer_scores 0 -1
+127.0.0.1:6379> ZRANGE racer_scores 0 -1
 1) "Norem"
 2) "Royce"
 3) "Prickett"
-{{< /clients-example >}}
+```
 
 `ZREMRANGEBYSCORE` is perhaps not the best command name,
 but it can be very useful, and returns the number of removed elements.
@@ -134,12 +134,12 @@ position of an element in the set of ordered elements.
 The `ZREVRANK` command is also available in order to get the rank, considering
 the elements sorted in a descending way.
 
-{{< clients-example ss_tutorial zrank >}}
-> ZRANK racer_scores "Norem"
+```valkey-cli
+127.0.0.1:6379> ZRANK racer_scores "Norem"
 (integer) 0
-> ZREVRANK racer_scores "Norem"
+127.0.0.1:6379> ZREVRANK racer_scores "Norem"
 (integer) 3
-{{< /clients-example >}}
+```
 
 ### Lexicographical scores
 
@@ -155,20 +155,20 @@ The main commands to operate with lexicographical ranges are `ZRANGEBYLEX`,
 For example, let's add again our list of famous hackers, but this time
 using a score of zero for all the elements. We'll see that because of the sorted sets ordering rules, they are already sorted lexicographically. Using `ZRANGEBYLEX` we can ask for lexicographical ranges:
 
-{{< clients-example ss_tutorial zadd_lex >}}
-> ZADD racer_scores 0 "Norem" 0 "Sam-Bodden" 0 "Royce" 0 "Castilla" 0 "Prickett" 0 "Ford"
+```valkey-cli
+127.0.0.1:6379> ZADD racer_scores 0 "Norem" 0 "Sam-Bodden" 0 "Royce" 0 "Castilla" 0 "Prickett" 0 "Ford"
 (integer) 3
-> ZRANGE racer_scores 0 -1
+127.0.0.1:6379> ZRANGE racer_scores 0 -1
 1) "Castilla"
 2) "Ford"
 3) "Norem"
 4) "Prickett"
 5) "Royce"
 6) "Sam-Bodden"
-> ZRANGEBYLEX racer_scores [A [L
+127.0.0.1:6379> ZRANGEBYLEX racer_scores [A [L
 1) "Castilla"
 2) "Ford"
-{{< /clients-example >}}
+```
 
 Ranges can be inclusive or exclusive (depending on the first character),
 also string infinite and minus infinite are specified respectively with
@@ -201,18 +201,18 @@ the #4932 best score here").
 ## Examples
 
 * There are two ways we can use a sorted set to represent a leaderboard. If we know a racer's new score, we can update it directly via the `ZADD` command. However, if we want to add points to an existing score, we can use the `ZINCRBY` command.
-{{< clients-example ss_tutorial leaderboard >}}
-> ZADD racer_scores 100 "Wood"
+```valkey-cli
+127.0.0.1:6379> ZADD racer_scores 100 "Wood"
 (integer) 1
-> ZADD racer_scores 100 "Henshaw"
+127.0.0.1:6379> ZADD racer_scores 100 "Henshaw"
 (integer) 1
-> ZADD racer_scores 150 "Henshaw"
+127.0.0.1:6379> ZADD racer_scores 150 "Henshaw"
 (integer) 0
-> ZINCRBY racer_scores 50 "Wood"
+127.0.0.1:6379> ZINCRBY racer_scores 50 "Wood"
 "150"
-> ZINCRBY racer_scores 50 "Henshaw"
+127.0.0.1:6379> ZINCRBY racer_scores 50 "Henshaw"
 "200"
-{{< /clients-example >}}
+```
 
 You'll see that `ZADD` returns 0 when the member already exists (the score is updated), while `ZINCRBY` returns the new score. The score for racer Henshaw went from 100, was changed to 150 with no regard for what score was there before, and then was incremented by 50 to 200.
 

--- a/topics/strings.md
+++ b/topics/strings.md
@@ -15,12 +15,12 @@ Since Valkey keys are strings, when we use the string type as a value too,
 we are mapping a string to another string. The string data type is useful
 for a number of use cases, like caching HTML fragments or pages.
 
-{{< clients-example set_tutorial set_get >}}
-    > SET bike:1 Deimos
-    OK
-    > GET bike:1
-    "Deimos"
-{{< /clients-example >}}
+```valkey-cli
+127.0.0.1:6379> SET bike:1 Deimos
+OK
+127.0.0.1:6379> GET bike:1
+"Deimos"
+```
 
 As you can see using the `SET` and the `GET` commands are the way we set
 and retrieve a string value. Note that `SET` will replace any existing value
@@ -34,12 +34,12 @@ The `SET` command has interesting options, that are provided as additional
 arguments. For example, I may ask `SET` to fail if the key already exists,
 or the opposite, that it only succeed if the key already exists:
 
-{{< clients-example set_tutorial setnx_xx >}}
-    > set bike:1 bike nx
-    (nil)
-    > set bike:1 bike xx
-    OK
-{{< /clients-example >}}
+```valkey-cli
+127.0.0.1:6379> set bike:1 bike nx
+(nil)
+127.0.0.1:6379> set bike:1 bike xx
+OK
+```
 
 There are a number of other commands for operating on strings. For example
 the `GETSET` command sets a key to a new value, returning the old value as the
@@ -54,14 +54,14 @@ The ability to set or retrieve the value of multiple keys in a single
 command is also useful for reduced latency. For this reason there are
 the `MSET` and `MGET` commands:
 
-{{< clients-example set_tutorial mset >}}
-    > mset bike:1 "Deimos" bike:2 "Ares" bike:3 "Vanth"
-    OK
-    > mget bike:1 bike:2 bike:3
-    1) "Deimos"
-    2) "Ares"
-    3) "Vanth"
-{{< /clients-example >}}
+```valkey-cli
+127.0.0.1:6379> mset bike:1 "Deimos" bike:2 "Ares" bike:3 "Vanth"
+OK
+127.0.0.1:6379> mget bike:1 bike:2 bike:3
+1) "Deimos"
+2) "Ares"
+3) "Vanth"
+```
 
 When `MGET` is used, Valkey returns an array of values.
 
@@ -69,14 +69,14 @@ When `MGET` is used, Valkey returns an array of values.
 Even if strings are the basic values of Valkey, there are interesting operations
 you can perform with them. For instance, one is atomic increment:
 
-{{< clients-example set_tutorial incr >}}
-    > set total_crashes 0
-    OK
-    > incr total_crashes
-    (integer) 1
-    > incrby total_crashes 10
-    (integer) 11
-{{< /clients-example >}}
+```valkey-cli
+127.0.0.1:6379> set total_crashes 0
+OK
+127.0.0.1:6379> incr total_crashes
+(integer) 1
+127.0.0.1:6379> incrby total_crashes 10
+(integer) 11
+```
 
 The `INCR` command parses the string value as an integer,
 increments it by one, and finally sets the obtained value as the new value.


### PR DESCRIPTION
Replace non-markdown code blocks like

    {{< clients-example stream_tutorial xgroup_create >}}
    > XGROUP CREATE race:france france_riders $
    OK
    {{< /clients-example >}}

with

    ```valkey-cli
    127.0.0.1:6379> XGROUP CREATE race:france france_riders $
    OK
    ```

Apart from changing the delimiters, the prompt is replaced with `127.0.0.1:6379>` which is what valkey-cli display by default.