### PR TITLE
Fix internal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,21 @@ links for the reply type. Note: do not use `@reply-type` specifiers; use only th
 **Important**: all links below are under construction.
 
 ```md
-@simple-string-reply: [Simple string reply](https://valkey.io/docs/reference/protocol-spec#simple-strings)
-@simple-error-reply: [Simple error reply](https://valkey.io/docs/reference/protocol-spec#simple-errors)
-@integer-reply: [Integer reply](https://valkey.io/docs/reference/protocol-spec#integers)
-@bulk-string-reply: [Bulk string reply](https://valkey.io/docs/reference/protocol-spec#bulk-strings)
-@array-reply: [Array reply](https://valkey.io/docs/reference/protocol-spec#arrays)
-@nil-reply: [Nil reply](https://valkey.io/docs/reference/protocol-spec#bulk-strings)
-@null-reply: [Null reply](https://valkey.io/docs/reference/protocol-spec#nulls)
-@boolean-reply: [Boolean reply](https://valkey.io/docs/reference/protocol-spec#booleans)
-@double-reply: [Double reply](https://valkey.io/docs/reference/protocol-spec#doubles)
-@big-number-reply: [Big number reply](https://valkey.io/docs/reference/protocol-spec#big-numbers)
-@bulk-error-reply: [Bulk error reply](https://valkey.io/docs/reference/protocol-spec#bulk-errors)
-@verbatim-string-reply: [Verbatim string reply](https://valkey.io/docs/reference/protocol-spec#verbatim-strings)
-@map-reply: [Map reply](https://valkey.io/docs/reference/protocol-spec#maps)
-@set-reply: [Set reply](https://valkey.io/docs/reference/protocol-spec#sets)
-@push-reply: [Push reply](https://valkey.io/docs/reference/protocol-spec#pushes)
+@simple-string-reply: [Simple string reply](https://valkey.io/topics/protocol#simple-strings)
+@simple-error-reply: [Simple error reply](https://valkey.io/topics/protocol#simple-errors)
+@integer-reply: [Integer reply](https://valkey.io/topics/protocol#integers)
+@bulk-string-reply: [Bulk string reply](https://valkey.io/topics/protocol#bulk-strings)
+@array-reply: [Array reply](https://valkey.io/topics/protocol#arrays)
+@nil-reply: [Nil reply](https://valkey.io/topics/protocol#bulk-strings)
+@null-reply: [Null reply](https://valkey.io/topics/protocol#nulls)
+@boolean-reply: [Boolean reply](https://valkey.io/topics/protocol#booleans)
+@double-reply: [Double reply](https://valkey.io/topics/protocol#doubles)
+@big-number-reply: [Big number reply](https://valkey.io/topics/protocol#big-numbers)
+@bulk-error-reply: [Bulk error reply](https://valkey.io/topics/protocol#bulk-errors)
+@verbatim-string-reply: [Verbatim string reply](https://valkey.io/topics/protocol#verbatim-strings)
+@map-reply: [Map reply](https://valkey.io/topics/protocol#maps)
+@set-reply: [Set reply](https://valkey.io/topics/protocol#sets)
+@push-reply: [Push reply](https://valkey.io/topics/protocol#pushes)
 ```
 
 ## Styling guidelines

--- a/commands/bgrewriteaof.md
+++ b/commands/bgrewriteaof.md
@@ -2,7 +2,7 @@ Instruct Valkey to start an [Append Only File][tpaof] rewrite process.
 The rewrite will create a small optimized version of the current Append Only
 File.
 
-[tpaof]: /topics/persistence#append-only-file
+[tpaof]: ../topics/persistence.md#append-only-file
 
 If `BGREWRITEAOF` fails, no data gets lost as the old AOF will be untouched.
 
@@ -21,5 +21,5 @@ The AOF rewrite is automatically triggered by Valkey, however the
 
 Please refer to the [persistence documentation][tp] for detailed information.
 
-[tp]: /topics/persistence
+[tp]: ../topics/persistence.md
 

--- a/commands/bgsave.md
+++ b/commands/bgsave.md
@@ -17,5 +17,5 @@ command.
 
 Please refer to the [persistence documentation][tp] for detailed information.
 
-[tp]: /topics/persistence
+[tp]: ../topics/persistence.md
 

--- a/commands/brpop.md
+++ b/commands/brpop.md
@@ -8,7 +8,7 @@ See the [BLPOP documentation][cb] for the exact semantics, since `BRPOP` is
 identical to `BLPOP` with the only difference being that it pops elements from
 the tail of a list instead of popping from the head.
 
-[cb]: /commands/blpop
+[cb]: blpop.md
 
 ## Examples
 

--- a/commands/bzpopmax.md
+++ b/commands/bzpopmax.md
@@ -12,7 +12,7 @@ See the [BZPOPMIN documentation][cb] for the exact semantics, since `BZPOPMAX`
 is identical to `BZPOPMIN` with the only difference being that it pops members
 with the highest scores instead of popping the ones with the lowest scores.
 
-[cb]: /commands/bzpopmin
+[cb]: bzpopmin.md
 
 ## Examples
 

--- a/commands/bzpopmin.md
+++ b/commands/bzpopmin.md
@@ -12,7 +12,7 @@ See the [BLPOP documentation][cl] for the exact semantics, since `BZPOPMIN` is
 identical to `BLPOP` with the only difference being the data structure being
 popped from.
 
-[cl]: /commands/blpop
+[cl]: blpop.md
 
 ## Examples
 

--- a/commands/command-docs.md
+++ b/commands/command-docs.md
@@ -42,7 +42,7 @@ The following keys may be included in the mapped reply:
 * **arguments:** an array of maps that describe the command's arguments.
   Please refer to the [Valkey command arguments][td] page for more information.
 
-[td]: /topics/command-arguments
+[td]: ../topics/command-arguments.md
 
 ## Examples
 

--- a/commands/command.md
+++ b/commands/command.md
@@ -189,10 +189,10 @@ This is an array containing all of the command's subcommands, if any.
 Some Valkey commands have subcommands (e.g., the `REWRITE` subcommand of `CONFIG`).
 Each element in the array represents one subcommand and follows the same specifications as those of `COMMAND`'s reply.
 
-[ta]: /topics/acl
-[tb]: /topics/command-tips
-[td]: /topics/key-specs
-[tr]: /topics/key-specs
+[ta]: ../topics/acl.md
+[tb]: ../topics/command-tips.md
+[td]: ../topics/key-specs.md
+[tr]: ../topics/key-specs.md
 
 ## Examples
 

--- a/commands/config-set.md
+++ b/commands/config-set.md
@@ -24,7 +24,7 @@ It is possible to switch persistence from RDB snapshotting to append-only file
 For more information about how to do that please check the [persistence
 page][tp].
 
-[tp]: /topics/persistence
+[tp]: ../topics/persistence.md
 
 In general what you should know is that setting the `appendonly` parameter to
 `yes` will start a background process to save the initial append-only file

--- a/commands/discard.md
+++ b/commands/discard.md
@@ -1,6 +1,6 @@
 Flushes all previously queued commands in a [transaction][tt] and restores the
 connection state to normal.
 
-[tt]: /topics/transactions
+[tt]: ../topics/transactions.md
 
 If `WATCH` was used, `DISCARD` unwatches all keys watched by the connection.

--- a/commands/exec.md
+++ b/commands/exec.md
@@ -1,9 +1,9 @@
 Executes all previously queued commands in a [transaction][tt] and restores the
 connection state to normal.
 
-[tt]: /topics/transactions
+[tt]: ../topics/transactions.md
 
 When using `WATCH`, `EXEC` will execute commands only if the watched keys were
 not modified, allowing for a [check-and-set mechanism][ttc].
 
-[ttc]: /topics/transactions#cas
+[ttc]: ../topics/transactions.md#cas

--- a/commands/expire.md
+++ b/commands/expire.md
@@ -29,7 +29,7 @@ Note that calling `EXPIRE`/`PEXPIRE` with a non-positive timeout or
 will be `del`, not `expired`).
 
 [del]: del.md
-[ntf]: /topics/notifications
+[ntf]: ../topics/notifications.md
 
 ## Options
 

--- a/commands/expire.md
+++ b/commands/expire.md
@@ -28,7 +28,7 @@ Note that calling `EXPIRE`/`PEXPIRE` with a non-positive timeout or
 [deleted][del] rather than expired (accordingly, the emitted [key event][ntf]
 will be `del`, not `expired`).
 
-[del]: /commands/del
+[del]: del.md
 [ntf]: /topics/notifications
 
 ## Options

--- a/commands/keys.md
+++ b/commands/keys.md
@@ -14,7 +14,7 @@ Don't use `KEYS` in your regular application code.
 If you're looking for a way to find keys in a subset of your keyspace, consider
 using `SCAN` or [sets][tdts].
 
-[tdts]: /topics/data-types#sets
+[tdts]: ../topics/data-types.md#sets
 
 Supported glob-style patterns:
 

--- a/commands/latency-doctor.md
+++ b/commands/latency-doctor.md
@@ -26,7 +26,7 @@ I have a few advices for you:
     use 'CONFIG SET slowlog-log-slower-than 1000'.
 - Check your Slow Log to understand what are the commands you are
     running which are too slow to execute. Please check
-    http://Valkey.io/commands/slowlog for more information.
+    [SLOWLOG](slowlog.md) for more information.
 - Deleting, expiring or evicting (because of maxmemory policy)
     large objects is a blocking operation. If you have very large
     objects that are often deleted, expired, or evicted, try to

--- a/commands/latency-doctor.md
+++ b/commands/latency-doctor.md
@@ -37,4 +37,4 @@ I have a few advices for you:
 
 For more information refer to the [Latency Monitoring Framework page][lm].
 
-[lm]: /topics/latency-monitor
+[lm]: ../topics/latency-monitor.md

--- a/commands/latency-graph.md
+++ b/commands/latency-graph.md
@@ -57,4 +57,4 @@ in the lower row) is the minimum, and a # in the higher row is the maximum.
 
 For more information refer to the [Latency Monitoring Framework page][lm].
 
-[lm]: /topics/latency-monitor
+[lm]: ../topics/latency-monitor.md

--- a/commands/latency-help.md
+++ b/commands/latency-help.md
@@ -3,4 +3,4 @@ subcommands.
 
 For more information refer to the [Latency Monitoring Framework page][lm].
 
-[lm]: /topics/latency-monitor
+[lm]: ../topics/latency-monitor.md

--- a/commands/latency-history.md
+++ b/commands/latency-history.md
@@ -34,4 +34,4 @@ Valid values for `event` are:
 
 For more information refer to the [Latency Monitoring Framework page][lm].
 
-[lm]: /topics/latency-monitor
+[lm]: ../topics/latency-monitor.md

--- a/commands/latency-latest.md
+++ b/commands/latency-latest.md
@@ -27,4 +27,4 @@ OK
 
 For more information refer to the [Latency Monitoring Framework page][lm].
 
-[lm]: /topics/latency-monitor
+[lm]: ../topics/latency-monitor.md

--- a/commands/latency-reset.md
+++ b/commands/latency-reset.md
@@ -27,4 +27,4 @@ Valid values for `event` are:
 
 For more information refer to the [Latency Monitoring Framework page][lm].
 
-[lm]: /topics/latency-monitor
+[lm]: ../topics/latency-monitor.md

--- a/commands/multi.md
+++ b/commands/multi.md
@@ -1,4 +1,4 @@
 Marks the start of a [transaction][tt] block.
 Subsequent commands will be queued for atomic execution using `EXEC`.
 
-[tt]: /topics/transactions
+[tt]: ../topics/transactions.md

--- a/commands/psync.md
+++ b/commands/psync.md
@@ -6,4 +6,4 @@ stream from the master.
 For more information about replication in Valkey please check the
 [replication page][tr].
 
-[tr]: /topics/replication
+[tr]: ../topics/replication.md

--- a/commands/save.md
+++ b/commands/save.md
@@ -11,4 +11,4 @@ good last resort to perform the dump of the latest dataset.
 
 Please refer to the [persistence documentation][tp] for detailed information.
 
-[tp]: /topics/persistence
+[tp]: ../topics/persistence.md

--- a/commands/set.md
+++ b/commands/set.md
@@ -35,7 +35,7 @@ OK
 
 ## Patterns
 
-**Note:** The following pattern is discouraged in favor of [the Redlock algorithm](https://valkey.io/topics/distlock) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
+**Note:** The following pattern is discouraged in favor of [the Redlock algorithm](../topics/distlock) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
 
 The command `SET resource-name anystring NX EX max-lock-time` is a simple way to implement a locking system with Valkey.
 

--- a/commands/set.md
+++ b/commands/set.md
@@ -35,7 +35,7 @@ OK
 
 ## Patterns
 
-**Note:** The following pattern is discouraged in favor of [the Redlock algorithm](../topics/distlock) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
+**Note:** The following pattern is discouraged in favor of [the Redlock algorithm](../topics/distlock.md) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
 
 The command `SET resource-name anystring NX EX max-lock-time` is a simple way to implement a locking system with Valkey.
 

--- a/commands/setbit.md
+++ b/commands/setbit.md
@@ -69,7 +69,7 @@ native programming language. Symmetrically, it is also possible to set an entire
 bitmap by performing the bits-to-bytes encoding in the client and calling `SET`
 with the resultant string.
 
-[ti]: /topics/data-types-intro#bitmaps
+[ti]: ../topics/data-types.md#bitmaps
 
 ## Pattern: setting multiple bits
 

--- a/commands/setnx.md
+++ b/commands/setnx.md
@@ -18,7 +18,7 @@ When `key` already holds a value, no operation is performed.
 
 **Please note that:**
 
-1. The following pattern is discouraged in favor of [the Redlock algorithm](../topics/distlock) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
+1. The following pattern is discouraged in favor of [the Redlock algorithm](../topics/distlock.md) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
 2. We document the old pattern anyway because certain existing implementations link to this page as a reference. Moreover it is an interesting example of how Valkey commands can be used in order to mount programming primitives.
 3. Anyway even assuming a single-instance locking primitive, starting with 2.6.12 it is possible to create a much simpler locking primitive, equivalent to the one discussed here, using the `SET` command to acquire the lock, and a simple Lua script to release the lock. The pattern is documented in the `SET` command page.
 

--- a/commands/setnx.md
+++ b/commands/setnx.md
@@ -18,7 +18,7 @@ When `key` already holds a value, no operation is performed.
 
 **Please note that:**
 
-1. The following pattern is discouraged in favor of [the Redlock algorithm](https://valkey.io/topics/distlock) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
+1. The following pattern is discouraged in favor of [the Redlock algorithm](../topics/distlock) which is only a bit more complex to implement, but offers better guarantees and is fault tolerant.
 2. We document the old pattern anyway because certain existing implementations link to this page as a reference. Moreover it is an interesting example of how Valkey commands can be used in order to mount programming primitives.
 3. Anyway even assuming a single-instance locking primitive, starting with 2.6.12 it is possible to create a much simpler locking primitive, equivalent to the one discussed here, using the `SET` command to acquire the lock, and a simple Lua script to release the lock. The pattern is documented in the `SET` command page.
 

--- a/commands/sort.md
+++ b/commands/sort.md
@@ -7,9 +7,9 @@ By default, sorting is numeric and elements are compared by their value
 interpreted as double precision floating point number.
 This is `SORT` in its simplest form:
 
-[tdtl]: /topics/data-types#lists
-[tdts]: /topics/data-types#set
-[tdtss]: /topics/data-types#sorted-sets
+[tdtl]: ../topics/data-types.md#lists
+[tdts]: ../topics/data-types.md#set
+[tdtss]: ../topics/data-types.md#sorted-sets
 
 ```
 SORT mylist

--- a/commands/sync.md
+++ b/commands/sync.md
@@ -7,4 +7,4 @@ stream from the master. It has been replaced in newer versions of Valkey by
 For more information about replication in Valkey please check the
 [replication page][tr].
 
-[tr]: /topics/replication
+[tr]: ../topics/replication.md

--- a/commands/unwatch.md
+++ b/commands/unwatch.md
@@ -1,5 +1,5 @@
 Flushes all the previously watched keys for a [transaction][tt].
 
-[tt]: /topics/transactions
+[tt]: ../topics/transactions.md
 
 If you call `EXEC` or `DISCARD`, there's no need to manually call `UNWATCH`.

--- a/commands/watch.md
+++ b/commands/watch.md
@@ -1,4 +1,4 @@
 Marks the given keys to be watched for conditional execution of a
 [transaction][tt].
 
-[tt]: /topics/transactions
+[tt]: ../topics/transactions.md

--- a/commands/zadd.md
+++ b/commands/zadd.md
@@ -46,7 +46,7 @@ that can also be used to verify if an element already exists or not.
 For an introduction to sorted sets, see the data types page on [sorted
 sets][tdtss].
 
-[tdtss]: /topics/data-types#sorted-sets
+[tdtss]: ../topics/data-types.md#sorted-sets
 
 Elements with the same score
 ---

--- a/resp2_replies.json
+++ b/resp2_replies.json
@@ -2,94 +2,94 @@
   "ACL": [],
   "ACL CAT": [
     "One of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements representing ACL categories or commands in a given category.",
-    "* [Simple error reply](/docs/reference/protocol-spec#simple-errors): the command returns an error if an invalid category name is given."
+    "* [Array reply](../topics/protocol.md#arrays): an array of [Bulk string reply](../topics/protocol.md#bulk-strings) elements representing ACL categories or commands in a given category.",
+    "* [Simple error reply](../topics/protocol.md#simple-errors): the command returns an error if an invalid category name is given."
   ],
   "ACL DELUSER": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of users that were deleted. This number will not always match the number of arguments since certain users may not exist."
+    "[Integer reply](../topics/protocol.md#integers): the number of users that were deleted. This number will not always match the number of arguments since certain users may not exist."
   ],
   "ACL DRYRUN": [
     "Any of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): an error describing why the user can't execute the command."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK` on success.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): an error describing why the user can't execute the command."
   ],
   "ACL GENPASS": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4."
   ],
   "ACL GETUSER": [
     "One of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of ACL rule definitions for the user.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if user does not exist."
+    "* [Array reply](../topics/protocol.md#arrays): a list of ACL rule definitions for the user.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if user does not exist."
   ],
   "ACL HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of subcommands and their descriptions."
   ],
   "ACL LIST": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements."
+    "[Array reply](../topics/protocol.md#arrays): an array of [Bulk string reply](../topics/protocol.md#bulk-strings) elements."
   ],
   "ACL LOG": [
     "When called to show security events:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements representing ACL security events.",
+    "* [Array reply](../topics/protocol.md#arrays): an array of [Bulk string reply](../topics/protocol.md#bulk-strings) elements representing ACL security events.",
     "When called with `RESET`:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the security log was cleared."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK` if the security log was cleared."
   ],
   "ACL SAVE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`.",
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`.",
     "The command may fail with an error for several reasons: if the file cannot be written or if the server is not configured to use an external ACL file."
   ],
   "ACL SETUSER": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`.",
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`.",
     "If the rules contain errors, the error is returned."
   ],
   "ACL USERS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): list of existing ACL users."
+    "[Array reply](../topics/protocol.md#arrays): list of existing ACL users."
   ],
   "ACL WHOAMI": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the username of the current connection."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the username of the current connection."
   ],
   "ACL-LOAD": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` on success.",
     "",
     "The command may fail with an error for several reasons: if the file is not readable, if there is an error inside the file, and in such cases, the error will be reported to the user in the error.",
     "Finally, the command will fail if the server is not configured to use an external ACL file."
   ],
   "APPEND": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string after the append operation."
+    "[Integer reply](../topics/protocol.md#integers): the length of the string after the append operation."
   ],
   "ASKING": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "AUTH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`, or an error if the password, or username/password pair, is invalid."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`, or an error if the password, or username/password pair, is invalid."
   ],
   "BGREWRITEAOF": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): a simple string reply indicating that the rewriting started or is about to start ASAP when the call is executed with success.",
+    "[Simple string reply](../topics/protocol.md#simple-strings): a simple string reply indicating that the rewriting started or is about to start ASAP when the call is executed with success.",
     "",
     "The command may reply with an error in certain cases, as documented above."
   ],
   "BGSAVE": [
     "One of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `Background saving started`.",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `Background saving scheduled`."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `Background saving started`.",
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `Background saving scheduled`."
   ],
   "BITCOUNT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of bits set to 1."
+    "[Integer reply](../topics/protocol.md#integers): the number of bits set to 1."
   ],
   "BITFIELD": [
     "One of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): each entry being the corresponding result of the sub-command given at the same position.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if OVERFLOW FAIL was given and overflows or underflows are detected."
+    "* [Array reply](../topics/protocol.md#arrays): each entry being the corresponding result of the sub-command given at the same position.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if OVERFLOW FAIL was given and overflows or underflows are detected."
   ],
   "BITFIELD_RO": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): each entry being the corresponding result of the sub-command given at the same position."
+    "[Array reply](../topics/protocol.md#arrays): each entry being the corresponding result of the sub-command given at the same position."
   ],
   "BITOP": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the size of the string stored in the destination key is equal to the size of the longest input string."
+    "[Integer reply](../topics/protocol.md#integers): the size of the string stored in the destination key is equal to the size of the longest input string."
   ],
   "BITPOS": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the position of the first bit set to 1 or 0 according to the request",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1`. In case the `bit` argument is 1 and the string is empty or composed of just zero bytes",
+    "* [Integer reply](../topics/protocol.md#integers): the position of the first bit set to 1 or 0 according to the request",
+    "* [Integer reply](../topics/protocol.md#integers): `-1`. In case the `bit` argument is 1 and the string is empty or composed of just zero bytes",
     "",
     "If we look for set bits (the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.",
     "",
@@ -102,263 +102,263 @@
   ],
   "BLMOVE": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped from the _source_ and pushed to the _destination_.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): the operation timed-out"
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the element being popped from the _source_ and pushed to the _destination_.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): the operation timed-out"
   ],
   "BLMPOP": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when no element could be popped and the _timeout_ is reached.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element being an array of the popped elements."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): when no element could be popped and the _timeout_ is reached.",
+    "* [Array reply](../topics/protocol.md#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element being an array of the popped elements."
   ],
   "BLPOP": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): no element could be popped and the timeout expired",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the key from which the element was popped and the value of the popped element."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): no element could be popped and the timeout expired",
+    "* [Array reply](../topics/protocol.md#arrays): the key from which the element was popped and the value of the popped element."
   ],
   "BRPOP": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): no element could be popped and the timeout expired.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the key from which the element was popped and the value of the popped element"
+    "* [Nil reply](../topics/protocol.md#bulk-strings): no element could be popped and the timeout expired.",
+    "* [Array reply](../topics/protocol.md#arrays): the key from which the element was popped and the value of the popped element"
   ],
   "BRPOPLPUSH": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped from _source_ and pushed to _destination_.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): the timeout is reached."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the element being popped from _source_ and pushed to _destination_.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): the timeout is reached."
   ],
   "BZMPOP": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when no element could be popped.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): when no element could be popped.",
+    "* [Array reply](../topics/protocol.md#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
   ],
   "BZPOPMAX": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when no element could be popped and the _timeout_ expired.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the keyname, popped member, and its score."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): when no element could be popped and the _timeout_ expired.",
+    "* [Array reply](../topics/protocol.md#arrays): the keyname, popped member, and its score."
   ],
   "BZPOPMIN": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when no element could be popped and the _timeout_ expired.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the keyname, popped member, and its score."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): when no element could be popped and the _timeout_ expired.",
+    "* [Array reply](../topics/protocol.md#arrays): the keyname, popped member, and its score."
   ],
   "CLIENT": [],
   "CLIENT CACHING": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` or an error if the argument is not \"yes\" or \"no\"."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` or an error if the argument is not \"yes\" or \"no\"."
   ],
   "CLIENT GETNAME": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the connection name of the current connection.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): the connection name was not set."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the connection name of the current connection.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): the connection name was not set."
   ],
   "CLIENT GETREDIR": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` when not redirecting notifications to any client.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if client tracking is not enabled.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the ID of the client to which notification are being redirected."
+    "* [Integer reply](../topics/protocol.md#integers): `0` when not redirecting notifications to any client.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` if client tracking is not enabled.",
+    "* [Integer reply](../topics/protocol.md#integers): the ID of the client to which notification are being redirected."
   ],
   "CLIENT HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of subcommands and their descriptions."
   ],
   "CLIENT ID": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the ID of the client."
+    "[Integer reply](../topics/protocol.md#integers): the ID of the client."
   ],
   "CLIENT INFO": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a unique string for the current client, as described at the `CLIENT LIST` page."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): a unique string for the current client, as described at the `CLIENT LIST` page."
   ],
   "CLIENT KILL": [
     "One of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when called in 3 argument format and the connection has been closed.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): when called in filter/value format, the number of clients killed."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK` when called in 3 argument format and the connection has been closed.",
+    "* [Integer reply](../topics/protocol.md#integers): when called in filter/value format, the number of clients killed."
   ],
   "CLIENT LIST": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): information and statistics about client connections."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): information and statistics about client connections."
   ],
   "CLIENT NO-EVICT": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "CLIENT NO-TOUCH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "CLIENT PAUSE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` or an error if the timeout is invalid."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` or an error if the timeout is invalid."
   ],
   "CLIENT REPLY": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when called with `ON`. When called with either `OFF` or `SKIP` sub-commands, no reply is made."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` when called with `ON`. When called with either `OFF` or `SKIP` sub-commands, no reply is made."
   ],
   "CLIENT SETINFO": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the attribute name was successfully set."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the attribute name was successfully set."
   ],
   "CLIENT SETNAME": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the connection name was successfully set."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the connection name was successfully set."
   ],
   "CLIENT TRACKING": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the connection was successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise, an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the connection was successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise, an error is returned."
   ],
   "CLIENT TRACKINGINFO": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of tracking information sections and their respective values."
+    "[Array reply](../topics/protocol.md#arrays): a list of tracking information sections and their respective values."
   ],
   "CLIENT UNBLOCK": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the client was unblocked successfully.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the client wasn't unblocked."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the client was unblocked successfully.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the client wasn't unblocked."
   ],
   "CLIENT UNPAUSE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "CLUSTER": [],
   "CLUSTER ADDSLOTS": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER ADDSLOTSRANGE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER BUMPEPOCH": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `BUMPED` if the epoch was incremented.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `STILL` if the node already has the greatest configured epoch in the cluster."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): `BUMPED` if the epoch was incremented.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): `STILL` if the node already has the greatest configured epoch in the cluster."
   ],
   "CLUSTER COUNT-FAILURE-REPORTS": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of active failure reports for the node."
+    "[Integer reply](../topics/protocol.md#integers): the number of active failure reports for the node."
   ],
   "CLUSTER COUNTKEYSINSLOT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The number of keys in the specified hash slot, or an error if the hash slot is invalid."
+    "[Integer reply](../topics/protocol.md#integers): The number of keys in the specified hash slot, or an error if the hash slot is invalid."
   ],
   "CLUSTER DELSLOTS": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER DELSLOTSRANGE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER FAILOVER": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was accepted and a manual failover is going to be attempted. An error if the operation cannot be executed, for example if the client is connected to a node that is already a master."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was accepted and a manual failover is going to be attempted. An error if the operation cannot be executed, for example if the client is connected to a node that is already a master."
   ],
   "CLUSTER FLUSHSLOTS": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`"
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`"
   ],
   "CLUSTER FORGET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was executed successfully. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was executed successfully. Otherwise an error is returned."
   ],
   "CLUSTER GETKEYSINSLOT": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array with up to count elements."
+    "[Array reply](../topics/protocol.md#arrays): an array with up to count elements."
   ],
   "CLUSTER HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of subcommands and their descriptions."
   ],
   "CLUSTER INFO": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): A map between named fields and values in the form of `<field>:<value>` lines separated by newlines composed by the two bytes `CRLF`."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): A map between named fields and values in the form of `<field>:<value>` lines separated by newlines composed by the two bytes `CRLF`."
   ],
   "CLUSTER KEYSLOT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The hash slot number for the specified key"
+    "[Integer reply](../topics/protocol.md#integers): The hash slot number for the specified key"
   ],
   "CLUSTER LINKS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array of maps where each map contains various attributes and their values of a cluster link."
+    "[Array reply](../topics/protocol.md#arrays): an array of maps where each map contains various attributes and their values of a cluster link."
   ],
   "CLUSTER MEET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. If the address or port specified are invalid an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. If the address or port specified are invalid an error is returned."
   ],
   "CLUSTER MYID": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the node ID."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the node ID."
   ],
   "CLUSTER MYSHARDID": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the node's shard ID."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the node's shard ID."
   ],
   "CLUSTER NODES": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the serialized cluster configuration."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the serialized cluster configuration."
   ],
   "CLUSTER REPLICAS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
+    "[Array reply](../topics/protocol.md#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
   ],
   "CLUSTER REPLICATE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER RESET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER SAVECONFIG": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER SET-CONFIG-EPOCH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER SETSLOT": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): all the sub-commands return `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): all the sub-commands return `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER SHARDS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of a map of hash ranges and shard nodes describing individual shards."
+    "[Array reply](../topics/protocol.md#arrays): a nested list of a map of hash ranges and shard nodes describing individual shards."
   ],
   "CLUSTER SLAVES": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
+    "[Array reply](../topics/protocol.md#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
   ],
   "CLUSTER SLOTS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): nested list of slot ranges with networking information."
+    "[Array reply](../topics/protocol.md#arrays): nested list of slot ranges with networking information."
   ],
   "COMMAND": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of command details. The order of the commands in the array is random."
+    "[Array reply](../topics/protocol.md#arrays): a nested list of command details. The order of the commands in the array is random."
   ],
   "COMMAND COUNT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of commands returned by `COMMAND`."
+    "[Integer reply](../topics/protocol.md#integers): the number of commands returned by `COMMAND`."
   ],
   "COMMAND DOCS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a map, as a flattened array, where each key is a command name, and each value is the documentary information."
+    "[Array reply](../topics/protocol.md#arrays): a map, as a flattened array, where each key is a command name, and each value is the documentary information."
   ],
   "COMMAND GETKEYS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): list of keys from the given command."
+    "[Array reply](../topics/protocol.md#arrays): list of keys from the given command."
   ],
   "COMMAND GETKEYSANDFLAGS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys from the given command and their usage flags."
+    "[Array reply](../topics/protocol.md#arrays): a list of keys from the given command and their usage flags."
   ],
   "COMMAND HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "COMMAND INFO": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of command details."
+    "[Array reply](../topics/protocol.md#arrays): a nested list of command details."
   ],
   "COMMAND LIST": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of command names."
+    "[Array reply](../topics/protocol.md#arrays): a list of command names."
   ],
   "CONFIG": [],
   "CONFIG GET": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of configuration parameters matching the provided arguments."
+    "[Array reply](../topics/protocol.md#arrays): a list of configuration parameters matching the provided arguments."
   ],
   "CONFIG HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "CONFIG RESETSTAT": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "CONFIG REWRITE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when the configuration was rewritten properly. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` when the configuration was rewritten properly. Otherwise an error is returned."
   ],
   "CONFIG SET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when the configuration was set properly. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` when the configuration was set properly. Otherwise an error is returned."
   ],
   "COPY": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _source_ was copied.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _source_ was not copied."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if _source_ was copied.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if _source_ was not copied."
   ],
   "DBSIZE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys in the currently-selected database."
+    "[Integer reply](../topics/protocol.md#integers): the number of keys in the currently-selected database."
   ],
   "DEBUG": [],
   "DECR": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after decrementing it."
+    "[Integer reply](../topics/protocol.md#integers): the value of the key after decrementing it."
   ],
   "DECRBY": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after decrementing it."
+    "[Integer reply](../topics/protocol.md#integers): the value of the key after decrementing it."
   ],
   "DEL": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that were removed."
+    "[Integer reply](../topics/protocol.md#integers): the number of keys that were removed."
   ],
   "DISCARD": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "DUMP": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The serialized value of the key.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): the key does not exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): The serialized value of the key.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): the key does not exist."
   ],
   "ECHO": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the given string."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the given string."
   ],
   "EVAL": [
     "The return value depends on the script that was executed."
@@ -374,30 +374,30 @@
   ],
   "EXEC": [
     "One of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): each element being the reply to each of the commands in the atomic transaction.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): the transaction was aborted because a `WATCH`ed key was touched."
+    "* [Array reply](../topics/protocol.md#arrays): each element being the reply to each of the commands in the atomic transaction.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): the transaction was aborted because a `WATCH`ed key was touched."
   ],
   "EXISTS": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that exist from those specified as arguments."
+    "[Integer reply](../topics/protocol.md#integers): the number of keys that exist from those specified as arguments."
   ],
   "EXPIRE": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the timeout was set."
   ],
   "EXPIREAT": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the timeout was set."
   ],
   "EXPIRETIME": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the expiration Unix timestamp in seconds.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration time.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+    "* [Integer reply](../topics/protocol.md#integers): the expiration Unix timestamp in seconds.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` if the key exists but has no associated expiration time.",
+    "* [Integer reply](../topics/protocol.md#integers): `-2` if the key does not exist."
   ],
   "FAILOVER": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was accepted and a coordinated failover is in progress. An error if the operation cannot be executed."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was accepted and a coordinated failover is in progress. An error if the operation cannot be executed."
   ],
   "FCALL": [
     "The return value depends on the function that was executed."
@@ -406,57 +406,57 @@
     "The return value depends on the function that was executed."
   ],
   "FLUSHALL": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FLUSHDB": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FUNCTION": [],
   "FUNCTION DELETE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FUNCTION DUMP": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the serialized payload"
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the serialized payload"
   ],
   "FUNCTION FLUSH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FUNCTION HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions"
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions"
   ],
   "FUNCTION KILL": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FUNCTION LIST": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): information about functions and libraries."
+    "[Array reply](../topics/protocol.md#arrays): information about functions and libraries."
   ],
   "FUNCTION LOAD": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the library name that was loaded."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the library name that was loaded."
   ],
   "FUNCTION RESTORE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FUNCTION STATS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): information about the function that's currently running and information about the available execution engines."
+    "[Array reply](../topics/protocol.md#arrays): information about the function that's currently running and information about the available execution engines."
   ],
   "GEOADD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): When used without optional arguments, the number of elements added to the sorted set (excluding score updates).  If the CH option is specified, the number of elements that were changed (added or updated)."
+    "[Integer reply](../topics/protocol.md#integers): When used without optional arguments, the number of elements added to the sorted set (excluding score updates).  If the CH option is specified, the number of elements that were changed (added or updated)."
   ],
   "GEODIST": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): one or both of the elements are missing.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): distance as a double (represented as a string) in the specified units."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): one or both of the elements are missing.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): distance as a double (represented as a string) in the specified units."
   ],
   "GEOHASH": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array where each element is the Geohash corresponding to each member name passed as an argument to the command."
+    "[Array reply](../topics/protocol.md#arrays): an array where each element is the Geohash corresponding to each member name passed as an argument to the command."
   ],
   "GEOPOS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): An array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command. Non-existing elements are reported as [Nil reply](/docs/reference/protocol-spec#bulk-strings) elements of the array."
+    "[Array reply](../topics/protocol.md#arrays): An array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command. Non-existing elements are reported as [Nil reply](../topics/protocol.md#bulk-strings) elements of the array."
   ],
   "GEORADIUS": [
     "One of the following:",
-    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
-    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "* If no `WITH*` option is specified, an [Array reply](../topics/protocol.md#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](../topics/protocol.md#arrays) of arrays, where each sub-array represents a single item:",
     "    1. The distance from the center as a floating point number, in the same unit specified in the radius.",
     "    1. The Geohash integer.",
     "    1. The coordinates as a two items x,y array (longitude,latitude).",
@@ -467,366 +467,366 @@
   ],
   "GEORADIUSBYMEMBER": [
     "One of the following:",
-    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
-    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "* If no `WITH*` option is specified, an [Array reply](../topics/protocol.md#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](../topics/protocol.md#arrays) of arrays, where each sub-array represents a single item:",
     "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
     "    * The Geohash integer.",
     "    * The coordinates as a two items x,y array (longitude,latitude)."
   ],
   "GEORADIUSBYMEMBER_RO": [
     "One of the following:",
-    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
-    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "* If no `WITH*` option is specified, an [Array reply](../topics/protocol.md#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](../topics/protocol.md#arrays) of arrays, where each sub-array represents a single item:",
     "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
     "    * The Geohash integer.",
     "    * The coordinates as a two items x,y array (longitude,latitude)."
   ],
   "GEORADIUS_RO": [
     "One of the following:",
-    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
-    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "* If no `WITH*` option is specified, an [Array reply](../topics/protocol.md#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](../topics/protocol.md#arrays) of arrays, where each sub-array represents a single item:",
     "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
     "    * The Geohash integer.",
     "    * The coordinates as a two items x,y array (longitude,latitude)."
   ],
   "GEOSEARCH": [
     "One of the following:",
-    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
-    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "* If no `WITH*` option is specified, an [Array reply](../topics/protocol.md#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](../topics/protocol.md#arrays) of arrays, where each sub-array represents a single item:",
     "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
     "    * The Geohash integer.",
     "    * The coordinates as a two items x,y array (longitude,latitude)."
   ],
   "GEOSEARCHSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set"
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting set"
   ],
   "GET": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the value of the key.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key does not exist."
   ],
   "GETBIT": [
     "The bit value stored at _offset_, one of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0`.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1`."
+    "* [Integer reply](../topics/protocol.md#integers): `0`.",
+    "* [Integer reply](../topics/protocol.md#integers): `1`."
   ],
   "GETDEL": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist or if the key's value type is not a string."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the value of the key.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key does not exist or if the key's value type is not a string."
   ],
   "GETEX": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of `key`",
-    "[Nil reply](/docs/reference/protocol-spec#bulk-strings): if `key` does not exist."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the value of `key`",
+    "[Nil reply](../topics/protocol.md#bulk-strings): if `key` does not exist."
   ],
   "GETRANGE": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): The substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
   ],
   "GETSET": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the old value stored at the key.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the old value stored at the key.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key does not exist."
   ],
   "HDEL": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of fields that were removed from the hash, excluding any specified but non-existing fields."
+    "[Integer reply](../topics/protocol.md#integers): the number of fields that were removed from the hash, excluding any specified but non-existing fields."
   ],
   "HELLO": [
-    "[Map reply](/docs/reference/protocol-spec#maps): a list of server properties.",
-    "[Simple error reply](/docs/reference/protocol-spec#simple-errors): if the `protover` requested does not exist."
+    "[Map reply](../topics/protocol.md#maps): a list of server properties.",
+    "[Simple error reply](../topics/protocol.md#simple-errors): if the `protover` requested does not exist."
   ],
   "HEXISTS": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the hash does not contain the field, or the key does not exist.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the hash contains the field."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the hash does not contain the field, or the key does not exist.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the hash contains the field."
   ],
   "HGET": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The value associated with the field.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): If the field is not present in the hash or key does not exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): The value associated with the field.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): If the field is not present in the hash or key does not exist."
   ],
   "HGETALL": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of fields and their values stored in the hash, or an empty list when key does not exist."
+    "[Array reply](../topics/protocol.md#arrays): a list of fields and their values stored in the hash, or an empty list when key does not exist."
   ],
   "HINCRBY": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the field after the increment operation."
+    "[Integer reply](../topics/protocol.md#integers): the value of the field after the increment operation."
   ],
   "HINCRBYFLOAT": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the field after the increment operation."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the value of the field after the increment operation."
   ],
   "HKEYS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of fields in the hash, or an empty list when the key does not exist"
+    "[Array reply](../topics/protocol.md#arrays): a list of fields in the hash, or an empty list when the key does not exist"
   ],
   "HLEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of fields in the hash, or 0 when the key does not exist."
+    "[Integer reply](../topics/protocol.md#integers): the number of fields in the hash, or 0 when the key does not exist."
   ],
   "HMGET": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values associated with the given fields, in the same order as they are requested."
+    "[Array reply](../topics/protocol.md#arrays): a list of values associated with the given fields, in the same order as they are requested."
   ],
   "HMSET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "HRANDFIELD": [
     "Any of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key doesn't exist",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a single, randomly selected field when the `count` option is not used",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list containing `count` fields when the `count` option is used, or an empty array if the key does not exists.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of fields and their values when `count` and `WITHVALUES` were both used."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key doesn't exist",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): a single, randomly selected field when the `count` option is not used",
+    "* [Array reply](../topics/protocol.md#arrays): a list containing `count` fields when the `count` option is used, or an empty array if the key does not exists.",
+    "* [Array reply](../topics/protocol.md#arrays): a list of fields and their values when `count` and `WITHVALUES` were both used."
   ],
   "HSCAN": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a two-element array.",
-    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
-    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) of field/value pairs that were scanned."
+    "[Array reply](../topics/protocol.md#arrays): a two-element array.",
+    "* The first element is a [Bulk string reply](../topics/protocol.md#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](../topics/protocol.md#arrays) of field/value pairs that were scanned."
   ],
   "HSET": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of fields that were added."
+    "[Integer reply](../topics/protocol.md#integers): the number of fields that were added."
   ],
   "HSETNX": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the field already exists in the hash and no operation was performed.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the field is a new field in the hash and the value was set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the field already exists in the hash and no operation was performed.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the field is a new field in the hash and the value was set."
   ],
   "HSTRLEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the string length of the value associated with the _field_, or zero when the _field_ isn't present in the hash or the _key_ doesn't exist at all."
+    "[Integer reply](../topics/protocol.md#integers): the string length of the value associated with the _field_, or zero when the _field_ isn't present in the hash or the _key_ doesn't exist at all."
   ],
   "HVALS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values in the hash, or an empty list when the key does not exist"
+    "[Array reply](../topics/protocol.md#arrays): a list of values in the hash, or an empty list when the key does not exist"
   ],
   "INCR": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after the increment."
+    "[Integer reply](../topics/protocol.md#integers): the value of the key after the increment."
   ],
   "INCRBY": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after the increment."
+    "[Integer reply](../topics/protocol.md#integers): the value of the key after the increment."
   ],
   "INCRBYFLOAT": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key after the increment."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the value of the key after the increment."
   ],
   "INFO": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a map of info fields, one field per line in the form of `<field>:<value>` where the value can be a comma separated map like `<key>=<val>`. Also contains section header lines starting with `#` and blank lines.",
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): a map of info fields, one field per line in the form of `<field>:<value>` where the value can be a comma separated map like `<key>=<val>`. Also contains section header lines starting with `#` and blank lines.",
     "",
     "Lines can contain a section name (starting with a `#` character) or a property. All the properties are in the form of `field:value` terminated by `\\r\\n`."
   ],
   "KEYS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys matching _pattern_."
+    "[Array reply](../topics/protocol.md#arrays): a list of keys matching _pattern_."
   ],
   "LASTSAVE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): UNIX TIME of the last DB save executed with success."
+    "[Integer reply](../topics/protocol.md#integers): UNIX TIME of the last DB save executed with success."
   ],
   "LATENCY": [],
   "LATENCY DOCTOR": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a human readable latency analysis report."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): a human readable latency analysis report."
   ],
   "LATENCY GRAPH": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): Latency graph"
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): Latency graph"
   ],
   "LATENCY HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "LATENCY HISTOGRAM": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets."
+    "[Array reply](../topics/protocol.md#arrays): a map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets."
   ],
   "LATENCY HISTORY": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array where each element is a two elements array representing the timestamp and the latency of the event."
+    "[Array reply](../topics/protocol.md#arrays): an array where each element is a two elements array representing the timestamp and the latency of the event."
   ],
   "LATENCY LATEST": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array where each element is a four elements array representing the event's name, timestamp, latest and all-time latency measurements."
+    "[Array reply](../topics/protocol.md#arrays): an array where each element is a four elements array representing the event's name, timestamp, latest and all-time latency measurements."
   ],
   "LATENCY RESET": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of event time series that were reset."
+    "[Integer reply](../topics/protocol.md#integers): the number of event time series that were reset."
   ],
   "LCS": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the longest common subsequence.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the length of the longest common subsequence when _LEN_ is given.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): an array with the LCS length and all the ranges in both the strings when _IDX_ is given."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the longest common subsequence.",
+    "* [Integer reply](../topics/protocol.md#integers): the length of the longest common subsequence when _LEN_ is given.",
+    "* [Array reply](../topics/protocol.md#arrays): an array with the LCS length and all the ranges in both the strings when _IDX_ is given."
   ],
   "LINDEX": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when _index_ is out of range.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the requested element."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): when _index_ is out of range.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the requested element."
   ],
   "LINSERT": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the list length after a successful insert operation.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` when the key doesn't exist.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` when the pivot wasn't found."
+    "* [Integer reply](../topics/protocol.md#integers): the list length after a successful insert operation.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` when the key doesn't exist.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` when the pivot wasn't found."
   ],
   "LLEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list."
+    "[Integer reply](../topics/protocol.md#integers): the length of the list."
   ],
   "LMOVE": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped and pushed."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the element being popped and pushed."
   ],
   "LMPOP": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if no element could be popped.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped and the second element being an array of elements."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if no element could be popped.",
+    "* [Array reply](../topics/protocol.md#arrays): a two-element array with the first element being the name of the key from which elements were popped and the second element being an array of elements."
   ],
   "LOLWUT": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a string containing generative computer art and the Valkey version."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): a string containing generative computer art and the Valkey version."
   ],
   "LPOP": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the value of the first element.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a list of popped elements."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key does not exist.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): when called without the _count_ argument, the value of the first element.",
+    "* [Array reply](../topics/protocol.md#arrays): when called with the _count_ argument, a list of popped elements."
   ],
   "LPOS": [
     "Any of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if there is no matching element.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): an integer representing the matching element.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): If the COUNT option is given, an array of integers representing the matching elements (or an empty array if there are no matches)."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if there is no matching element.",
+    "* [Integer reply](../topics/protocol.md#integers): an integer representing the matching element.",
+    "* [Array reply](../topics/protocol.md#arrays): If the COUNT option is given, an array of integers representing the matching elements (or an empty array if there are no matches)."
   ],
   "LPUSH": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+    "[Integer reply](../topics/protocol.md#integers): the length of the list after the push operation."
   ],
   "LPUSHX": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+    "[Integer reply](../topics/protocol.md#integers): the length of the list after the push operation."
   ],
   "LRANGE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of elements in the specified range, or an empty array if the key doesn't exist."
+    "[Array reply](../topics/protocol.md#arrays): a list of elements in the specified range, or an empty array if the key doesn't exist."
   ],
   "LREM": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of removed elements."
+    "[Integer reply](../topics/protocol.md#integers): the number of removed elements."
   ],
   "LSET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "LTRIM": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "MEMORY": [],
   "MEMORY DOCTOR": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a memory problems report."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): a memory problems report."
   ],
   "MEMORY HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions"
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions"
   ],
   "MEMORY MALLOC-STATS": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the memory allocator's internal statistics report"
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the memory allocator's internal statistics report"
   ],
   "MEMORY PURGE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "MEMORY STATS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of memory usage metrics and their values."
+    "[Array reply](../topics/protocol.md#arrays): a nested list of memory usage metrics and their values."
   ],
   "MEMORY USAGE": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the memory usage in bytes.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist."
+    "* [Integer reply](../topics/protocol.md#integers): the memory usage in bytes.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key does not exist."
   ],
   "MGET": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values at the specified keys."
+    "[Array reply](../topics/protocol.md#arrays): a list of values at the specified keys."
   ],
   "MIGRATE": [
     "One of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `NOKEY` when no keys were found in the source instance."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK` on success.",
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `NOKEY` when no keys were found in the source instance."
   ],
   "MODULE": [],
   "MODULE HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "MODULE LIST": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): list of loaded modules. Each element in the list represents a represents a module, and is in itself a list of property names and their values. The following properties is reported for each loaded module:",
+    "[Array reply](../topics/protocol.md#arrays): list of loaded modules. Each element in the list represents a represents a module, and is in itself a list of property names and their values. The following properties is reported for each loaded module:",
     "* name: the name of the module.",
     "* ver: the version of the module."
   ],
   "MODULE LOAD": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was loaded."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the module was loaded."
   ],
   "MODULE LOADEX": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was loaded."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the module was loaded."
   ],
   "MODULE UNLOAD": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was unloaded."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the module was unloaded."
   ],
   "MONITOR": [
     "**Non-standard return value**. Dumps the received commands in an infinite flow."
   ],
   "MOVE": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _key_ was moved.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _key_ wasn't moved."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if _key_ was moved.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if _key_ wasn't moved."
   ],
   "MSET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): always `OK` because `MSET` can't fail."
+    "[Simple string reply](../topics/protocol.md#simple-strings): always `OK` because `MSET` can't fail."
   ],
   "MSETNX": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if no key was set (at least one key already existed).",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if all the keys were set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if no key was set (at least one key already existed).",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if all the keys were set."
   ],
   "MULTI": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "OBJECT": [],
   "OBJECT ENCODING": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key doesn't exist.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the encoding of the object."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key doesn't exist.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the encoding of the object."
   ],
   "OBJECT FREQ": [
     "One of the following:",
-    "[Integer reply](/docs/reference/protocol-spec#integers): the counter's value.",
-    "[Nil reply](/docs/reference/protocol-spec#bulk-strings): if _key_ doesn't exist."
+    "[Integer reply](../topics/protocol.md#integers): the counter's value.",
+    "[Nil reply](../topics/protocol.md#bulk-strings): if _key_ doesn't exist."
   ],
   "OBJECT HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions"
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions"
   ],
   "OBJECT IDLETIME": [
     "One of the following:",
-    "[Integer reply](/docs/reference/protocol-spec#integers): the idle time in seconds.",
-    "[Nil reply](/docs/reference/protocol-spec#bulk-strings): if _key_ doesn't exist."
+    "[Integer reply](../topics/protocol.md#integers): the idle time in seconds.",
+    "[Nil reply](../topics/protocol.md#bulk-strings): if _key_ doesn't exist."
   ],
   "OBJECT REFCOUNT": [
     "One of the following:",
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of references.",
-    "[Nil reply](/docs/reference/protocol-spec#bulk-strings): if _key_ doesn't exist."
+    "[Integer reply](../topics/protocol.md#integers): the number of references.",
+    "[Nil reply](../topics/protocol.md#bulk-strings): if _key_ doesn't exist."
   ],
   "PERSIST": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _key_ does not exist or does not have an associated timeout.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout has been removed."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if _key_ does not exist or does not have an associated timeout.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the timeout has been removed."
   ],
   "PEXPIRE": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0`if the timeout was not set. For example, if the key doesn't exist, or the operation skipped because of the provided arguments.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+    "* [Integer reply](../topics/protocol.md#integers): `0`if the timeout was not set. For example, if the key doesn't exist, or the operation skipped because of the provided arguments.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the timeout was set."
   ],
   "PEXPIREAT": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set. For example, if the key doesn't exist, or the operation was skipped due to the provided arguments."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the timeout was set.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the timeout was not set. For example, if the key doesn't exist, or the operation was skipped due to the provided arguments."
   ],
   "PEXPIRETIME": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): Expiration Unix timestamp in milliseconds.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration time.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+    "* [Integer reply](../topics/protocol.md#integers): Expiration Unix timestamp in milliseconds.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` if the key exists but has no associated expiration time.",
+    "* [Integer reply](../topics/protocol.md#integers): `-2` if the key does not exist."
   ],
   "PFADD": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if at least one HyperLogLog internal register was altered.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if no HyperLogLog internal registers were altered."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if at least one HyperLogLog internal register was altered.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if no HyperLogLog internal registers were altered."
   ],
   "PFCOUNT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the approximated number of unique elements observed via `PFADD`."
+    "[Integer reply](../topics/protocol.md#integers): the approximated number of unique elements observed via `PFADD`."
   ],
   "PFDEBUG": [],
   "PFMERGE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "PFSELFTEST": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "PING": [
     "Any of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `PONG` when no argument is provided.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the provided argument."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `PONG` when no argument is provided.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the provided argument."
   ],
   "PSETEX": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "PSUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each pattern, one message with the first element being the string `psubscribe` is pushed as a confirmation that the command succeeded."
@@ -836,485 +836,485 @@
   ],
   "PTTL": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): TTL in milliseconds.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+    "* [Integer reply](../topics/protocol.md#integers): TTL in milliseconds.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` if the key exists but has no associated expiration.",
+    "* [Integer reply](../topics/protocol.md#integers): `-2` if the key does not exist."
   ],
   "PUBLISH": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of clients that received the message. Note that in a Valkey Cluster, only clients that are connected to the same node as the publishing client are included in the count."
+    "[Integer reply](../topics/protocol.md#integers): the number of clients that received the message. Note that in a Valkey Cluster, only clients that are connected to the same node as the publishing client are included in the count."
   ],
   "PUBSUB": [],
   "PUBSUB CHANNELS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of active channels, optionally matching the specified pattern."
+    "[Array reply](../topics/protocol.md#arrays): a list of active channels, optionally matching the specified pattern."
   ],
   "PUBSUB HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "PUBSUB NUMPAT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of patterns all the clients are subscribed to."
+    "[Integer reply](../topics/protocol.md#integers): the number of patterns all the clients are subscribed to."
   ],
   "PUBSUB NUMSUB": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): the number of subscribers per channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers"
+    "[Array reply](../topics/protocol.md#arrays): the number of subscribers per channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers"
   ],
   "PUBSUB SHARDCHANNELS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of active channels, optionally matching the specified pattern."
+    "[Array reply](../topics/protocol.md#arrays): a list of active channels, optionally matching the specified pattern."
   ],
   "PUBSUB SHARDNUMSUB": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): the number of subscribers per shard channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers."
+    "[Array reply](../topics/protocol.md#arrays): the number of subscribers per shard channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers."
   ],
   "PUNSUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each pattern, one message with the first element being the string `punsubscribe` is pushed as a confirmation that the command succeeded."
   ],
   "QUIT": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): OK."
+    "[Simple string reply](../topics/protocol.md#simple-strings): OK."
   ],
   "RANDOMKEY": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when the database is empty.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a random key in database."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): when the database is empty.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): a random key in database."
   ],
   "READONLY": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "READWRITE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "RENAME": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "RENAMENX": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _key_ was renamed to _newkey_.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _newkey_ already exists."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if _key_ was renamed to _newkey_.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if _newkey_ already exists."
   ],
   "REPLCONF": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "REPLICAOF": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "RESET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `RESET`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `RESET`."
   ],
   "RESTORE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "RESTORE-ASKING": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "ROLE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): where the first element is one of `master`, `slave`, or `sentinel`, and the additional elements are role-specific as illustrated above."
+    "[Array reply](../topics/protocol.md#arrays): where the first element is one of `master`, `slave`, or `sentinel`, and the additional elements are role-specific as illustrated above."
   ],
   "RPOP": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the value of the last element.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a list of popped elements."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key does not exist.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): when called without the _count_ argument, the value of the last element.",
+    "* [Array reply](../topics/protocol.md#arrays): when called with the _count_ argument, a list of popped elements."
   ],
   "RPOPLPUSH": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped and pushed.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the source list is empty."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the element being popped and pushed.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the source list is empty."
   ],
   "RPUSH": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+    "[Integer reply](../topics/protocol.md#integers): the length of the list after the push operation."
   ],
   "RPUSHX": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+    "[Integer reply](../topics/protocol.md#integers): the length of the list after the push operation."
   ],
   "SADD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements that were added to the set, not including all the elements already present in the set."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements that were added to the set, not including all the elements already present in the set."
   ],
   "SAVE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SCAN": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, an array with two elements.",
-    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
-    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) with the names of scanned keys."
+    "[Array reply](../topics/protocol.md#arrays): specifically, an array with two elements.",
+    "* The first element is a [Bulk string reply](../topics/protocol.md#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](../topics/protocol.md#arrays) with the names of scanned keys."
   ],
   "SCARD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the cardinality (number of elements) of the set, or `0` if the key does not exist."
+    "[Integer reply](../topics/protocol.md#integers): the cardinality (number of elements) of the set, or `0` if the key does not exist."
   ],
   "SCRIPT": [],
   "SCRIPT DEBUG": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SCRIPT EXISTS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array of integers that correspond to the specified SHA1 digest arguments."
+    "[Array reply](../topics/protocol.md#arrays): an array of integers that correspond to the specified SHA1 digest arguments."
   ],
   "SCRIPT FLUSH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SCRIPT HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "SCRIPT KILL": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SCRIPT LOAD": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the SHA1 digest of the script added into the script cache."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the SHA1 digest of the script added into the script cache."
   ],
   "SDIFF": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list with members of the resulting set."
+    "[Array reply](../topics/protocol.md#arrays): a list with members of the resulting set."
   ],
   "SDIFFSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting set."
   ],
   "SELECT": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SET": [
     "Any of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): `GET` not given: Operation was aborted (conflict with one of the `XX`/`NX` options).",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. `GET` not given: The key was set.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): `GET` given: The key didn't exist before the `SET`.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `GET` given: The previous value of the key."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): `GET` not given: Operation was aborted (conflict with one of the `XX`/`NX` options).",
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK`. `GET` not given: The key was set.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): `GET` given: The key didn't exist before the `SET`.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): `GET` given: The previous value of the key."
   ],
   "SETBIT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the original bit value stored at _offset_."
+    "[Integer reply](../topics/protocol.md#integers): the original bit value stored at _offset_."
   ],
   "SETEX": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SETNX": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the key was not set.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the key was set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the key was not set.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the key was set."
   ],
   "SETRANGE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string after it was modified by the command."
+    "[Integer reply](../topics/protocol.md#integers): the length of the string after it was modified by the command."
   ],
   "SHUTDOWN": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if _ABORT_ was specified and shutdown was aborted. On successful shutdown, nothing is returned because the server quits and the connection is closed. On failure, an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if _ABORT_ was specified and shutdown was aborted. On successful shutdown, nothing is returned because the server quits and the connection is closed. On failure, an error is returned."
   ],
   "SINTER": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list with the members of the resulting set."
+    "[Array reply](../topics/protocol.md#arrays): a list with the members of the resulting set."
   ],
   "SINTERCARD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting intersection."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting intersection."
   ],
   "SINTERSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting set."
   ],
   "SISMEMBER": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the element is not a member of the set, or when the key does not exist.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the element is a member of the set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the element is not a member of the set, or when the key does not exist.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the element is a member of the set."
   ],
   "SLAVEOF": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SLOWLOG": [],
   "SLOWLOG GET": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of slow log entries per the above format."
+    "[Array reply](../topics/protocol.md#arrays): a list of slow log entries per the above format."
   ],
   "SLOWLOG HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "SLOWLOG LEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries in the slow log."
+    "[Integer reply](../topics/protocol.md#integers): the number of entries in the slow log."
   ],
   "SLOWLOG RESET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SMEMBERS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): all members of the set."
+    "[Array reply](../topics/protocol.md#arrays): all members of the set."
   ],
   "SMISMEMBER": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list representing the membership of the given elements, in the same order as they are requested."
+    "[Array reply](../topics/protocol.md#arrays): a list representing the membership of the given elements, in the same order as they are requested."
   ],
   "SMOVE": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the element is moved.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the element is not a member of _source_ and no operation was performed."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the element is moved.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the element is not a member of _source_ and no operation was performed."
   ],
   "SORT": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): without passing the _STORE_ option, the command returns a list of sorted elements.",
-    "[Integer reply](/docs/reference/protocol-spec#integers): when the _STORE_ option is specified, the command returns the number of sorted elements in the destination list."
+    "[Array reply](../topics/protocol.md#arrays): without passing the _STORE_ option, the command returns a list of sorted elements.",
+    "[Integer reply](../topics/protocol.md#integers): when the _STORE_ option is specified, the command returns the number of sorted elements in the destination list."
   ],
   "SORT_RO": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sorted elements."
+    "[Array reply](../topics/protocol.md#arrays): a list of sorted elements."
   ],
   "SPOP": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the removed member.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a list of the removed members."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key does not exist.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): when called without the _count_ argument, the removed member.",
+    "* [Array reply](../topics/protocol.md#arrays): when called with the _count_ argument, a list of the removed members."
   ],
   "SPUBLISH": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of clients that received the message. Note that in a Valkey Cluster, only clients that are connected to the same node as the publishing client are included in the count"
+    "[Integer reply](../topics/protocol.md#integers): the number of clients that received the message. Note that in a Valkey Cluster, only clients that are connected to the same node as the publishing client are included in the count"
   ],
   "SRANDMEMBER": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or a [Nil reply](/docs/reference/protocol-spec#bulk-strings) when _key_ doesn't exist.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when the optional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or a [Nil reply](../topics/protocol.md#bulk-strings) when _key_ doesn't exist.",
+    "* [Array reply](../topics/protocol.md#arrays): when the optional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist."
   ],
   "SREM": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members that were removed from the set, not including non existing members."
+    "[Integer reply](../topics/protocol.md#integers): the number of members that were removed from the set, not including non existing members."
   ],
   "SSCAN": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, an array with two elements:",
-    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
-    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) with the names of scanned members."
+    "[Array reply](../topics/protocol.md#arrays): specifically, an array with two elements:",
+    "* The first element is a [Bulk string reply](../topics/protocol.md#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](../topics/protocol.md#arrays) with the names of scanned members."
   ],
   "SSUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each shard channel, one message with the first element being the string `ssubscribe` is pushed as a confirmation that the command succeeded. Note that this command can also return a -MOVED redirect."
   ],
   "STRLEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string stored at key, or 0 when the key does not exist."
+    "[Integer reply](../topics/protocol.md#integers): the length of the string stored at key, or 0 when the key does not exist."
   ],
   "SUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each channel, one message with the first element being the string `subscribe` is pushed as a confirmation that the command succeeded."
   ],
   "SUBSTR": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
   ],
   "SUNION": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list with members of the resulting set."
+    "[Array reply](../topics/protocol.md#arrays): a list with members of the resulting set."
   ],
   "SUNIONSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting set."
   ],
   "SUNSUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each shard channel, one message with the first element being the string `sunsubscribe` is pushed as a confirmation that the command succeeded."
   ],
   "SWAPDB": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SYNC": [
     "**Non-standard return value**, a bulk transfer of the data followed by `PING` and write requests from the master."
   ],
   "TIME": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, a two-element array consisting of the Unix timestamp in seconds and the microseconds' count."
+    "[Array reply](../topics/protocol.md#arrays): specifically, a two-element array consisting of the Unix timestamp in seconds and the microseconds' count."
   ],
   "TOUCH": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of touched keys."
+    "[Integer reply](../topics/protocol.md#integers): the number of touched keys."
   ],
   "TTL": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): TTL in seconds.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+    "* [Integer reply](../topics/protocol.md#integers): TTL in seconds.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` if the key exists but has no associated expiration.",
+    "* [Integer reply](../topics/protocol.md#integers): `-2` if the key does not exist."
   ],
   "TYPE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): the type of _key_, or `none` when _key_ doesn't exist."
+    "[Simple string reply](../topics/protocol.md#simple-strings): the type of _key_, or `none` when _key_ doesn't exist."
   ],
   "UNLINK": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that were unlinked."
+    "[Integer reply](../topics/protocol.md#integers): the number of keys that were unlinked."
   ],
   "UNSUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each channel, one message with the first element being the string `unsubscribe` is pushed as a confirmation that the command succeeded."
   ],
   "UNWATCH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "WAIT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the command returns the number of replicas reached by all the writes performed in the context of the current connection."
+    "[Integer reply](../topics/protocol.md#integers): the command returns the number of replicas reached by all the writes performed in the context of the current connection."
   ],
   "WAITAOF": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): The command returns an array of two integers:",
+    "[Array reply](../topics/protocol.md#arrays): The command returns an array of two integers:",
     "1. The first is the number of local Redises (0 or 1) that have fsynced to AOF  all writes performed in the context of the current connection",
     "2. The second is the number of replicas that have acknowledged doing the same."
   ],
   "WATCH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "XACK": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged."
+    "[Integer reply](../topics/protocol.md#integers): The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged."
   ],
   "XADD": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The ID of the added entry. The ID is the one automatically generated if an asterisk (`*`) is passed as the _id_ argument, otherwise the command just returns the same ID specified by the user during insertion.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the NOMKSTREAM option is given and the key doesn't exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): The ID of the added entry. The ID is the one automatically generated if an asterisk (`*`) is passed as the _id_ argument, otherwise the command just returns the same ID specified by the user during insertion.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the NOMKSTREAM option is given and the key doesn't exist."
   ],
   "XAUTOCLAIM": [
-    "[Array reply](/docs/reference/protocol-spec#arrays), specifically, an array with three elements:",
+    "[Array reply](../topics/protocol.md#arrays), specifically, an array with three elements:",
     "1. A stream ID to be used as the _start_ argument for the next call to XAUTOCLAIM.",
-    "2. An [Array reply](/docs/reference/protocol-spec#arrays) containing all the successfully claimed messages in the same format as `XRANGE`.",
-    "3. An [Array reply](/docs/reference/protocol-spec#arrays) containing message IDs that no longer exist in the stream, and were deleted from the PEL in which they were found."
+    "2. An [Array reply](../topics/protocol.md#arrays) containing all the successfully claimed messages in the same format as `XRANGE`.",
+    "3. An [Array reply](../topics/protocol.md#arrays) containing message IDs that no longer exist in the stream, and were deleted from the PEL in which they were found."
   ],
   "XCLAIM": [
     "Any of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when the _JUSTID_ option is specified, an array of IDs of messages successfully claimed.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of stream entries, each of which contains an array of two elements, the entry ID and the entry data itself."
+    "* [Array reply](../topics/protocol.md#arrays): when the _JUSTID_ option is specified, an array of IDs of messages successfully claimed.",
+    "* [Array reply](../topics/protocol.md#arrays): an array of stream entries, each of which contains an array of two elements, the entry ID and the entry data itself."
   ],
   "XDEL": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries that were deleted."
+    "[Integer reply](../topics/protocol.md#integers): the number of entries that were deleted."
   ],
   "XGROUP": [],
   "XGROUP CREATE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "XGROUP CREATECONSUMER": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of created consumers, either 0 or 1."
+    "[Integer reply](../topics/protocol.md#integers): the number of created consumers, either 0 or 1."
   ],
   "XGROUP DELCONSUMER": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of pending messages the consumer had before it was deleted."
+    "[Integer reply](../topics/protocol.md#integers): the number of pending messages the consumer had before it was deleted."
   ],
   "XGROUP DESTROY": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of destroyed consumer groups, either 0 or 1."
+    "[Integer reply](../topics/protocol.md#integers): the number of destroyed consumer groups, either 0 or 1."
   ],
   "XGROUP HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "XGROUP SETID": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "XINFO": [],
   "XINFO CONSUMERS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of consumers and their attributes."
+    "[Array reply](../topics/protocol.md#arrays): a list of consumers and their attributes."
   ],
   "XINFO GROUPS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of consumer groups."
+    "[Array reply](../topics/protocol.md#arrays): a list of consumer groups."
   ],
   "XINFO HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "XINFO STREAM": [
     "One of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when the _FULL_ argument is used, a list of information about a stream in summary form.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when the _FULL_ argument is used, a list of information about a stream in extended form."
+    "* [Array reply](../topics/protocol.md#arrays): when the _FULL_ argument is used, a list of information about a stream in summary form.",
+    "* [Array reply](../topics/protocol.md#arrays): when the _FULL_ argument is used, a list of information about a stream in extended form."
   ],
   "XLEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries of the stream at _key_."
+    "[Integer reply](../topics/protocol.md#integers): the number of entries of the stream at _key_."
   ],
   "XPENDING": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): different data depending on the way XPENDING is called, as explained on this page."
+    "* [Array reply](../topics/protocol.md#arrays): different data depending on the way XPENDING is called, as explained on this page."
   ],
   "XRANGE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of stream entries with IDs matching the specified range."
+    "[Array reply](../topics/protocol.md#arrays): a list of stream entries with IDs matching the specified range."
   ],
   "XREAD": [
     "One of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): an array where each element is an array composed of a two elements containing the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
+    "* [Array reply](../topics/protocol.md#arrays): an array where each element is an array composed of a two elements containing the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
   ],
   "XREADGROUP": [
     "One of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): an array where each element is an array composed of a two elements containing the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
+    "* [Array reply](../topics/protocol.md#arrays): an array where each element is an array composed of a two elements containing the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
   ],
   "XREVRANGE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): The command returns the entries with IDs matching the specified range. The returned entries are complete, which means that the ID and all the fields they are composed of are returned. Moreover, the entries are returned with their fields and values in the same order as `XADD` added them."
+    "[Array reply](../topics/protocol.md#arrays): The command returns the entries with IDs matching the specified range. The returned entries are complete, which means that the ID and all the fields they are composed of are returned. Moreover, the entries are returned with their fields and values in the same order as `XADD` added them."
   ],
   "XSETID": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "XTRIM": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The number of entries deleted from the stream."
+    "[Integer reply](../topics/protocol.md#integers): The number of entries deleted from the stream."
   ],
   "ZADD": [
     "Any of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new members when the _CH_ option is not used.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new or updated members when the _CH_ option is used.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the updated score of the member when the _INCR_ option is used."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options.",
+    "* [Integer reply](../topics/protocol.md#integers): the number of new members when the _CH_ option is not used.",
+    "* [Integer reply](../topics/protocol.md#integers): the number of new or updated members when the _CH_ option is used.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the updated score of the member when the _INCR_ option is used."
   ],
   "ZCARD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the cardinality (number of members) of the sorted set, or 0 if the key doesn't exist."
+    "[Integer reply](../topics/protocol.md#integers): the cardinality (number of members) of the sorted set, or 0 if the key doesn't exist."
   ],
   "ZCOUNT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the specified score range."
+    "[Integer reply](../topics/protocol.md#integers): the number of members in the specified score range."
   ],
   "ZDIFF": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the result of the difference including, optionally, scores when the _WITHSCORES_ option is used."
+    "* [Array reply](../topics/protocol.md#arrays): the result of the difference including, optionally, scores when the _WITHSCORES_ option is used."
   ],
   "ZDIFFSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting sorted set at _destination_."
+    "[Integer reply](../topics/protocol.md#integers): the number of members in the resulting sorted set at _destination_."
   ],
   "ZINCRBY": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the new score of _member_ as a double precision floating point number."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the new score of _member_ as a double precision floating point number."
   ],
   "ZINTER": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the result of the intersection including, optionally, scores when the _WITHSCORES_ option is used."
+    "* [Array reply](../topics/protocol.md#arrays): the result of the intersection including, optionally, scores when the _WITHSCORES_ option is used."
   ],
   "ZINTERCARD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting intersection."
+    "[Integer reply](../topics/protocol.md#integers): the number of members in the resulting intersection."
   ],
   "ZINTERSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting sorted set at the _destination_."
+    "[Integer reply](../topics/protocol.md#integers): the number of members in the resulting sorted set at the _destination_."
   ],
   "ZLEXCOUNT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the specified score range."
+    "[Integer reply](../topics/protocol.md#integers): the number of members in the specified score range."
   ],
   "ZMPOP": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): when no element could be popped.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): when no element could be popped.",
+    "* [Array reply](../topics/protocol.md#arrays): A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
   ],
   "ZMSCORE": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the member does not exist in the sorted set.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) _member_ scores as double-precision floating point numbers."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the member does not exist in the sorted set.",
+    "* [Array reply](../topics/protocol.md#arrays): a list of [Bulk string reply](../topics/protocol.md#bulk-strings) _member_ scores as double-precision floating point numbers."
   ],
   "ZPOPMAX": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of popped elements and scores."
+    "* [Array reply](../topics/protocol.md#arrays): a list of popped elements and scores."
   ],
   "ZPOPMIN": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of popped elements and scores."
+    "* [Array reply](../topics/protocol.md#arrays): a list of popped elements and scores."
   ],
   "ZRANDMEMBER": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or [Nil reply](/docs/reference/protocol-spec#bulk-strings) when _key_ doesn't exist.",
-    "[Array reply](/docs/reference/protocol-spec#arrays): when the additional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist. If the _WITHSCORES_ modifier is used, the reply is a list of members and their scores from the sorted set."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or [Nil reply](../topics/protocol.md#bulk-strings) when _key_ doesn't exist.",
+    "[Array reply](../topics/protocol.md#arrays): when the additional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist. If the _WITHSCORES_ modifier is used, the reply is a list of members and their scores from the sorted set."
   ],
   "ZRANGE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given."
+    "[Array reply](../topics/protocol.md#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given."
   ],
   "ZRANGEBYLEX": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of elements in the specified score range."
+    "[Array reply](../topics/protocol.md#arrays): a list of elements in the specified score range."
   ],
   "ZRANGEBYSCORE": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of the members with, optionally, their scores in the specified score range."
+    "* [Array reply](../topics/protocol.md#arrays): a list of the members with, optionally, their scores in the specified score range."
   ],
   "ZRANGESTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting sorted set."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting sorted set."
   ],
   "ZRANK": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist or the member does not exist in the sorted set.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the rank of the member when _WITHSCORE_ is not used.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the rank and score of the member when _WITHSCORE_ is used."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key does not exist or the member does not exist in the sorted set.",
+    "* [Integer reply](../topics/protocol.md#integers): the rank of the member when _WITHSCORE_ is not used.",
+    "* [Array reply](../topics/protocol.md#arrays): the rank and score of the member when _WITHSCORE_ is used."
   ],
   "ZREM": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members removed from the sorted set, not including non-existing members."
+    "[Integer reply](../topics/protocol.md#integers): the number of members removed from the sorted set, not including non-existing members."
   ],
   "ZREMRANGEBYLEX": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members removed."
+    "[Integer reply](../topics/protocol.md#integers): the number of members removed."
   ],
   "ZREMRANGEBYRANK": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members removed."
+    "[Integer reply](../topics/protocol.md#integers): the number of members removed."
   ],
   "ZREMRANGEBYSCORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members removed."
+    "[Integer reply](../topics/protocol.md#integers): the number of members removed."
   ],
   "ZREVRANGE": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of members in the specified range, optionally with their scores if _WITHSCORE_ was used."
+    "* [Array reply](../topics/protocol.md#arrays): a list of members in the specified range, optionally with their scores if _WITHSCORE_ was used."
   ],
   "ZREVRANGEBYLEX": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of members in the specified score range."
+    "[Array reply](../topics/protocol.md#arrays): a list of members in the specified score range."
   ],
   "ZREVRANGEBYSCORE": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of the members and, optionally, their scores in the specified score range."
+    "* [Array reply](../topics/protocol.md#arrays): a list of the members and, optionally, their scores in the specified score range."
   ],
   "ZREVRANK": [
     "One of the following:",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if the key does not exist or the member does not exist in the sorted set.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): The rank of the member when _WITHSCORE_ is not used.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): The rank and score of the member when _WITHSCORE_ is used."
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if the key does not exist or the member does not exist in the sorted set.",
+    "* [Integer reply](../topics/protocol.md#integers): The rank of the member when _WITHSCORE_ is not used.",
+    "* [Array reply](../topics/protocol.md#arrays): The rank and score of the member when _WITHSCORE_ is used."
   ],
   "ZSCAN": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): cursor and scan response in array form."
+    "[Array reply](../topics/protocol.md#arrays): cursor and scan response in array form."
   ],
   "ZSCORE": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the score of the member (a double-precision floating point number), represented as a string.",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if _member_ does not exist in the sorted set, or the key does not exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the score of the member (a double-precision floating point number), represented as a string.",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if _member_ does not exist in the sorted set, or the key does not exist."
   ],
   "ZUNION": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): the result of the union with, optionally, their scores when _WITHSCORES_ is used."
+    "[Array reply](../topics/protocol.md#arrays): the result of the union with, optionally, their scores when _WITHSCORES_ is used."
   ],
   "ZUNIONSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting sorted set."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting sorted set."
   ]
 }

--- a/resp3_replies.json
+++ b/resp3_replies.json
@@ -2,94 +2,94 @@
   "ACL": [],
   "ACL CAT": [
     "One of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements representing ACL categories or commands in a given category.",
-    "* [Simple error reply](/docs/reference/protocol-spec#simple-errors): the command returns an error if an invalid category name is given."
+    "* [Array reply](../topics/protocol.md#arrays): an array of [Bulk string reply](../topics/protocol.md#bulk-strings) elements representing ACL categories or commands in a given category.",
+    "* [Simple error reply](../topics/protocol.md#simple-errors): the command returns an error if an invalid category name is given."
   ],
   "ACL DELUSER": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of users that were deleted. This number will not always match the number of arguments since certain users may not exist."
+    "[Integer reply](../topics/protocol.md#integers): the number of users that were deleted. This number will not always match the number of arguments since certain users may not exist."
   ],
   "ACL DRYRUN": [
     "Any of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): an error describing why the user can't execute the command."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK` on success.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): an error describing why the user can't execute the command."
   ],
   "ACL GENPASS": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4."
   ],
   "ACL GETUSER": [
     "One of the following:",
-    "* [Map reply](/docs/reference/protocol-spec#maps): a set of ACL rule definitions for the user",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if user does not exist."
+    "* [Map reply](../topics/protocol.md#maps): a set of ACL rule definitions for the user",
+    "* [Null reply](../topics/protocol.md#nulls): if user does not exist."
   ],
   "ACL HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of subcommands and their descriptions."
   ],
   "ACL LIST": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements."
+    "[Array reply](../topics/protocol.md#arrays): an array of [Bulk string reply](../topics/protocol.md#bulk-strings) elements."
   ],
   "ACL LOAD": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` on success.",
     "",
     "The command may fail with an error for several reasons: if the file is not readable, if there is an error inside the file, and in such cases, the error will be reported to the user in the error.",
     "Finally, the command will fail if the server is not configured to use an external ACL file."
   ],
   "ACL LOG": [
     "When called to show security events:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) elements representing ACL security events.",
+    "* [Array reply](../topics/protocol.md#arrays): an array of [Bulk string reply](../topics/protocol.md#bulk-strings) elements representing ACL security events.",
     "When called with `RESET`:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the security log was cleared."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK` if the security log was cleared."
   ],
   "ACL SAVE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`.",
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`.",
     "The command may fail with an error for several reasons: if the file cannot be written or if the server is not configured to use an external ACL file."
   ],
   "ACL SETUSER": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`.",
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`.",
     "If the rules contain errors, the error is returned."
   ],
   "ACL USERS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): list of existing ACL users."
+    "[Array reply](../topics/protocol.md#arrays): list of existing ACL users."
   ],
   "ACL WHOAMI": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the username of the current connection."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the username of the current connection."
   ],
   "APPEND": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string after the append operation."
+    "[Integer reply](../topics/protocol.md#integers): the length of the string after the append operation."
   ],
   "ASKING": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "AUTH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`, or an error if the password, or username/password pair, is invalid."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`, or an error if the password, or username/password pair, is invalid."
   ],
   "BGREWRITEAOF": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a simple string reply indicating that the rewriting started or is about to start ASAP when the call is executed with success.",
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): a simple string reply indicating that the rewriting started or is about to start ASAP when the call is executed with success.",
     "",
     "The command may reply with an error in certain cases, as documented above."
   ],
   "BGSAVE": [
     "One of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `Background saving started`.",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `Background saving scheduled`."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `Background saving started`.",
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `Background saving scheduled`."
   ],
   "BITCOUNT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of bits set to 1."
+    "[Integer reply](../topics/protocol.md#integers): the number of bits set to 1."
   ],
   "BITFIELD": [
     "One of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): each entry being the corresponding result of the sub-command given at the same position.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if OVERFLOW FAIL was given and overflows or underflows are detected."
+    "* [Array reply](../topics/protocol.md#arrays): each entry being the corresponding result of the sub-command given at the same position.",
+    "* [Null reply](../topics/protocol.md#nulls): if OVERFLOW FAIL was given and overflows or underflows are detected."
   ],
   "BITFIELD_RO": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): each entry being the corresponding result of the sub-command given at the same position."
+    "[Array reply](../topics/protocol.md#arrays): each entry being the corresponding result of the sub-command given at the same position."
   ],
   "BITOP": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the size of the string stored in the destination key is equal to the size of the longest input string."
+    "[Integer reply](../topics/protocol.md#integers): the size of the string stored in the destination key is equal to the size of the longest input string."
   ],
   "BITPOS": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the position of the first bit set to 1 or 0 according to the request",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1`. In case the `bit` argument is 1 and the string is empty or composed of just zero bytes",
+    "* [Integer reply](../topics/protocol.md#integers): the position of the first bit set to 1 or 0 according to the request",
+    "* [Integer reply](../topics/protocol.md#integers): `-1`. In case the `bit` argument is 1 and the string is empty or composed of just zero bytes",
     "",
     "If we look for set bits (the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.",
     "",
@@ -102,263 +102,263 @@
   ],
   "BLMOVE": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped from the _source_ and pushed to the _destination_.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): the operation timed-out"
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the element being popped from the _source_ and pushed to the _destination_.",
+    "* [Null reply](../topics/protocol.md#nulls): the operation timed-out"
   ],
   "BLMPOP": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): when no element could be popped and the _timeout_ is reached.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element being an array of the popped elements."
+    "* [Null reply](../topics/protocol.md#nulls): when no element could be popped and the _timeout_ is reached.",
+    "* [Array reply](../topics/protocol.md#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element being an array of the popped elements."
   ],
   "BLPOP": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): no element could be popped and the timeout expired",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the key from which the element was popped and the value of the popped element."
+    "* [Null reply](../topics/protocol.md#nulls): no element could be popped and the timeout expired",
+    "* [Array reply](../topics/protocol.md#arrays): the key from which the element was popped and the value of the popped element."
   ],
   "BRPOP": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): no element could be popped and the timeout expired.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the key from which the element was popped and the value of the popped element"
+    "* [Null reply](../topics/protocol.md#nulls): no element could be popped and the timeout expired.",
+    "* [Array reply](../topics/protocol.md#arrays): the key from which the element was popped and the value of the popped element"
   ],
   "BRPOPLPUSH": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped from _source_ and pushed to _destination_.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): the timeout is reached."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the element being popped from _source_ and pushed to _destination_.",
+    "* [Null reply](../topics/protocol.md#nulls): the timeout is reached."
   ],
   "BZMPOP": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): when no element could be popped.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
+    "* [Null reply](../topics/protocol.md#nulls): when no element could be popped.",
+    "* [Array reply](../topics/protocol.md#arrays): a two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
   ],
   "BZPOPMAX": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): when no element could be popped and the _timeout_ expired.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the keyname, popped member, and its score."
+    "* [Null reply](../topics/protocol.md#nulls): when no element could be popped and the _timeout_ expired.",
+    "* [Array reply](../topics/protocol.md#arrays): the keyname, popped member, and its score."
   ],
   "BZPOPMIN": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): when no element could be popped and the _timeout_ expired.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the keyname, popped member, and its score."
+    "* [Null reply](../topics/protocol.md#nulls): when no element could be popped and the _timeout_ expired.",
+    "* [Array reply](../topics/protocol.md#arrays): the keyname, popped member, and its score."
   ],
   "CLIENT": [],
   "CLIENT CACHING": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` or an error if the argument is not \"yes\" or \"no\"."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` or an error if the argument is not \"yes\" or \"no\"."
   ],
   "CLIENT GETNAME": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the connection name of the current connection.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): the connection name was not set."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the connection name of the current connection.",
+    "* [Null reply](../topics/protocol.md#nulls): the connection name was not set."
   ],
   "CLIENT GETREDIR": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` when not redirecting notifications to any client.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if client tracking is not enabled.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the ID of the client to which notification are being redirected."
+    "* [Integer reply](../topics/protocol.md#integers): `0` when not redirecting notifications to any client.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` if client tracking is not enabled.",
+    "* [Integer reply](../topics/protocol.md#integers): the ID of the client to which notification are being redirected."
   ],
   "CLIENT HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of subcommands and their descriptions."
   ],
   "CLIENT ID": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the ID of the client."
+    "[Integer reply](../topics/protocol.md#integers): the ID of the client."
   ],
   "CLIENT INFO": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a unique string for the current client, as described at the `CLIENT LIST` page."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): a unique string for the current client, as described at the `CLIENT LIST` page."
   ],
   "CLIENT KILL": [
     "One of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when called in 3 argument format and the connection has been closed.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): when called in filter/value format, the number of clients killed."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK` when called in 3 argument format and the connection has been closed.",
+    "* [Integer reply](../topics/protocol.md#integers): when called in filter/value format, the number of clients killed."
   ],
   "CLIENT LIST": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): information and statistics about client connections."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): information and statistics about client connections."
   ],
   "CLIENT NO-EVICT": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "CLIENT NO-TOUCH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "CLIENT PAUSE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` or an error if the timeout is invalid."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` or an error if the timeout is invalid."
   ],
   "CLIENT REPLY": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when called with `ON`. When called with either `OFF` or `SKIP` sub-commands, no reply is made."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` when called with `ON`. When called with either `OFF` or `SKIP` sub-commands, no reply is made."
   ],
   "CLIENT SETINFO": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the attribute name was successfully set."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the attribute name was successfully set."
   ],
   "CLIENT SETNAME": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the connection name was successfully set."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the connection name was successfully set."
   ],
   "CLIENT TRACKING": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the connection was successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise, an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the connection was successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise, an error is returned."
   ],
   "CLIENT TRACKINGINFO": [
-    "[Map reply](/docs/reference/protocol-spec#maps): a list of tracking information sections and their respective values."
+    "[Map reply](../topics/protocol.md#maps): a list of tracking information sections and their respective values."
   ],
   "CLIENT UNBLOCK": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the client was unblocked successfully.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the client wasn't unblocked."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the client was unblocked successfully.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the client wasn't unblocked."
   ],
   "CLIENT UNPAUSE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "CLUSTER": [],
   "CLUSTER ADDSLOTS": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER ADDSLOTSRANGE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER BUMPEPOCH": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `BUMPED` if the epoch was incremented.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `STILL` if the node already has the greatest configured epoch in the cluster."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): `BUMPED` if the epoch was incremented.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): `STILL` if the node already has the greatest configured epoch in the cluster."
   ],
   "CLUSTER COUNT-FAILURE-REPORTS": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of active failure reports for the node."
+    "[Integer reply](../topics/protocol.md#integers): the number of active failure reports for the node."
   ],
   "CLUSTER COUNTKEYSINSLOT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The number of keys in the specified hash slot, or an error if the hash slot is invalid."
+    "[Integer reply](../topics/protocol.md#integers): The number of keys in the specified hash slot, or an error if the hash slot is invalid."
   ],
   "CLUSTER DELSLOTS": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER DELSLOTSRANGE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER FAILOVER": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was accepted and a manual failover is going to be attempted. An error if the operation cannot be executed, for example if the client is connected to a node that is already a master."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was accepted and a manual failover is going to be attempted. An error if the operation cannot be executed, for example if the client is connected to a node that is already a master."
   ],
   "CLUSTER FLUSHSLOTS": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "CLUSTER FORGET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was executed successfully. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was executed successfully. Otherwise an error is returned."
   ],
   "CLUSTER GETKEYSINSLOT": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array with up to count elements."
+    "[Array reply](../topics/protocol.md#arrays): an array with up to count elements."
   ],
   "CLUSTER HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of subcommands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of subcommands and their descriptions."
   ],
   "CLUSTER INFO": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): A map between named fields and values in the form of <field>:<value> lines separated by newlines composed by the two bytes CRLF"
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): A map between named fields and values in the form of <field>:<value> lines separated by newlines composed by the two bytes CRLF"
   ],
   "CLUSTER KEYSLOT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The hash slot number for the specified key"
+    "[Integer reply](../topics/protocol.md#integers): The hash slot number for the specified key"
   ],
   "CLUSTER LINKS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array of [Map reply](/docs/reference/protocol-spec#maps) where each map contains various attributes and their values of a cluster link."
+    "[Array reply](../topics/protocol.md#arrays): an array of [Map reply](../topics/protocol.md#maps) where each map contains various attributes and their values of a cluster link."
   ],
   "CLUSTER MEET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. If the address or port specified are invalid an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. If the address or port specified are invalid an error is returned."
   ],
   "CLUSTER MYID": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the node ID."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the node ID."
   ],
   "CLUSTER MYSHARDID": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the node's shard ID."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the node's shard ID."
   ],
   "CLUSTER NODES": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the serialized cluster configuration."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the serialized cluster configuration."
   ],
   "CLUSTER REPLICAS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
+    "[Array reply](../topics/protocol.md#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
   ],
   "CLUSTER REPLICATE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER RESET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER SAVECONFIG": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER SET-CONFIG-EPOCH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER SETSLOT": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): all the sub-commands return `OK` if the command was successful. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): all the sub-commands return `OK` if the command was successful. Otherwise an error is returned."
   ],
   "CLUSTER SHARDS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of [Map reply](/docs/reference/protocol-spec#maps) of hash ranges and shard nodes describing individual shards."
+    "[Array reply](../topics/protocol.md#arrays): a nested list of [Map reply](../topics/protocol.md#maps) of hash ranges and shard nodes describing individual shards."
   ],
   "CLUSTER SLAVES": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
+    "[Array reply](../topics/protocol.md#arrays): a list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`."
   ],
   "CLUSTER SLOTS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): nested list of slot ranges with networking information."
+    "[Array reply](../topics/protocol.md#arrays): nested list of slot ranges with networking information."
   ],
   "COMMAND": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of command details. The order of the commands in the array is random."
+    "[Array reply](../topics/protocol.md#arrays): a nested list of command details. The order of the commands in the array is random."
   ],
   "COMMAND COUNT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of commands returned by `COMMAND`."
+    "[Integer reply](../topics/protocol.md#integers): the number of commands returned by `COMMAND`."
   ],
   "COMMAND DOCS": [
-    "[Map reply](/docs/reference/protocol-spec#maps): a map where each key is a command name, and each value is the documentary information."
+    "[Map reply](../topics/protocol.md#maps): a map where each key is a command name, and each value is the documentary information."
   ],
   "COMMAND GETKEYS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys from the given command."
+    "[Array reply](../topics/protocol.md#arrays): a list of keys from the given command."
   ],
   "COMMAND GETKEYSANDFLAGS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys from the given command and their usage flags."
+    "[Array reply](../topics/protocol.md#arrays): a list of keys from the given command and their usage flags."
   ],
   "COMMAND HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "COMMAND INFO": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a nested list of command details."
+    "[Array reply](../topics/protocol.md#arrays): a nested list of command details."
   ],
   "COMMAND LIST": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of command names."
+    "[Array reply](../topics/protocol.md#arrays): a list of command names."
   ],
   "CONFIG": [],
   "CONFIG GET": [
-    "[Map reply](/docs/reference/protocol-spec#maps): a list of configuration parameters matching the provided arguments."
+    "[Map reply](../topics/protocol.md#maps): a list of configuration parameters matching the provided arguments."
   ],
   "CONFIG HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "CONFIG RESETSTAT": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "CONFIG REWRITE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when the configuration was rewritten properly. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` when the configuration was rewritten properly. Otherwise an error is returned."
   ],
   "CONFIG SET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` when the configuration was set properly. Otherwise an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` when the configuration was set properly. Otherwise an error is returned."
   ],
   "COPY": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _source_ was copied.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _source_ was not copied."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if _source_ was copied.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if _source_ was not copied."
   ],
   "DBSIZE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys in the currently-selected database."
+    "[Integer reply](../topics/protocol.md#integers): the number of keys in the currently-selected database."
   ],
   "DEBUG": [],
   "DECR": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after decrementing it."
+    "[Integer reply](../topics/protocol.md#integers): the value of the key after decrementing it."
   ],
   "DECRBY": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after decrementing it."
+    "[Integer reply](../topics/protocol.md#integers): the value of the key after decrementing it."
   ],
   "DEL": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that were removed."
+    "[Integer reply](../topics/protocol.md#integers): the number of keys that were removed."
   ],
   "DISCARD": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "DUMP": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the serialized value of the key.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): the key does not exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the serialized value of the key.",
+    "* [Null reply](../topics/protocol.md#nulls): the key does not exist."
   ],
   "ECHO": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the given string."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the given string."
   ],
   "EVAL": [
     "The return value depends on the script that was executed."
@@ -374,30 +374,30 @@
   ],
   "EXEC": [
     "One of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): each element being the reply to each of the commands in the atomic transaction.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): the transaction was aborted because a `WATCH`ed key was touched."
+    "* [Array reply](../topics/protocol.md#arrays): each element being the reply to each of the commands in the atomic transaction.",
+    "* [Null reply](../topics/protocol.md#nulls): the transaction was aborted because a `WATCH`ed key was touched."
   ],
   "EXISTS": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that exist from those specified as arguments."
+    "[Integer reply](../topics/protocol.md#integers): the number of keys that exist from those specified as arguments."
   ],
   "EXPIRE": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the timeout was set."
   ],
   "EXPIREAT": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the timeout was set."
   ],
   "EXPIRETIME": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the expiration Unix timestamp in seconds.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration time.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+    "* [Integer reply](../topics/protocol.md#integers): the expiration Unix timestamp in seconds.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` if the key exists but has no associated expiration time.",
+    "* [Integer reply](../topics/protocol.md#integers): `-2` if the key does not exist."
   ],
   "FAILOVER": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the command was accepted and a coordinated failover is in progress. An error if the operation cannot be executed."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the command was accepted and a coordinated failover is in progress. An error if the operation cannot be executed."
   ],
   "FCALL": [
     "The return value depends on the function that was executed."
@@ -406,57 +406,57 @@
     "The return value depends on the function that was executed."
   ],
   "FLUSHALL": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FLUSHDB": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FUNCTION": [],
   "FUNCTION DELETE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FUNCTION DUMP": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the serialized payload"
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the serialized payload"
   ],
   "FUNCTION FLUSH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FUNCTION HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "FUNCTION KILL": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FUNCTION LIST": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): information about functions and libraries."
+    "[Array reply](../topics/protocol.md#arrays): information about functions and libraries."
   ],
   "FUNCTION LOAD": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the library name that was loaded."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the library name that was loaded."
   ],
   "FUNCTION RESTORE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "FUNCTION STATS": [
-    "[Map reply](/docs/reference/protocol-spec#maps): information about the function that's currently running and information about the available execution engines."
+    "[Map reply](../topics/protocol.md#maps): information about the function that's currently running and information about the available execution engines."
   ],
   "GEOADD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): When used without optional arguments, the number of elements added to the sorted set (excluding score updates).  If the CH option is specified, the number of elements that were changed (added or updated)."
+    "[Integer reply](../topics/protocol.md#integers): When used without optional arguments, the number of elements added to the sorted set (excluding score updates).  If the CH option is specified, the number of elements that were changed (added or updated)."
   ],
   "GEODIST": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): one or both of the elements are missing.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): distance as a double (represented as a string) in the specified units."
+    "* [Null reply](../topics/protocol.md#nulls): one or both of the elements are missing.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): distance as a double (represented as a string) in the specified units."
   ],
   "GEOHASH": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): An array where each element is the Geohash corresponding to each member name passed as an argument to the command."
+    "[Array reply](../topics/protocol.md#arrays): An array where each element is the Geohash corresponding to each member name passed as an argument to the command."
   ],
   "GEOPOS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): An array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command. Non-existing elements are reported as [Null reply](/docs/reference/protocol-spec#nulls) elements of the array."
+    "[Array reply](../topics/protocol.md#arrays): An array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command. Non-existing elements are reported as [Null reply](../topics/protocol.md#nulls) elements of the array."
   ],
   "GEORADIUS": [
     "One of the following:",
-    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
-    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "* If no `WITH*` option is specified, an [Array reply](../topics/protocol.md#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](../topics/protocol.md#arrays) of arrays, where each sub-array represents a single item:",
     "    1. The distance from the center as a floating point number, in the same unit specified in the radius.",
     "    1. The Geohash integer.",
     "    1. The coordinates as a two items x,y array (longitude,latitude).",
@@ -467,366 +467,366 @@
   ],
   "GEORADIUSBYMEMBER": [
     "One of the following:",
-    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
-    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "* If no `WITH*` option is specified, an [Array reply](../topics/protocol.md#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](../topics/protocol.md#arrays) of arrays, where each sub-array represents a single item:",
     "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
     "    * The Geohash integer.",
     "    * The coordinates as a two items x,y array (longitude,latitude)."
   ],
   "GEORADIUSBYMEMBER_RO": [
     "One of the following:",
-    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
-    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "* If no `WITH*` option is specified, an [Array reply](../topics/protocol.md#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](../topics/protocol.md#arrays) of arrays, where each sub-array represents a single item:",
     "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
     "    * The Geohash integer.",
     "    * The coordinates as a two items x,y array (longitude,latitude)."
   ],
   "GEORADIUS_RO": [
     "One of the following:",
-    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
-    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "* If no `WITH*` option is specified, an [Array reply](../topics/protocol.md#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](../topics/protocol.md#arrays) of arrays, where each sub-array represents a single item:",
     "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
     "    * The Geohash integer.",
     "    * The coordinates as a two items x,y array (longitude,latitude)."
   ],
   "GEOSEARCH": [
     "One of the following:",
-    "* If no `WITH*` option is specified, an [Array reply](/docs/reference/protocol-spec#arrays) of matched member names",
-    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](/docs/reference/protocol-spec#arrays) of arrays, where each sub-array represents a single item:",
+    "* If no `WITH*` option is specified, an [Array reply](../topics/protocol.md#arrays) of matched member names",
+    "* If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply](../topics/protocol.md#arrays) of arrays, where each sub-array represents a single item:",
     "    * The distance from the center as a floating point number, in the same unit specified in the radius.",
     "    * The Geohash integer.",
     "    * The coordinates as a two items x,y array (longitude,latitude)."
   ],
   "GEOSEARCHSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set"
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting set"
   ],
   "GET": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): key does not exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the value of the key.",
+    "* [Null reply](../topics/protocol.md#nulls): key does not exist."
   ],
   "GETBIT": [
     "The bit value stored at _offset_, one of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0`.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1`."
+    "* [Integer reply](../topics/protocol.md#integers): `0`.",
+    "* [Integer reply](../topics/protocol.md#integers): `1`."
   ],
   "GETDEL": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist or if the key's value type is not a string."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the value of the key.",
+    "* [Null reply](../topics/protocol.md#nulls): if the key does not exist or if the key's value type is not a string."
   ],
   "GETEX": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of `key`",
-    "[Null reply](/docs/reference/protocol-spec#nulls): if `key` does not exist."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the value of `key`",
+    "[Null reply](../topics/protocol.md#nulls): if `key` does not exist."
   ],
   "GETRANGE": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): The substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
   ],
   "GETSET": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the old value stored at the key.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the old value stored at the key.",
+    "* [Null reply](../topics/protocol.md#nulls): if the key does not exist."
   ],
   "HDEL": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The number of fields that were removed from the hash, excluding any specified but non-existing fields."
+    "[Integer reply](../topics/protocol.md#integers): The number of fields that were removed from the hash, excluding any specified but non-existing fields."
   ],
   "HELLO": [
-    "[Map reply](/docs/reference/protocol-spec#maps): a list of server properties.",
-    "[Simple error reply](/docs/reference/protocol-spec#simple-errors): if the `protover` requested does not exist."
+    "[Map reply](../topics/protocol.md#maps): a list of server properties.",
+    "[Simple error reply](../topics/protocol.md#simple-errors): if the `protover` requested does not exist."
   ],
   "HEXISTS": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the hash does not contain the field, or the key does not exist.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the hash contains the field."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the hash does not contain the field, or the key does not exist.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the hash contains the field."
   ],
   "HGET": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The value associated with the field.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): If the field is not present in the hash or key does not exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): The value associated with the field.",
+    "* [Null reply](../topics/protocol.md#nulls): If the field is not present in the hash or key does not exist."
   ],
   "HGETALL": [
-    "[Map reply](/docs/reference/protocol-spec#maps): a map of fields and their values stored in the hash, or an empty list when key does not exist."
+    "[Map reply](../topics/protocol.md#maps): a map of fields and their values stored in the hash, or an empty list when key does not exist."
   ],
   "HINCRBY": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the field after the increment operation."
+    "[Integer reply](../topics/protocol.md#integers): the value of the field after the increment operation."
   ],
   "HINCRBYFLOAT": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The value of the field after the increment operation."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): The value of the field after the increment operation."
   ],
   "HKEYS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of fields in the hash, or an empty list when the key does not exist."
+    "[Array reply](../topics/protocol.md#arrays): a list of fields in the hash, or an empty list when the key does not exist."
   ],
   "HLEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of the fields in the hash, or 0 when the key does not exist."
+    "[Integer reply](../topics/protocol.md#integers): the number of the fields in the hash, or 0 when the key does not exist."
   ],
   "HMGET": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values associated with the given fields, in the same order as they are requested."
+    "[Array reply](../topics/protocol.md#arrays): a list of values associated with the given fields, in the same order as they are requested."
   ],
   "HMSET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "HRANDFIELD": [
     "Any of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key doesn't exist",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a single, randomly selected field when the `count` option is not used",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list containing `count` fields when the `count` option is used, or an empty array if the key does not exists.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of fields and their values when `count` and `WITHVALUES` were both used."
+    "* [Null reply](../topics/protocol.md#nulls): if the key doesn't exist",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): a single, randomly selected field when the `count` option is not used",
+    "* [Array reply](../topics/protocol.md#arrays): a list containing `count` fields when the `count` option is used, or an empty array if the key does not exists.",
+    "* [Array reply](../topics/protocol.md#arrays): a list of fields and their values when `count` and `WITHVALUES` were both used."
   ],
   "HSCAN": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a two-element array.",
-    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
-    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) of field/value pairs that were scanned."
+    "[Array reply](../topics/protocol.md#arrays): a two-element array.",
+    "* The first element is a [Bulk string reply](../topics/protocol.md#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](../topics/protocol.md#arrays) of field/value pairs that were scanned."
   ],
   "HSET": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of fields that were added."
+    "[Integer reply](../topics/protocol.md#integers): the number of fields that were added."
   ],
   "HSETNX": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the field already exists in the hash and no operation was performed.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the field is a new field in the hash and the value was set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the field already exists in the hash and no operation was performed.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the field is a new field in the hash and the value was set."
   ],
   "HSTRLEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the string length of the value associated with the _field_, or zero when the _field_ isn't present in the hash or the _key_ doesn't exist at all."
+    "[Integer reply](../topics/protocol.md#integers): the string length of the value associated with the _field_, or zero when the _field_ isn't present in the hash or the _key_ doesn't exist at all."
   ],
   "HVALS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values in the hash, or an empty list when the key does not exist."
+    "[Array reply](../topics/protocol.md#arrays): a list of values in the hash, or an empty list when the key does not exist."
   ],
   "INCR": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after the increment."
+    "[Integer reply](../topics/protocol.md#integers): the value of the key after the increment."
   ],
   "INCRBY": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the value of the key after the increment."
+    "[Integer reply](../topics/protocol.md#integers): the value of the key after the increment."
   ],
   "INCRBYFLOAT": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the value of the key after the increment."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the value of the key after the increment."
   ],
   "INFO": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a map of info fields, one field per line in the form of `<field>:<value>` where the value can be a comma separated map like `<key>=<val>`. Also contains section header lines starting with `#` and blank lines.",
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): a map of info fields, one field per line in the form of `<field>:<value>` where the value can be a comma separated map like `<key>=<val>`. Also contains section header lines starting with `#` and blank lines.",
     "",
     "Lines can contain a section name (starting with a `#` character) or a property. All the properties are in the form of `field:value` terminated by `\\r\\n`."
   ],
   "KEYS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of keys matching _pattern_."
+    "[Array reply](../topics/protocol.md#arrays): a list of keys matching _pattern_."
   ],
   "LASTSAVE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): UNIX TIME of the last DB save executed with success."
+    "[Integer reply](../topics/protocol.md#integers): UNIX TIME of the last DB save executed with success."
   ],
   "LATENCY": [],
   "LATENCY DOCTOR": [
-    "[Verbatim string reply](/docs/reference/protocol-spec#verbatim-strings): a human readable latency analysis report."
+    "[Verbatim string reply](../topics/protocol.md#verbatim-strings): a human readable latency analysis report."
   ],
   "LATENCY GRAPH": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): Latency graph"
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): Latency graph"
   ],
   "LATENCY HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "LATENCY HISTOGRAM": [
-    "[Map reply](/docs/reference/protocol-spec#maps): a map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets."
+    "[Map reply](../topics/protocol.md#maps): a map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets."
   ],
   "LATENCY HISTORY": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array where each element is a two elements array representing the timestamp and the latency of the event."
+    "[Array reply](../topics/protocol.md#arrays): an array where each element is a two elements array representing the timestamp and the latency of the event."
   ],
   "LATENCY LATEST": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array where each element is a four elements array representing the event's name, timestamp, latest and all-time latency measurements."
+    "[Array reply](../topics/protocol.md#arrays): an array where each element is a four elements array representing the event's name, timestamp, latest and all-time latency measurements."
   ],
   "LATENCY RESET": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of event time series that were reset."
+    "[Integer reply](../topics/protocol.md#integers): the number of event time series that were reset."
   ],
   "LCS": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the longest common subsequence.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the length of the longest common subsequence when _LEN_ is given.",
-    "* [Map reply](/docs/reference/protocol-spec#maps): a map with the LCS length and all the ranges in both the strings when _IDX_ is given."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the longest common subsequence.",
+    "* [Integer reply](../topics/protocol.md#integers): the length of the longest common subsequence when _LEN_ is given.",
+    "* [Map reply](../topics/protocol.md#maps): a map with the LCS length and all the ranges in both the strings when _IDX_ is given."
   ],
   "LINDEX": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): when _index_ is out of range.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the requested element."
+    "* [Null reply](../topics/protocol.md#nulls): when _index_ is out of range.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the requested element."
   ],
   "LINSERT": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the list length after a successful insert operation.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` when the key doesn't exist.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` when the pivot wasn't found."
+    "* [Integer reply](../topics/protocol.md#integers): the list length after a successful insert operation.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` when the key doesn't exist.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` when the pivot wasn't found."
   ],
   "LLEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list."
+    "[Integer reply](../topics/protocol.md#integers): the length of the list."
   ],
   "LMOVE": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped and pushed."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the element being popped and pushed."
   ],
   "LMPOP": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if no element could be popped.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a two-element array with the first element being the name of the key from which elements were popped and the second element being an array of elements."
+    "* [Null reply](../topics/protocol.md#nulls): if no element could be popped.",
+    "* [Array reply](../topics/protocol.md#arrays): a two-element array with the first element being the name of the key from which elements were popped and the second element being an array of elements."
   ],
   "LOLWUT": [
-    "[Verbatim string reply](/docs/reference/protocol-spec#verbatim-strings): a string containing generative computer art and the Valkey version."
+    "[Verbatim string reply](../topics/protocol.md#verbatim-strings): a string containing generative computer art and the Valkey version."
   ],
   "LPOP": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the value of the first element.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a list of popped elements."
+    "* [Null reply](../topics/protocol.md#nulls): if the key does not exist.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): when called without the _count_ argument, the value of the first element.",
+    "* [Array reply](../topics/protocol.md#arrays): when called with the _count_ argument, a list of popped elements."
   ],
   "LPOS": [
     "Any of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if there is no matching element.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): an integer representing the matching element.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): If the COUNT option is given, an array of integers representing the matching elements (or an empty array if there are no matches)."
+    "* [Null reply](../topics/protocol.md#nulls): if there is no matching element.",
+    "* [Integer reply](../topics/protocol.md#integers): an integer representing the matching element.",
+    "* [Array reply](../topics/protocol.md#arrays): If the COUNT option is given, an array of integers representing the matching elements (or an empty array if there are no matches)."
   ],
   "LPUSH": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+    "[Integer reply](../topics/protocol.md#integers): the length of the list after the push operation."
   ],
   "LPUSHX": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+    "[Integer reply](../topics/protocol.md#integers): the length of the list after the push operation."
   ],
   "LRANGE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of elements in the specified range, or an empty array if the key doesn't exist."
+    "[Array reply](../topics/protocol.md#arrays): a list of elements in the specified range, or an empty array if the key doesn't exist."
   ],
   "LREM": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of removed elements."
+    "[Integer reply](../topics/protocol.md#integers): the number of removed elements."
   ],
   "LSET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "LTRIM": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "MEMORY": [],
   "MEMORY DOCTOR": [
-    "[Verbatim string reply](/docs/reference/protocol-spec#verbatim-strings): a memory problems report."
+    "[Verbatim string reply](../topics/protocol.md#verbatim-strings): a memory problems report."
   ],
   "MEMORY HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "MEMORY MALLOC-STATS": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The memory allocator's internal statistics report."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): The memory allocator's internal statistics report."
   ],
   "MEMORY PURGE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "MEMORY STATS": [
-    "[Map reply](/docs/reference/protocol-spec#maps): memory usage metrics and their values."
+    "[Map reply](../topics/protocol.md#maps): memory usage metrics and their values."
   ],
   "MEMORY USAGE": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the memory usage in bytes.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist."
+    "* [Integer reply](../topics/protocol.md#integers): the memory usage in bytes.",
+    "* [Null reply](../topics/protocol.md#nulls): if the key does not exist."
   ],
   "MGET": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of values at the specified keys."
+    "[Array reply](../topics/protocol.md#arrays): a list of values at the specified keys."
   ],
   "MIGRATE": [
     "One of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` on success.",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `NOKEY` when no keys were found in the source instance."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK` on success.",
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `NOKEY` when no keys were found in the source instance."
   ],
   "MODULE": [],
   "MODULE HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions"
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions"
   ],
   "MODULE LIST": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): list of loaded modules. Each element in the list represents a represents a module, and is a [Map reply](/docs/reference/protocol-spec#maps) of property names and their values. The following properties is reported for each loaded module:",
+    "[Array reply](../topics/protocol.md#arrays): list of loaded modules. Each element in the list represents a represents a module, and is a [Map reply](../topics/protocol.md#maps) of property names and their values. The following properties is reported for each loaded module:",
     "* name: the name of the module.",
     "* ver: the version of the module."
   ],
   "MODULE LOAD": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was loaded."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the module was loaded."
   ],
   "MODULE LOADEX": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was loaded."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the module was loaded."
   ],
   "MODULE UNLOAD": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if the module was unloaded."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if the module was unloaded."
   ],
   "MONITOR": [
     "**Non-standard return value**. Dumps the received commands in an infinite flow."
   ],
   "MOVE": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _key_ was moved.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _key_ wasn't moved."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if _key_ was moved.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if _key_ wasn't moved."
   ],
   "MSET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): always `OK` because `MSET` can't fail."
+    "[Simple string reply](../topics/protocol.md#simple-strings): always `OK` because `MSET` can't fail."
   ],
   "MSETNX": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if no key was set (at least one key already existed).",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if all the keys were set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if no key was set (at least one key already existed).",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if all the keys were set."
   ],
   "MULTI": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "OBJECT": [],
   "OBJECT ENCODING": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key doesn't exist.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the encoding of the object."
+    "* [Null reply](../topics/protocol.md#nulls): if the key doesn't exist.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the encoding of the object."
   ],
   "OBJECT FREQ": [
     "One of the following:",
-    "[Integer reply](/docs/reference/protocol-spec#integers): the counter's value.",
-    "[Null reply](/docs/reference/protocol-spec#nulls): if _key_ doesn't exist."
+    "[Integer reply](../topics/protocol.md#integers): the counter's value.",
+    "[Null reply](../topics/protocol.md#nulls): if _key_ doesn't exist."
   ],
   "OBJECT HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "OBJECT IDLETIME": [
     "One of the following:",
-    "[Integer reply](/docs/reference/protocol-spec#integers): the idle time in seconds.",
-    "[Null reply](/docs/reference/protocol-spec#nulls): if _key_ doesn't exist."
+    "[Integer reply](../topics/protocol.md#integers): the idle time in seconds.",
+    "[Null reply](../topics/protocol.md#nulls): if _key_ doesn't exist."
   ],
   "OBJECT REFCOUNT": [
     "One of the following:",
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of references.",
-    "[Null reply](/docs/reference/protocol-spec#nulls): if _key_ doesn't exist."
+    "[Integer reply](../topics/protocol.md#integers): the number of references.",
+    "[Null reply](../topics/protocol.md#nulls): if _key_ doesn't exist."
   ],
   "PERSIST": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _key_ does not exist or does not have an associated timeout.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout has been removed."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if _key_ does not exist or does not have an associated timeout.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the timeout has been removed."
   ],
   "PEXPIRE": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0`if the timeout was not set. For example, if the key doesn't exist, or the operation skipped because of the provided arguments.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set."
+    "* [Integer reply](../topics/protocol.md#integers): `0`if the timeout was not set. For example, if the key doesn't exist, or the operation skipped because of the provided arguments.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the timeout was set."
   ],
   "PEXPIREAT": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the timeout was set.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the timeout was not set. For example, if the key doesn't exist, or the operation was skipped due to the provided arguments."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the timeout was set.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the timeout was not set. For example, if the key doesn't exist, or the operation was skipped due to the provided arguments."
   ],
   "PEXPIRETIME": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): Expiration Unix timestamp in milliseconds.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration time.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+    "* [Integer reply](../topics/protocol.md#integers): Expiration Unix timestamp in milliseconds.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` if the key exists but has no associated expiration time.",
+    "* [Integer reply](../topics/protocol.md#integers): `-2` if the key does not exist."
   ],
   "PFADD": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if at least one HyperLogLog internal register was altered.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if no HyperLogLog internal registers were altered."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if at least one HyperLogLog internal register was altered.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if no HyperLogLog internal registers were altered."
   ],
   "PFCOUNT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the approximated number of unique elements observed via `PFADD`"
+    "[Integer reply](../topics/protocol.md#integers): the approximated number of unique elements observed via `PFADD`"
   ],
   "PFDEBUG": [],
   "PFMERGE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "PFSELFTEST": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "PING": [
     "Any of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `PONG` when no argument is provided.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the provided argument."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `PONG` when no argument is provided.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the provided argument."
   ],
   "PSETEX": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "PSUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each pattern, one message with the first element being the string `psubscribe` is pushed as a confirmation that the command succeeded."
@@ -836,550 +836,550 @@
   ],
   "PTTL": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): TTL in milliseconds.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+    "* [Integer reply](../topics/protocol.md#integers): TTL in milliseconds.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` if the key exists but has no associated expiration.",
+    "* [Integer reply](../topics/protocol.md#integers): `-2` if the key does not exist."
   ],
   "PUBLISH": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of clients that received the message. Note that in a Valkey Cluster, only clients that are connected to the same node as the publishing client are included in the count."
+    "[Integer reply](../topics/protocol.md#integers): the number of clients that received the message. Note that in a Valkey Cluster, only clients that are connected to the same node as the publishing client are included in the count."
   ],
   "PUBSUB": [],
   "PUBSUB CHANNELS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of active channels, optionally matching the specified pattern."
+    "[Array reply](../topics/protocol.md#arrays): a list of active channels, optionally matching the specified pattern."
   ],
   "PUBSUB HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "PUBSUB NUMPAT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of patterns all the clients are subscribed to."
+    "[Integer reply](../topics/protocol.md#integers): the number of patterns all the clients are subscribed to."
   ],
   "PUBSUB NUMSUB": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): the number of subscribers per channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers"
+    "[Array reply](../topics/protocol.md#arrays): the number of subscribers per channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers"
   ],
   "PUBSUB SHARDCHANNELS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of active channels, optionally matching the specified pattern."
+    "[Array reply](../topics/protocol.md#arrays): a list of active channels, optionally matching the specified pattern."
   ],
   "PUBSUB SHARDNUMSUB": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): the number of subscribers per shard channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers."
+    "[Array reply](../topics/protocol.md#arrays): the number of subscribers per shard channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers."
   ],
   "PUNSUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each pattern, one message with the first element being the string `punsubscribe` is pushed as a confirmation that the command succeeded."
   ],
   "QUIT": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "RANDOMKEY": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): when the database is empty.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): a random key in the database."
+    "* [Null reply](../topics/protocol.md#nulls): when the database is empty.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): a random key in the database."
   ],
   "READONLY": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "READWRITE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "RENAME": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "RENAMENX": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if _key_ was renamed to _newkey_.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if _newkey_ already exists."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if _key_ was renamed to _newkey_.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if _newkey_ already exists."
   ],
   "REPLCONF": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "REPLICAOF": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "RESET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `RESET`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `RESET`."
   ],
   "RESTORE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "RESTORE-ASKING": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "ROLE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): where the first element is one of `master`, `slave`, or `sentinel`, and the additional elements are role-specific as illustrated above."
+    "[Array reply](../topics/protocol.md#arrays): where the first element is one of `master`, `slave`, or `sentinel`, and the additional elements are role-specific as illustrated above."
   ],
   "RPOP": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the value of the last element.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when called with the _count_ argument, a list of popped elements."
+    "* [Null reply](../topics/protocol.md#nulls): if the key does not exist.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): when called without the _count_ argument, the value of the last element.",
+    "* [Array reply](../topics/protocol.md#arrays): when called with the _count_ argument, a list of popped elements."
   ],
   "RPOPLPUSH": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the element being popped and pushed.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the source list is empty."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): the element being popped and pushed.",
+    "* [Null reply](../topics/protocol.md#nulls): if the source list is empty."
   ],
   "RPUSH": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+    "[Integer reply](../topics/protocol.md#integers): the length of the list after the push operation."
   ],
   "RPUSHX": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the list after the push operation."
+    "[Integer reply](../topics/protocol.md#integers): the length of the list after the push operation."
   ],
   "SADD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements that were added to the set, not including all the elements already present in the set."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements that were added to the set, not including all the elements already present in the set."
   ],
   "SAVE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SCAN": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, an array with two elements.",
-    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
-    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) with the names of scanned keys."
+    "[Array reply](../topics/protocol.md#arrays): specifically, an array with two elements.",
+    "* The first element is a [Bulk string reply](../topics/protocol.md#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](../topics/protocol.md#arrays) with the names of scanned keys."
   ],
   "SCARD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The cardinality (number of elements) of the set, or 0 if the key does not exist."
+    "[Integer reply](../topics/protocol.md#integers): The cardinality (number of elements) of the set, or 0 if the key does not exist."
   ],
   "SCRIPT": [],
   "SCRIPT DEBUG": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SCRIPT EXISTS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): an array of integers that correspond to the specified SHA1 digest arguments."
+    "[Array reply](../topics/protocol.md#arrays): an array of integers that correspond to the specified SHA1 digest arguments."
   ],
   "SCRIPT FLUSH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SCRIPT HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "SCRIPT KILL": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SCRIPT LOAD": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the SHA1 digest of the script added into the script cache."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the SHA1 digest of the script added into the script cache."
   ],
   "SDIFF": [
-    "[Set reply](/docs/reference/protocol-spec#sets): the resulting set."
+    "[Set reply](../topics/protocol.md#sets): the resulting set."
   ],
   "SDIFFSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting set."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting set."
   ],
   "SELECT": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SENTINEL CKQUORUM": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): Returns OK if the current Sentinel configuration is able to reach the quorum needed to failover a master, and the majority needed to authorize the failover."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): Returns OK if the current Sentinel configuration is able to reach the quorum needed to failover a master, and the majority needed to authorize the failover."
   ],
   "SENTINEL CONFIG": [
     "One of the following:",
-    "* [Map reply](/docs/reference/protocol-spec#maps): When 'SENTINEL-CONFIG GET' is called, returns a map.",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. When 'SENTINEL-CONFIG SET' is called, returns OK on success."
+    "* [Map reply](../topics/protocol.md#maps): When 'SENTINEL-CONFIG GET' is called, returns a map.",
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK`. When 'SENTINEL-CONFIG SET' is called, returns OK on success."
   ],
   "SENTINEL DEBUG": [
     "One of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. The configuration update was successful.",
-    "* [Map reply](/docs/reference/protocol-spec#maps): List of configurable time parameters and their values (milliseconds)."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK`. The configuration update was successful.",
+    "* [Map reply](../topics/protocol.md#maps): List of configurable time parameters and their values (milliseconds)."
   ],
   "SENTINEL FAILOVER": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. Force a fail over as if the master was not reachable, and without asking for agreement to other Sentinels."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`. Force a fail over as if the master was not reachable, and without asking for agreement to other Sentinels."
   ],
   "SENTINEL FLUSHCONFIG": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. Force Sentinel to rewrite its configuration on disk, including the current Sentinel state."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`. Force Sentinel to rewrite its configuration on disk, including the current Sentinel state."
   ],
   "SENTINEL GET MASTER-ADDR-BY-NAME": [],
   "SENTINEL HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): Helpful text about subcommands."
+    "[Array reply](../topics/protocol.md#arrays): Helpful text about subcommands."
   ],
   "SENTINEL INFO CACHE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): This is actually a map, the odd entries are a master name, and the even entries are the last cached INFO output from that master and all its replicas."
+    "[Array reply](../topics/protocol.md#arrays): This is actually a map, the odd entries are a master name, and the even entries are the last cached INFO output from that master and all its replicas."
   ],
   "SENTINEL IS MASTER-DOWN-BY-ADDR": [],
   "SENTINEL MASTER": [
-    "[Map reply](/docs/reference/protocol-spec#maps): The state and info of the specified master."
+    "[Map reply](../topics/protocol.md#maps): The state and info of the specified master."
   ],
   "SENTINEL MASTERS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): List of monitored Valkey masters, and their state."
+    "[Array reply](../topics/protocol.md#arrays): List of monitored Valkey masters, and their state."
   ],
   "SENTINEL MONITOR": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SENTINEL MYID": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): Node ID of the sentinel instance."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): Node ID of the sentinel instance."
   ],
   "SENTINEL PENDING SCRIPTS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): List of pending scripts."
+    "[Array reply](../topics/protocol.md#arrays): List of pending scripts."
   ],
   "SENTINEL REMOVE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SENTINEL REPLICAS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): List of replicas for this master, and their state."
+    "[Array reply](../topics/protocol.md#arrays): List of replicas for this master, and their state."
   ],
   "SENTINEL RESET": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The number of masters that were reset."
+    "[Integer reply](../topics/protocol.md#integers): The number of masters that were reset."
   ],
   "SENTINEL SENTINELS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): List of sentinel instances, and their state."
+    "[Array reply](../topics/protocol.md#arrays): List of sentinel instances, and their state."
   ],
   "SENTINEL SET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SENTINEL SIMULATE FAILURE": [
     "One of the following:",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. The simulated flag was set.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): Supported simulates flags. Returned in case `HELP` was used."
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK`. The simulated flag was set.",
+    "* [Array reply](../topics/protocol.md#arrays): Supported simulates flags. Returned in case `HELP` was used."
   ],
   "SENTINEL SLAVES": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): List of monitored replicas, and their state."
+    "[Array reply](../topics/protocol.md#arrays): List of monitored replicas, and their state."
   ],
   "SET": [
     "Any of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): `GET` not given: Operation was aborted (conflict with one of the `XX`/`NX` options).",
-    "* [Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`. `GET` not given: The key was set.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): `GET` given: The key didn't exist before the `SET`.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): `GET` given: The previous value of the key."
+    "* [Null reply](../topics/protocol.md#nulls): `GET` not given: Operation was aborted (conflict with one of the `XX`/`NX` options).",
+    "* [Simple string reply](../topics/protocol.md#simple-strings): `OK`. `GET` not given: The key was set.",
+    "* [Null reply](../topics/protocol.md#nulls): `GET` given: The key didn't exist before the `SET`.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): `GET` given: The previous value of the key."
   ],
   "SETBIT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the original bit value stored at _offset_."
+    "[Integer reply](../topics/protocol.md#integers): the original bit value stored at _offset_."
   ],
   "SETEX": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SETNX": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the key was not set.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the key was set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the key was not set.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the key was set."
   ],
   "SETRANGE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string after it was modified by the command."
+    "[Integer reply](../topics/protocol.md#integers): the length of the string after it was modified by the command."
   ],
   "SHUTDOWN": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK` if _ABORT_ was specified and shutdown was aborted. On successful shutdown, nothing is returned because the server quits and the connection is closed. On failure, an error is returned."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK` if _ABORT_ was specified and shutdown was aborted. On successful shutdown, nothing is returned because the server quits and the connection is closed. On failure, an error is returned."
   ],
   "SINTER": [
-    "[Set reply](/docs/reference/protocol-spec#sets): the resulting set."
+    "[Set reply](../topics/protocol.md#sets): the resulting set."
   ],
   "SINTERCARD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of the elements in the resulting intersection."
+    "[Integer reply](../topics/protocol.md#integers): the number of the elements in the resulting intersection."
   ],
   "SINTERSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of the elements in the result set."
+    "[Integer reply](../topics/protocol.md#integers): the number of the elements in the result set."
   ],
   "SISMEMBER": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the element is not a member of the set, or when the key does not exist.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the element is a member of the set."
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the element is not a member of the set, or when the key does not exist.",
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the element is a member of the set."
   ],
   "SLAVEOF": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SLOWLOG": [],
   "SLOWLOG GET": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of slow log entries per the above format."
+    "[Array reply](../topics/protocol.md#arrays): a list of slow log entries per the above format."
   ],
   "SLOWLOG HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "SLOWLOG LEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries in the slow log."
+    "[Integer reply](../topics/protocol.md#integers): the number of entries in the slow log."
   ],
   "SLOWLOG RESET": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SMEMBERS": [
-    "[Set reply](/docs/reference/protocol-spec#sets): all members of the set."
+    "[Set reply](../topics/protocol.md#sets): all members of the set."
   ],
   "SMISMEMBER": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list representing the membership of the given elements, in the same order as they are requested."
+    "[Array reply](../topics/protocol.md#arrays): a list representing the membership of the given elements, in the same order as they are requested."
   ],
   "SMOVE": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `1` if the element is moved.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `0` if the element is not a member of _source_ and no operation was performed."
+    "* [Integer reply](../topics/protocol.md#integers): `1` if the element is moved.",
+    "* [Integer reply](../topics/protocol.md#integers): `0` if the element is not a member of _source_ and no operation was performed."
   ],
   "SORT": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): without passing the _STORE_ option, the command returns a list of sorted elements.",
-    "[Integer reply](/docs/reference/protocol-spec#integers): when the _STORE_ option is specified, the command returns the number of sorted elements in the destination list."
+    "[Array reply](../topics/protocol.md#arrays): without passing the _STORE_ option, the command returns a list of sorted elements.",
+    "[Integer reply](../topics/protocol.md#integers): when the _STORE_ option is specified, the command returns the number of sorted elements in the destination list."
   ],
   "SORT_RO": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sorted elements."
+    "[Array reply](../topics/protocol.md#arrays): a list of sorted elements."
   ],
   "SPOP": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist.",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): when called without the _count_ argument, the removed member.",
-    "* [Set reply](/docs/reference/protocol-spec#sets): when called with the _count_ argument, the set of removed members."
+    "* [Null reply](../topics/protocol.md#nulls): if the key does not exist.",
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): when called without the _count_ argument, the removed member.",
+    "* [Set reply](../topics/protocol.md#sets): when called with the _count_ argument, the set of removed members."
   ],
   "SPUBLISH": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of clients that received the message. Note that in a Valkey Cluster, only clients that are connected to the same node as the publishing client are included in the count"
+    "[Integer reply](../topics/protocol.md#integers): the number of clients that received the message. Note that in a Valkey Cluster, only clients that are connected to the same node as the publishing client are included in the count"
   ],
   "SRANDMEMBER": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or a [Null reply](/docs/reference/protocol-spec#nulls) when _key_ doesn't exist.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when the optional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or a [Null reply](../topics/protocol.md#nulls) when _key_ doesn't exist.",
+    "* [Array reply](../topics/protocol.md#arrays): when the optional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist."
   ],
   "SREM": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): Number of members that were removed from the set, not including non existing members."
+    "[Integer reply](../topics/protocol.md#integers): Number of members that were removed from the set, not including non existing members."
   ],
   "SSCAN": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, an array with two elements:",
-    "* The first element is a [Bulk string reply](/docs/reference/protocol-spec#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
-    "* The second element is an [Array reply](/docs/reference/protocol-spec#arrays) with the names of scanned members."
+    "[Array reply](../topics/protocol.md#arrays): specifically, an array with two elements:",
+    "* The first element is a [Bulk string reply](../topics/protocol.md#bulk-strings) that represents an unsigned 64-bit number, the cursor.",
+    "* The second element is an [Array reply](../topics/protocol.md#arrays) with the names of scanned members."
   ],
   "SSUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each shard channel, one message with the first element being the string 'ssubscribe' is pushed as a confirmation that the command succeeded. Note that this command can also return a -MOVED redirect."
   ],
   "STRLEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the length of the string stored at key, or 0 when the key does not exist."
+    "[Integer reply](../topics/protocol.md#integers): the length of the string stored at key, or 0 when the key does not exist."
   ],
   "SUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each channel, one message with the first element being the string `subscribe` is pushed as a confirmation that the command succeeded."
   ],
   "SUBSTR": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): the substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
   ],
   "SUNION": [
-    "[Set reply](/docs/reference/protocol-spec#sets): the resulting set."
+    "[Set reply](../topics/protocol.md#sets): the resulting set."
   ],
   "SUNIONSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): Number of the elements in the resulting set."
+    "[Integer reply](../topics/protocol.md#integers): Number of the elements in the resulting set."
   ],
   "SUNSUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each shard channel, one message with the first element being the string `sunsubscribe` is pushed as a confirmation that the command succeeded."
   ],
   "SWAPDB": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "SYNC": [
     "**Non-standard return value**, a bulk transfer of the data followed by `PING` and write requests from the master."
   ],
   "TIME": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): specifically, a two-element array consisting of the Unix timestamp in seconds and the microseconds' count."
+    "[Array reply](../topics/protocol.md#arrays): specifically, a two-element array consisting of the Unix timestamp in seconds and the microseconds' count."
   ],
   "TOUCH": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of touched keys."
+    "[Integer reply](../topics/protocol.md#integers): the number of touched keys."
   ],
   "TTL": [
     "One of the following:",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): TTL in seconds.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-1` if the key exists but has no associated expiration.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): `-2` if the key does not exist."
+    "* [Integer reply](../topics/protocol.md#integers): TTL in seconds.",
+    "* [Integer reply](../topics/protocol.md#integers): `-1` if the key exists but has no associated expiration.",
+    "* [Integer reply](../topics/protocol.md#integers): `-2` if the key does not exist."
   ],
   "TYPE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): the type of _key_, or `none` when _key_ doesn't exist."
+    "[Simple string reply](../topics/protocol.md#simple-strings): the type of _key_, or `none` when _key_ doesn't exist."
   ],
   "UNLINK": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of keys that were unlinked."
+    "[Integer reply](../topics/protocol.md#integers): the number of keys that were unlinked."
   ],
   "UNSUBSCRIBE": [
     "When successful, this command doesn't return anything. Instead, for each channel, one message with the first element being the string `unsubscribe` is pushed as a confirmation that the command succeeded."
   ],
   "UNWATCH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "WAIT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of replicas reached by all the writes performed in the context of the current connection."
+    "[Integer reply](../topics/protocol.md#integers): the number of replicas reached by all the writes performed in the context of the current connection."
   ],
   "WAITAOF": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): The command returns an array of two integers:",
+    "[Array reply](../topics/protocol.md#arrays): The command returns an array of two integers:",
     "1. The first is the number of local Redises (0 or 1) that have fsynced to AOF  all writes performed in the context of the current connection",
     "2. The second is the number of replicas that have acknowledged doing the same."
   ],
   "WATCH": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "XACK": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged."
+    "[Integer reply](../topics/protocol.md#integers): The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged."
   ],
   "XADD": [
     "One of the following:",
-    "* [Bulk string reply](/docs/reference/protocol-spec#bulk-strings): The ID of the added entry. The ID is the one automatically generated if an asterisk (`*`) is passed as the _id_ argument, otherwise the command just returns the same ID specified by the user during insertion.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the NOMKSTREAM option is given and the key doesn't exist."
+    "* [Bulk string reply](../topics/protocol.md#bulk-strings): The ID of the added entry. The ID is the one automatically generated if an asterisk (`*`) is passed as the _id_ argument, otherwise the command just returns the same ID specified by the user during insertion.",
+    "* [Null reply](../topics/protocol.md#nulls): if the NOMKSTREAM option is given and the key doesn't exist."
   ],
   "XAUTOCLAIM": [
-    "[Array reply](/docs/reference/protocol-spec#arrays), specifically, an array with three elements:",
+    "[Array reply](../topics/protocol.md#arrays), specifically, an array with three elements:",
     "1. A stream ID to be used as the _start_ argument for the next call to XAUTOCLAIM.",
-    "2. An [Array reply](/docs/reference/protocol-spec#arrays) containing all the successfully claimed messages in the same format as `XRANGE`.",
-    "3. An [Array reply](/docs/reference/protocol-spec#arrays) containing message IDs that no longer exist in the stream, and were deleted from the PEL in which they were found."
+    "2. An [Array reply](../topics/protocol.md#arrays) containing all the successfully claimed messages in the same format as `XRANGE`.",
+    "3. An [Array reply](../topics/protocol.md#arrays) containing message IDs that no longer exist in the stream, and were deleted from the PEL in which they were found."
   ],
   "XCLAIM": [
     "Any of the following:",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): when the _JUSTID_ option is specified, an array of IDs of messages successfully claimed.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): an array of stream entries, each of which contains an array of two elements, the entry ID and the entry data itself."
+    "* [Array reply](../topics/protocol.md#arrays): when the _JUSTID_ option is specified, an array of IDs of messages successfully claimed.",
+    "* [Array reply](../topics/protocol.md#arrays): an array of stream entries, each of which contains an array of two elements, the entry ID and the entry data itself."
   ],
   "XDEL": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries that were deleted."
+    "[Integer reply](../topics/protocol.md#integers): the number of entries that were deleted."
   ],
   "XGROUP": [],
   "XGROUP CREATE": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "XGROUP CREATECONSUMER": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of created consumers, either 0 or 1."
+    "[Integer reply](../topics/protocol.md#integers): the number of created consumers, either 0 or 1."
   ],
   "XGROUP DELCONSUMER": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of pending messages the consumer had before it was deleted."
+    "[Integer reply](../topics/protocol.md#integers): the number of pending messages the consumer had before it was deleted."
   ],
   "XGROUP DESTROY": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of destroyed consumer groups, either 0 or 1."
+    "[Integer reply](../topics/protocol.md#integers): the number of destroyed consumer groups, either 0 or 1."
   ],
   "XGROUP HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "XGROUP SETID": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "XINFO": [],
   "XINFO CONSUMERS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of consumers and their attributes."
+    "[Array reply](../topics/protocol.md#arrays): a list of consumers and their attributes."
   ],
   "XINFO GROUPS": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of consumer groups."
+    "[Array reply](../topics/protocol.md#arrays): a list of consumer groups."
   ],
   "XINFO HELP": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of sub-commands and their descriptions."
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "XINFO STREAM": [
     "One of the following:",
-    "* [Map reply](/docs/reference/protocol-spec#maps): when the _FULL_ argument was not given, a list of information about a stream in summary form.",
-    "* [Map reply](/docs/reference/protocol-spec#maps): when the _FULL_ argument was given, a list of information about a stream in extended form."
+    "* [Map reply](../topics/protocol.md#maps): when the _FULL_ argument was not given, a list of information about a stream in summary form.",
+    "* [Map reply](../topics/protocol.md#maps): when the _FULL_ argument was given, a list of information about a stream in extended form."
   ],
   "XLEN": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of entries of the stream at _key_."
+    "[Integer reply](../topics/protocol.md#integers): the number of entries of the stream at _key_."
   ],
   "XPENDING": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): different data depending on the way XPENDING is called, as explained on this page."
+    "* [Array reply](../topics/protocol.md#arrays): different data depending on the way XPENDING is called, as explained on this page."
   ],
   "XRANGE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of stream entries with IDs matching the specified range."
+    "[Array reply](../topics/protocol.md#arrays): a list of stream entries with IDs matching the specified range."
   ],
   "XREAD": [
     "One of the following:",
-    "* [Map reply](/docs/reference/protocol-spec#maps): A map of key-value elements where each element is composed of the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
+    "* [Map reply](../topics/protocol.md#maps): A map of key-value elements where each element is composed of the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
+    "* [Null reply](../topics/protocol.md#nulls): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
   ],
   "XREADGROUP": [
     "One of the following:",
-    "* [Map reply](/docs/reference/protocol-spec#maps): A map of key-value elements where each element is composed of the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
+    "* [Map reply](../topics/protocol.md#maps): A map of key-value elements where each element is composed of the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`.",
+    "* [Null reply](../topics/protocol.md#nulls): if the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served."
   ],
   "XREVRANGE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): The command returns the entries with IDs matching the specified range. The returned entries are complete, which means that the ID and all the fields they are composed of are returned. Moreover, the entries are returned with their fields and values in the same order as `XADD` added them."
+    "[Array reply](../topics/protocol.md#arrays): The command returns the entries with IDs matching the specified range. The returned entries are complete, which means that the ID and all the fields they are composed of are returned. Moreover, the entries are returned with their fields and values in the same order as `XADD` added them."
   ],
   "XSETID": [
-    "[Simple string reply](/docs/reference/protocol-spec#simple-strings): `OK`."
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
   "XTRIM": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): The number of entries deleted from the stream."
+    "[Integer reply](../topics/protocol.md#integers): The number of entries deleted from the stream."
   ],
   "ZADD": [
     "Any of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new members when the _CH_ option is not used.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the number of new or updated members when the _CH_ option is used.",
-    "* [Double reply](/docs/reference/protocol-spec#doubles): the updated score of the member when the _INCR_ option is used."
+    "* [Null reply](../topics/protocol.md#nulls): if the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options.",
+    "* [Integer reply](../topics/protocol.md#integers): the number of new members when the _CH_ option is not used.",
+    "* [Integer reply](../topics/protocol.md#integers): the number of new or updated members when the _CH_ option is used.",
+    "* [Double reply](../topics/protocol.md#doubles): the updated score of the member when the _INCR_ option is used."
   ],
   "ZCARD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the cardinality (number of members) of the sorted set, or 0 if the key doesn't exist."
+    "[Integer reply](../topics/protocol.md#integers): the cardinality (number of members) of the sorted set, or 0 if the key doesn't exist."
   ],
   "ZCOUNT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the specified score range."
+    "[Integer reply](../topics/protocol.md#integers): the number of members in the specified score range."
   ],
   "ZDIFF": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the result of the difference including, optionally, scores when the _WITHSCORES_ option is used."
+    "* [Array reply](../topics/protocol.md#arrays): the result of the difference including, optionally, scores when the _WITHSCORES_ option is used."
   ],
   "ZDIFFSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting sorted set at _destination_."
+    "[Integer reply](../topics/protocol.md#integers): the number of members in the resulting sorted set at _destination_."
   ],
   "ZINCRBY": [
-    "[Double reply](/docs/reference/protocol-spec#doubles): the new score of _member_."
+    "[Double reply](../topics/protocol.md#doubles): the new score of _member_."
   ],
   "ZINTER": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the result of the intersection including, optionally, scores when the _WITHSCORES_ option is used."
+    "* [Array reply](../topics/protocol.md#arrays): the result of the intersection including, optionally, scores when the _WITHSCORES_ option is used."
   ],
   "ZINTERCARD": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting intersection."
+    "[Integer reply](../topics/protocol.md#integers): the number of members in the resulting intersection."
   ],
   "ZINTERSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the resulting sorted set at the _destination_."
+    "[Integer reply](../topics/protocol.md#integers): the number of members in the resulting sorted set at the _destination_."
   ],
   "ZLEXCOUNT": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members in the specified score range."
+    "[Integer reply](../topics/protocol.md#integers): the number of members in the specified score range."
   ],
   "ZMPOP": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): when no element could be popped.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
+    "* [Null reply](../topics/protocol.md#nulls): when no element could be popped.",
+    "* [Array reply](../topics/protocol.md#arrays): A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
   ],
   "ZMSCORE": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the member does not exist in the sorted set.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of [Double reply](/docs/reference/protocol-spec#doubles) _member_ scores as double-precision floating point numbers."
+    "* [Null reply](../topics/protocol.md#nulls): if the member does not exist in the sorted set.",
+    "* [Array reply](../topics/protocol.md#arrays): a list of [Double reply](../topics/protocol.md#doubles) _member_ scores as double-precision floating point numbers."
   ],
   "ZPOPMAX": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of popped elements and scores."
+    "* [Array reply](../topics/protocol.md#arrays): a list of popped elements and scores."
   ],
   "ZPOPMIN": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of popped elements and scores."
+    "* [Array reply](../topics/protocol.md#arrays): a list of popped elements and scores."
   ],
   "ZRANDMEMBER": [
-    "[Bulk string reply](/docs/reference/protocol-spec#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or [Null reply](/docs/reference/protocol-spec#nulls) when _key_ doesn't exist.",
-    "[Array reply](/docs/reference/protocol-spec#arrays): when the additional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist. If the _WITHSCORES_ modifier is used, the reply is a list of members and their scores from the sorted set."
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): without the additional _count_ argument, the command returns a randomly selected member, or [Null reply](../topics/protocol.md#nulls) when _key_ doesn't exist.",
+    "[Array reply](../topics/protocol.md#arrays): when the additional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist. If the _WITHSCORES_ modifier is used, the reply is a list of members and their scores from the sorted set."
   ],
   "ZRANGE": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given."
+    "[Array reply](../topics/protocol.md#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given."
   ],
   "ZRANGEBYLEX": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): a list of elements in the specified score range."
+    "[Array reply](../topics/protocol.md#arrays): a list of elements in the specified score range."
   ],
   "ZRANGEBYSCORE": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of the members with, optionally, their scores in the specified score range."
+    "* [Array reply](../topics/protocol.md#arrays): a list of the members with, optionally, their scores in the specified score range."
   ],
   "ZRANGESTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting sorted set."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting sorted set."
   ],
   "ZRANK": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist or the member does not exist in the sorted set.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): the rank of the member when _WITHSCORE_ is not used.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): the rank and score of the member when _WITHSCORE_ is used."
+    "* [Null reply](../topics/protocol.md#nulls): if the key does not exist or the member does not exist in the sorted set.",
+    "* [Integer reply](../topics/protocol.md#integers): the rank of the member when _WITHSCORE_ is not used.",
+    "* [Array reply](../topics/protocol.md#arrays): the rank and score of the member when _WITHSCORE_ is used."
   ],
   "ZREM": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of members removed from the sorted set, not including non-existing members."
+    "[Integer reply](../topics/protocol.md#integers): the number of members removed from the sorted set, not including non-existing members."
   ],
   "ZREMRANGEBYLEX": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): Number of members removed."
+    "[Integer reply](../topics/protocol.md#integers): Number of members removed."
   ],
   "ZREMRANGEBYRANK": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): Number of members removed."
+    "[Integer reply](../topics/protocol.md#integers): Number of members removed."
   ],
   "ZREMRANGEBYSCORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): Number of members removed."
+    "[Integer reply](../topics/protocol.md#integers): Number of members removed."
   ],
   "ZREVRANGE": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of members in the specified range, optionally with their scores if _WITHSCORE_ was used."
+    "* [Array reply](../topics/protocol.md#arrays): a list of members in the specified range, optionally with their scores if _WITHSCORE_ was used."
   ],
   "ZREVRANGEBYLEX": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): List of the elements in the specified score range."
+    "[Array reply](../topics/protocol.md#arrays): List of the elements in the specified score range."
   ],
   "ZREVRANGEBYSCORE": [
-    "* [Array reply](/docs/reference/protocol-spec#arrays): a list of the members and, optionally, their scores in the specified score range."
+    "* [Array reply](../topics/protocol.md#arrays): a list of the members and, optionally, their scores in the specified score range."
   ],
   "ZREVRANK": [
     "One of the following:",
-    "* [Null reply](/docs/reference/protocol-spec#nulls): if the key does not exist or the member does not exist in the sorted set.",
-    "* [Integer reply](/docs/reference/protocol-spec#integers): The rank of the member when _WITHSCORE_ is not used.",
-    "* [Array reply](/docs/reference/protocol-spec#arrays): The rank and score of the member when _WITHSCORE_ is used."
+    "* [Null reply](../topics/protocol.md#nulls): if the key does not exist or the member does not exist in the sorted set.",
+    "* [Integer reply](../topics/protocol.md#integers): The rank of the member when _WITHSCORE_ is not used.",
+    "* [Array reply](../topics/protocol.md#arrays): The rank and score of the member when _WITHSCORE_ is used."
   ],
   "ZSCAN": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): cursor and scan response in array form."
+    "[Array reply](../topics/protocol.md#arrays): cursor and scan response in array form."
   ],
   "ZSCORE": [
     "One of the following:",
-    "* [Double reply](/docs/reference/protocol-spec#doubles): the score of the member (a double-precision floating point number).",
-    "* [Nil reply](/docs/reference/protocol-spec#bulk-strings): if _member_ does not exist in the sorted set, or the key does not exist."
+    "* [Double reply](../topics/protocol.md#doubles): the score of the member (a double-precision floating point number).",
+    "* [Nil reply](../topics/protocol.md#bulk-strings): if _member_ does not exist in the sorted set, or the key does not exist."
   ],
   "ZUNION": [
-    "[Array reply](/docs/reference/protocol-spec#arrays): the result of the union with, optionally, their scores when _WITHSCORES_ is used."
+    "[Array reply](../topics/protocol.md#arrays): the result of the union with, optionally, their scores when _WITHSCORES_ is used."
   ],
   "ZUNIONSTORE": [
-    "[Integer reply](/docs/reference/protocol-spec#integers): the number of elements in the resulting sorted set."
+    "[Integer reply](../topics/protocol.md#integers): the number of elements in the resulting sorted set."
   ]
 }

--- a/topics/bitmaps.md
+++ b/topics/bitmaps.md
@@ -22,7 +22,7 @@ Some examples of bitmap use cases include:
 * `SETBIT` sets a bit at the provided offset to 0 or 1.
 * `GETBIT` returns the value of a bit at a given offset.
 
-See the [complete list of bitmap commands](../commands/?group=bitmap).
+See the [complete list of bitmap commands](../commands/#bitmap).
 
 
 ## Example

--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -326,7 +326,7 @@ to run the script.
 #### Interact with the cluster
 
 To connect to Valkey Cluster, you'll need a cluster-aware Valkey client. 
-See the documentation for your [client of choice](/resources/clients/) to determine its cluster support.
+See the documentation for your [client of choice](../clients/) to determine its cluster support.
 
 You can also test your Valkey Cluster using the `valkey-cli` command line utility:
 

--- a/topics/command-arguments.md
+++ b/topics/command-arguments.md
@@ -49,7 +49,7 @@ Every element in the _arguments_ array is a map with the following fields:
   For arguments types other than _oneof_ and _block_, this is a string that describes the value in the command's syntax.
   For the _oneof_ and _block_ types, this is an array of nested arguments, each being a map as described in this section.
 
-[tr]: /topics/key-specs
+[tr]: key-specs.md
 
 ## Example
 

--- a/topics/data-store.md
+++ b/topics/data-store.md
@@ -16,11 +16,13 @@ The examples in this article refer to a simple bicycle inventory.
 
 ## Setup
 
-See the [installation guides](/docs/install/install-redis/) to install Valkey on your local machine.
+See the [installation guides](installation.md) to install Valkey on your local machine.
 
 ## Connect
 
-The first step is to connect to Valkey. You can find further details about the connection options in this documentation site's [connection section](/docs/connect/). The following example shows how to connect to a Valkey server that runs on localhost (`-h 127.0.0.1`) and listens on the default port (`-p 6379`): 
+The first step is to connect to Valkey. There are client connectors for [most programming languages](../clients/).
+You can also connect using [valkey-cli][cli.md], the command line interface.
+The following example shows how to connect to a Valkey server that runs on localhost (`-h 127.0.0.1`) and listens on the default port (`-p 6379`):
 
 ```sh
 $ valkey-cli -h 127.0.0.1 -p 6379
@@ -59,7 +61,7 @@ Hashes are the equivalent of dictionaries (dicts or hash maps). Among other thin
 8) "4972"
 ```
 
-You can get a complete overview of available data types in this documentation site's [data types section](/docs/data-types/). Each data type has commands allowing you to manipulate or retrieve data. The [commands reference](../commands/) provides a sophisticated explanation.
+You can get a complete overview of available data types in this documentation site's [data types section](data-types.md). Each data type has commands allowing you to manipulate or retrieve data. The [commands reference](../commands/) provides a sophisticated explanation.
 
 ## Scan the keyspace
 

--- a/topics/data-types.md
+++ b/topics/data-types.md
@@ -21,7 +21,7 @@ If you'd like to try a comprehensive tutorial for each data structure, see their
 For more information, see:
 
 * [Overview of Strings](strings.md)
-* [String command reference](../commands/?group=string)
+* [String command reference](../commands/#string)
 
 ## Lists
 
@@ -29,7 +29,7 @@ For more information, see:
 For more information, see:
 
 * [Overview of Lists](lists.md)
-* [List command reference](../commands/?group=list)
+* [List command reference](../commands/#list)
 
 ## Sets
 
@@ -38,7 +38,7 @@ With a Set, you can add, remove, and test for existence in O(1) time (in other w
 For more information, see:
 
 * [Overview of Sets](sets.md)
-* [Set command reference](../commands/?group=set)
+* [Set command reference](../commands/#set)
 
 ## Hashes
 
@@ -47,7 +47,7 @@ As such, Hashes resemble [Python dictionaries](https://docs.python.org/3/tutoria
 For more information, see:
 
 * [Overview of Hashes](hashes.md)
-* [Hashes command reference](../commands/?group=hash)
+* [Hashes command reference](../commands/#hash)
 
 ## Sorted sets
 
@@ -55,7 +55,7 @@ For more information, see:
 For more information, see:
 
 * [Overview of Sorted Sets](sorted-sets.md)
-* [Sorted Set command reference](../commands/?group=sorted-set)
+* [Sorted Set command reference](../commands/#sorted-set)
 
 ## Streams
 
@@ -64,7 +64,7 @@ Streams help record events in the order they occur and then syndicate them for p
 For more information, see:
 
 * [Overview of Streams](streams-intro.md)
-* [Streams command reference](../commands/?group=stream)
+* [Streams command reference](../commands/#stream)
 
 ## Geospatial indexes
 
@@ -72,7 +72,7 @@ For more information, see:
 For more information, see:
 
 * [Overview of Geospatial indexes](geospatial.md)
-* [Geospatial indexes command reference](../commands/?group=geo)
+* [Geospatial indexes command reference](../commands/#geo)
 
 ## Bitmaps
 
@@ -80,7 +80,7 @@ For more information, see:
 For more information, see:
 
 * [Overview of Bitmaps](bitmaps.md)
-* [Bitmap command reference](../commands/?group=bitmap)
+* [Bitmap command reference](../commands/#bitmap)
 
 ## Bitfields
 
@@ -96,7 +96,7 @@ For more information, see:
 The [HyperLogLog](hyperloglogs.md) data structures provide probabilistic estimates of the cardinality (i.e., number of elements) of large sets. For more information, see:
 
 * [Overview of HyperLogLog](hyperloglogs.md)
-* [HyperLogLog command reference](../commands/?group=hyperloglog)
+* [HyperLogLog command reference](../commands/#hyperloglog)
 
 ## Extensions
 

--- a/topics/data-types.md
+++ b/topics/data-types.md
@@ -103,6 +103,6 @@ The [HyperLogLog](hyperloglogs.md) data structures provide probabilistic estimat
 To extend the features provided by the included data types, use one of these options:
 
 1. Write your own custom [server-side functions in Lua](programmability.md).
-1. Write your own Valkey module using the [modules API](modules-intro.md) or check out the [community-supported modules](../resources/modules/).
+1. Write your own Valkey module using the [modules API](modules-intro.md) or check out the [community-supported modules](../modules/).
 
 <hr>

--- a/topics/eval-intro.md
+++ b/topics/eval-intro.md
@@ -177,7 +177,7 @@ For example:
 ```
 
 In this case, the application should first load it with `SCRIPT LOAD` and then call `EVALSHA` once more to run the cached script by its SHA1 sum.
-Most of [Valkey' clients](/clients/) already provide utility APIs for doing that automatically.
+Most of [Valkey' clients](../clients/) already provide utility APIs for doing that automatically.
 Please consult your client's documentation regarding the specific details.
 
 ### `!EVALSHA` in the context of pipelining

--- a/topics/geospatial.md
+++ b/topics/geospatial.md
@@ -14,7 +14,7 @@ This data structure is useful for finding nearby points within a given radius or
 * `GEOADD` adds a location to a given geospatial index (note that longitude comes before latitude with this command).
 * `GEOSEARCH` returns locations with a given radius or a bounding box.
 
-See the [complete list of geospatial index commands](../commands/?group=geo).
+See the [complete list of geospatial index commands](../commands/#geo).
 
 
 ## Examples

--- a/topics/hashes.md
+++ b/topics/hashes.md
@@ -63,7 +63,7 @@ encoded in special way in memory that make them very memory efficient.
 * `HMGET` returns the values at one or more given fields.
 * `HINCRBY` increments the value at a given field by the integer provided.
 
-See the [complete list of hash commands](../commands/?group=hash).
+See the [complete list of hash commands](../commands/#hash).
 
 
 ## Examples

--- a/topics/history.md
+++ b/topics/history.md
@@ -129,7 +129,7 @@ Itamar Haber from Redis Labs, Zhao Zhao from Alibaba and Madelyn Olson from
 Amazon. The members were selected “based on demonstrated, long-term personal
 involvement and contributions”. This was described in the projects
 [Governance][governance-2020] page which was the inspiration for the current
-[Valkey governance](valkey-governance).
+[Valkey governance][valkey-governance].
 
 [governance-2020]: https://web.archive.org/web/20200709170526/https://redis.io/topics/governance
 [valkey-governance]: https://github.com/valkey-io/valkey/blob/unstable/GOVERNANCE.md

--- a/topics/hyperloglogs.md
+++ b/topics/hyperloglogs.md
@@ -79,7 +79,7 @@ One HyperLogLog is created per page (video/song) per period, and every IP/identi
 * `PFCOUNT` returns an estimate of the number of items in the set.
 * `PFMERGE` combines two or more HyperLogLogs into one.
 
-See the [complete list of HyperLogLog commands](../commands/?group=hyperloglog).
+See the [complete list of HyperLogLog commands](../commands/#hyperloglog).
 
 ## Performance
 

--- a/topics/installation.md
+++ b/topics/installation.md
@@ -86,7 +86,7 @@ Note that a Valkey instance exposed to the internet without any security [is ver
 
 Of course using Valkey just from the command line interface is not enough as the goal is to use it from your application. To do so, you need to download and install a Valkey client library for your programming language.
 
-You'll find a [full list of clients for different languages in this page](/clients/).
+You'll find a [full list of clients for different languages in this page](../clients/).
 
 
 ## Valkey persistence

--- a/topics/introduction.md
+++ b/topics/introduction.md
@@ -34,7 +34,7 @@ Valkey also includes:
 * [LRU eviction of keys](lru-cache.md)
 * [Automatic failover](sentinel.md)
 
-You can use Valkey from [most programming languages](/clients/).
+You can use Valkey from [most programming languages](../clients/).
 
 Valkey is written in **ANSI C** and works on most POSIX systems like Linux,
 \*BSD, and Mac OS X, without external dependencies. Linux and OS X are the two operating systems where Valkey is developed and tested the most, and we **recommend using Linux for deployment**. Valkey may work in Solaris-derived systems like SmartOS, but support is *best effort*.

--- a/topics/key-specs.md
+++ b/topics/key-specs.md
@@ -101,7 +101,6 @@ Examples:
 * The `MSET` command has a _range_ of _-1_, _2_ and _0_.
 * The `XREAD` command has a _range_ of _-1_, _1_ and _2_.
 * The `ZUNION` command has a _start_search_ type _index_ with the value _1_, and `find_keys` of type _keynum_ with values of _0_, _1_ and _1_.
-* The [`AI.DAGRUN`](https://oss.redislabs.com/redisai/master/commands/#aidagrun) command has a _start_search_ of type _keyword_ with values of _"LOAD"_ and _1_, and `find_keys` of type _keynum_ with values of _0_, _1_ and _1_.
 
 **Note:**
 this isn't a perfect solution as the module writers can come up with anything.

--- a/topics/keyspace.md
+++ b/topics/keyspace.md
@@ -131,7 +131,7 @@ Don't use `KEYS` in your regular application code.
 If you're looking for a way to find keys in a subset of your keyspace, consider
 using `SCAN` or [sets][tdts].
 
-[tdts]: /topics/data-types#sets
+[tdts]: data-types.md#sets
 
 Supported glob-style patterns:
 

--- a/topics/lists.md
+++ b/topics/lists.md
@@ -30,7 +30,7 @@ For example:
 * `BLMOVE` atomically moves elements from a source list to a target list.
   If the source list is empty, the command will block until a new element becomes available.
 
-See the [complete series of list commands](../commands/?group=list).
+See the [complete series of list commands](../commands/#list).
 
 ## Examples
 

--- a/topics/persistence.md
+++ b/topics/persistence.md
@@ -26,7 +26,7 @@ To learn more about how to evaluate your Valkey persistence strategy, read on.
 * RDB is very good for disaster recovery, being a single compact file that can be transferred to far data centers, or onto Amazon S3 (possibly encrypted).
 * RDB maximizes Valkey performances since the only work the Valkey parent process needs to do in order to persist is forking a child that will do all the rest. The parent process will never perform disk I/O or alike.
 * RDB allows faster restarts with big datasets compared to AOF.
-* On replicas, RDB supports [partial resynchronizations after restarts and failovers](https://valkey.io/topics/replication#partial-resynchronizations-after-restarts-and-failovers).
+* On replicas, RDB supports [partial resynchronizations after restarts and failovers](replication.md#partial-resynchronizations-after-restarts-and-failovers).
 
 ## RDB disadvantages
 

--- a/topics/protocol.md
+++ b/topics/protocol.md
@@ -64,7 +64,7 @@ This is the simplest model possible; however, there are some exceptions:
 * The `MONITOR` command.
   Invoking the `MONITOR` command switches the connection to an ad-hoc push mode.
   The protocol of this mode is not specified but is obvious to parse.
-* [Protected mode](/docs/management/security/#protected-mode).
+* [Protected mode](security.md#protected-mode).
   Connections opened from a non-loopback address to a Valkey while in protected mode are denied and terminated by the server.
   Before terminating the connection, Valkey unconditionally sends a `-DENIED` reply, regardless of whether the client writes to the socket.
 * The [RESP3 Push type](#resp3-pushes).

--- a/topics/sets.md
+++ b/topics/sets.md
@@ -21,7 +21,7 @@ You can use Sets to efficiently:
 * `SINTER` returns the set of members that two or more sets have in common (i.e., the intersection).
 * `SCARD` returns the size (a.k.a. cardinality) of a set.
 
-See the [complete list of set commands](../commands/?group=set).
+See the [complete list of set commands](../commands/#set).
 
 ## Examples
 

--- a/topics/sorted-sets.md
+++ b/topics/sorted-sets.md
@@ -223,7 +223,7 @@ You'll see that `ZADD` returns 0 when the member already exists (the score is up
 * `ZRANK` returns the rank of the provided member, assuming the sorted is in ascending order.
 * `ZREVRANK` returns the rank of the provided member, assuming the sorted set is in descending order.
  
-See the [complete list of sorted set commands](../commands/?group=sorted-set).
+See the [complete list of sorted set commands](../commands/#sorted-set).
 
 ## Performance
 

--- a/topics/streams-intro.md
+++ b/topics/streams-intro.md
@@ -29,7 +29,7 @@ Streams support several trimming strategies (to prevent streams from growing unb
 * `XRANGE` returns a range of entries between two supplied entry IDs.
 * `XLEN` returns the length of a stream.
  
-See the [complete list of stream commands](../commands/?group=stream).
+See the [complete list of stream commands](../commands/#stream).
 
 
 ## Examples

--- a/topics/strings.md
+++ b/topics/strings.md
@@ -115,7 +115,7 @@ By default, a single String can be a maximum of 512 MB.
 
 To perform bitwise operations on a string, see the [bitmaps data type](bitmaps.md) docs.
 
-See the [complete list of string commands](../commands/?group=string).
+See the [complete list of string commands](../commands/#string).
 
 ## Performance
 


### PR DESCRIPTION
After validation, I discovered these internal links that were either broken links, absolute paths or missing the .md suffix. All internal links are now relative with the actual filename, .md for most of them.

There are some links to the directories `commands/`, `clients/` and `modules/`. These pages (index.html) should be generated when deploying.