### PR TITLE
Generate man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 tmp
 .DS_Store
+_build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,198 @@
+# Copyright (C) 2024, The Valkey contributors
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Path to the code repo.
+VALKEY_ROOT ?= ../valkey
+
+# Where to install man pages
+INSTALL_MAN_DIR ?= /usr/local/share/man
+
+# Where to put the generated pages.
+BUILD_DIR ?= _build
+MD_DIR ?= $(BUILD_DIR)/md
+MAN_DIR ?= $(BUILD_DIR)/man
+HTML_DIR ?= $(BUILD_DIR)/html
+
+# -----------------------------------
+
+.PHONY: all man html md clean distclean install uninstall
+
+all: man
+
+# ---- Sanity check ----
+
+ifeq ("$(wildcard $(VALKEY_ROOT))","")
+    $(error Please proved the VALKEY_ROOT variable pointing to the Valkey source code)
+endif
+
+# ---- Source files ----
+
+topics   = $(wildcard topics/*)
+commands = $(wildcard commands/*.md)
+
+# ---- Temp files ----
+
+# JSON files for the commands that have a .md file (excluding undocumented commands).
+json_for_documented_commands = $(commands:commands/%.md=$(VALKEY_ROOT)/src/commands/%.json)
+
+$(BUILD_DIR)/.commands-per-group.json: $(VALKEY_ROOT)/src/commands/. utils/build-command-groups.py | $(BUILD_DIR)
+	utils/build-command-groups.py $(json_for_documented_commands) > $@
+$(BUILD_DIR):
+	mkdir -p $@
+
+# ---- Pre-processed mardown files (make md) ----
+
+md_topics_dir = $(MD_DIR)/topics
+md_topics = $(topics:topics/%=$(md_topics_dir)/%)
+$(md_topics): | $(md_topics_dir)
+
+md_commands_dir  = $(MD_DIR)/commands
+md_commands      = $(commands:commands/%=$(md_commands_dir)/%)
+$(md_commands): | $(md_commands_dir)
+
+md_targets = $(md_topics) $(md_commands) $(md_commands_dir)/index.md
+
+$(md_topics_dir) $(md_commands_dir):
+	mkdir -p $@
+
+$(md_topics_dir)/%.md: topics/%.md utils/preprocess-markdown.py | $(md_topics_dir)
+	utils/preprocess-markdown.py $< > $@
+$(md_topics_dir)/%.png: topics/%.png | $(md_topics_dir)
+	cp $< $@
+$(md_topics_dir)/%.gif: topics/%.gif | $(md_topics_dir)
+	cp $< $@
+
+$(md_commands_dir)/index.md: $(BUILD_DIR)/.commands-per-group.json groups.json utils/build-command-index.py | $(md_commands_dir)
+	utils/build-command-index.py --suffix .md \
+	 --groups-json groups.json \
+	 --commands-per-group-json $(BUILD_DIR)/.commands-per-group.json > $@
+
+$(md_commands_dir)/%.md: commands/%.md $(VALKEY_ROOT)/src/commands/%.json $(BUILD_DIR)/.commands-per-group.json \
+                         utils/preprocess-markdown.py utils/command_syntax.py
+	utils/preprocess-markdown.py --page-type command \
+	 --commands-per-group-json $(BUILD_DIR)/.commands-per-group.json \
+	 --valkey-root $(VALKEY_ROOT) $< > $@
+
+# ---- HTML (make html) ----
+
+html_topics_dir = $(HTML_DIR)/topics
+html_topics     = $(topics:topics/%.md=$(html_topics_dir)/%.html)
+html_topics_pics = $(topics:topics/%.png=$(html_topics_dir)/%.png) $(topics:topics/%.gif=$(html_topics_dir)/%.gif)
+$(html_topics): | $(html_topics_dir)
+
+html_commands_dir = $(HTML_DIR)/commands
+html_commands     = $(commands:commands/%.md=$(html_commands_dir)/%.html)
+$(html_commands): | $(html_commands_dir)
+
+html_targets = $(html_topics) $(html_topics_pics) $(html_commands) $(html_commands_dir)/index.html
+
+$(html_topics_dir) $(html_commands_dir):
+	mkdir -p $@
+
+$(html_topics_dir)/%.html: topics/%.md utils/preprocess-markdown.py | $(html_topics_dir)
+	utils/preprocess-markdown.py --suffix .html $< | pandoc -s --to html -o $@ -
+$(html_topics_dir)/%.png: topics/%.png | $(html_topics_dir)
+	cp $< $@
+$(html_topics_dir)/%.gif: topics/%.gif | $(html_topics_dir)
+	cp $< $@
+
+$(html_commands_dir)/index.html: $(BUILD_DIR)/.commands-per-group.json groups.json utils/build-command-index.py | $(html_commands_dir)
+	utils/build-command-index.py --suffix .html \
+	 --groups-json groups.json \
+	 --commands-per-group-json $(BUILD_DIR)/.commands-per-group.json \
+	 | pandoc -s --to html -o $@ -
+$(html_commands_dir)/%.html: commands/%.md $(VALKEY_ROOT)/src/commands/%.json $(BUILD_DIR)/.commands-per-group.json \
+                             utils/preprocess-markdown.py utils/command_syntax.py
+	utils/preprocess-markdown.py --suffix .html --page-type command \
+	 --commands-per-group-json $(BUILD_DIR)/.commands-per-group.json \
+	 --valkey-root $(VALKEY_ROOT) $< \
+	 | pandoc -s --to html -o $@ -
+
+# ---- Man pages (make man) ----
+
+# Split topics into configs, programs and topics
+progs = valkey-cli valkey-server valkey-benchmark valkey-sentinel valkey-check-rdb valkey-check-aof
+programs = $(progs:valkey-%=topics/%.md)
+configs = topics/valkey.conf.md
+
+man1_src = $(filter $(programs),$(topics))
+man3_src = $(commands)
+man4_src = $(filter $(configs),$(topics))
+man7_src = $(filter-out $(programs) $(configs) topics/index.md,$(topics))
+
+# Target man pages
+man1     = $(man1_src:topics/%.md=$(MAN_DIR)/man1/valkey-%.1)
+man3     = $(man3_src:commands/%.md=$(MAN_DIR)/man3/%.3valkey)
+man4     = $(man4_src:topics/%.md=$(MAN_DIR)/man4/%.4)
+man7     = $(man7_src:topics/%.md=$(MAN_DIR)/man7/valkey-%.7) $(MAN_DIR)/man7/valkey-commands.7 $(MAN_DIR)/man7/valkey.7
+
+man_targets = $(man1) $(man3) $(man4) $(man7)
+
+$(man1): | $(MAN_DIR)/man1
+$(man3): | $(MAN_DIR)/man3
+$(man4): | $(MAN_DIR)/man4
+$(man7): | $(MAN_DIR)/man7
+$(MAN_DIR)/man1 $(MAN_DIR)/man3 $(MAN_DIR)/man4 $(MAN_DIR)/man7:
+	mkdir -p $@
+
+man_scripts = utils/preprocess-markdown.py utils/command_syntax.py utils/links-to-man.py
+
+$(MAN_DIR)/man1/valkey-%.1: topics/%.md $(man_scripts)
+	utils/preprocess-markdown.py --man --page-type program $< \
+	 | utils/links-to-man.py - | pandoc -s --to man -o $@ -
+$(MAN_DIR)/man3/%.3valkey: commands/%.md $(VALKEY_ROOT)/src/commands/%.json $(BUILD_DIR)/.commands-per-group.json $(man_scripts)
+	utils/preprocess-markdown.py --man --page-type command \
+	 --commands-per-group-json $(BUILD_DIR)/.commands-per-group.json \
+	 --valkey-root $(VALKEY_ROOT) $< \
+	 | utils/links-to-man.py - | pandoc -s --to man -o $@ -
+$(MAN_DIR)/man4/%.4: topics/%.md $(man_scripts)
+	utils/preprocess-markdown.py --man --page-type config $< \
+	 | utils/links-to-man.py - | pandoc -s --to man -o $@ -
+$(MAN_DIR)/man7/valkey-%.7: topics/%.md $(man_scripts)
+	utils/preprocess-markdown.py --man --page-type topic $< \
+	 | utils/links-to-man.py - | pandoc -s --to man -o $@ -
+$(MAN_DIR)/man7/valkey.7: topics/index.md $(man_scripts)
+	utils/preprocess-markdown.py --man --page-type topic $< \
+	 | utils/links-to-man.py - | pandoc -s --to man -o $@ -
+$(MAN_DIR)/man7/valkey-commands.7: $(BUILD_DIR)/.commands-per-group.json groups.json utils/build-command-index.py
+	utils/build-command-index.py --man \
+	 --groups-json groups.json \
+	 --commands-per-group-json $(BUILD_DIR)/.commands-per-group.json \
+	 | pandoc -s --to man -o $@ -
+
+.PHONY: install-man uninstall-man
+install-man: man | $(INSTALL_MAN_DIR)/man1 $(INSTALL_MAN_DIR)/man3 $(INSTALL_MAN_DIR)/man4 $(INSTALL_MAN_DIR)/man7
+	cp $(MAN_DIR)/man1/valkey*.1 $(INSTALL_MAN_DIR)/man1/
+	cp $(MAN_DIR)/man3/*.3valkey $(INSTALL_MAN_DIR)/man3/
+	cp $(MAN_DIR)/man4/valkey*.4 $(INSTALL_MAN_DIR)/man4/
+	cp $(MAN_DIR)/man7/valkey*.7 $(INSTALL_MAN_DIR)/man7/
+
+$(INSTALL_MAN_DIR)/man1 $(INSTALL_MAN_DIR)/man3 $(INSTALL_MAN_DIR)/man4 $(INSTALL_MAN_DIR)/man7:
+	mkdir -p $@
+
+uninstall-man:
+	rm $(INSTALL_MAN_DIR)/man1/valkey*.1
+	rm $(INSTALL_MAN_DIR)/man3/*.3valkey
+	rm $(INSTALL_MAN_DIR)/man4/valkey*.4
+	rm $(INSTALL_MAN_DIR)/man7/valkey*.7
+
+# -------
+
+# All targets
+targets = $(man_targets) $(html_targets) $(md_targets)
+
+md: $(md_targets)
+
+html: $(html_targets)
+
+man: $(man_targets)
+
+clean:
+	rm -f $(targets) $(BUILD_DIR)/.commands-per-group.json
+distclean:
+	rm -rf $(BUILD_DIR)
+
+install: install-man
+
+uninstall: uninstall-man

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ endif
 topics   = $(wildcard topics/*)
 commands = $(wildcard commands/*.md)
 
+topics_md   = $(filter %.md,$(topics))
+topics_pics = $(filter-out %.md,$(topics))
+
 # ---- Temp files ----
 
 # JSON files for the commands that have a .md file (excluding undocumented commands).
@@ -81,8 +84,8 @@ $(md_commands_dir)/%.md: commands/%.md $(VALKEY_ROOT)/src/commands/%.json $(BUIL
 # ---- HTML (make html) ----
 
 html_topics_dir = $(HTML_DIR)/topics
-html_topics     = $(topics:topics/%.md=$(html_topics_dir)/%.html)
-html_topics_pics = $(topics:topics/%.png=$(html_topics_dir)/%.png) $(topics:topics/%.gif=$(html_topics_dir)/%.gif)
+html_topics     = $(topics_md:topics/%.md=$(html_topics_dir)/%.html)
+html_topics_pics = $(topics_pics:topics/%=$(html_topics_dir)/%)
 $(html_topics): | $(html_topics_dir)
 
 html_commands_dir = $(HTML_DIR)/commands
@@ -120,10 +123,10 @@ progs = valkey-cli valkey-server valkey-benchmark valkey-sentinel valkey-check-r
 programs = $(progs:valkey-%=topics/%.md)
 configs = topics/valkey.conf.md
 
-man1_src = $(filter $(programs),$(topics))
+man1_src = $(filter $(programs),$(topics_md))
 man3_src = $(commands)
-man4_src = $(filter $(configs),$(topics))
-man7_src = $(filter-out $(programs) $(configs) topics/index.md,$(topics))
+man4_src = $(filter $(configs),$(topics_md))
+man7_src = $(filter-out $(programs) $(configs) topics/index.md,$(topics_md))
 
 # Target man pages
 man1     = $(man1_src:topics/%.md=$(MAN_DIR)/man1/valkey-%.1)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all: man
 # ---- Sanity check ----
 
 ifeq ("$(wildcard $(VALKEY_ROOT))","")
-    $(error Please proved the VALKEY_ROOT variable pointing to the Valkey source code)
+    $(error Please provide the VALKEY_ROOT variable pointing to the Valkey source code)
 endif
 
 # ---- Source files ----
@@ -41,7 +41,7 @@ $(BUILD_DIR)/.commands-per-group.json: $(VALKEY_ROOT)/src/commands/. utils/build
 $(BUILD_DIR):
 	mkdir -p $@
 
-# ---- Pre-processed mardown files (make md) ----
+# ---- Pre-processed markdown files (make md) ----
 
 md_topics_dir = $(MD_DIR)/topics
 md_topics = $(topics:topics/%=$(md_topics_dir)/%)

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ ifeq ("$(wildcard $(VALKEY_ROOT))","")
     $(error Please provide the VALKEY_ROOT variable pointing to the Valkey source code)
 endif
 
+ifeq ("$(shell which pandoc)","")
+    $(error Please install pandoc)
+endif
+
 # ---- Source files ----
 
 topics   = $(wildcard topics/*)

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ The content of this doc repo is backing the documentation on the website, man
 pages and potentially other formats. Links between pages are *relative* and
 point directly to the `.md` files as they are stored in this repo. Don't start
 links with `/`. This makes sure the links point to existing files regardless of
-where in the file system they docs are located, which makes it easier find
+where in the file system the docs are located, which makes it easier to find
 broken links. In text editors and in the GitHub user inteface, it's possible to
 click on the links to open the corresponding Markdown page. Here's a [starting point](
 
 Examples: `../commands/get.md` or `replication.md`.
 
-A few exeptions are links to the `topics/`, `commands/`, `clients/` and
+A few exceptions are links to the `topics/`, `commands/`, `clients/` and
 `modules/` directories, which end with a slash. These pages are generated (with
-the exeption of `topics/` which is in `topics/index.md`).
+the exception of `topics/` which is in `topics/index.md`).
 
 Examples: `../commands/#sorted-set`, `../topics/`, `./`.
 
@@ -45,13 +45,13 @@ Examples: `../commands/#sorted-set`, `../topics/`, `./`.
 The files under `topics/` are generic documentation pages. The `index.md` page is a starting point.
 
 In the top of these files, there's a frontmatter metadata section, between two
-linkes of three dashes (`---`). These are YAML fields of which we use only the
+lines of three dashes (`---`). These are YAML fields of which we use only the
 `title` field (and possibly `linkTitle`). The title field is used instead of an
 H1 heading in each of the pages.
 
 ### Clients, modules, libraries, tools
 
-We maintain links to clients, module, libraries and tool in various langauges in
+We maintain links to clients, modules, libraries and tools in various langauges in
 JSON files stored under `clients/`, `modules/`, `libraries/` and `tools/`
 respectively.
 
@@ -89,13 +89,13 @@ See: https://github.com/valkey-io/valkey/tree/unstable/src/commands/
 
 For each command there's a Markdown file with a complete, human-readable
 description.
-We process this files to provide a better experience.
+We process these files to provide a better experience.
 
 *   Inside text, all commands should be written in all caps, in between
     backticks.
     For example: `INCR`.
 
-The reply types and descriptsions are stored in separate JSON files in this doc repo.
+The reply types and descriptions are stored in separate JSON files in this doc repo.
 Each command will have a description and both RESP2 and RESP3 return values.
 When adding or editing return values, be sure to edit both files. Use the following
 links for the reply type.
@@ -127,7 +127,7 @@ Please use the following formatting rules (aiming for smaller diffs that are eas
   That makes the diff harder to review when only one word is changed.
 * Single linebreaks are not significant in Markdown, so when editing an existing
   sentence or paragraph, don't change the existing linebreaks. That just makes
-  reviewing harding.
+  reviewing harder.
 
 ### Checking your work
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ This repo comes with a Makefile to build and install man pages.
     make VALKEY_ROOT=path/to/valkey
     sudo make install INSTALL_MAN_DIR=/usr/local/share/man
 
-Prerequisites: GNU Make, Python 3, Pandoc. Additionally, the scripts need access
-to the valkey code repo, where metadata files about the commands are stored.
+Prerequisites: GNU Make, Python 3, Python 3 YAML (pyyaml), Pandoc.
+Additionally, the scripts need access to the valkey code repo,
+where metadata files about the commands are stored.
 
 The pages are generated under `_build/man/` by default. The default install
 location is `/usr/local/share/man` (in the appropriate subdirectories).
@@ -128,6 +129,7 @@ Please use the following formatting rules (aiming for smaller diffs that are eas
 * Single linebreaks are not significant in Markdown, so when editing an existing
   sentence or paragraph, don't change the existing linebreaks. That just makes
   reviewing harder.
+* Start every sentence on a new line.
 
 ### Checking your work
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ point directly to the `.md` files as they are stored in this repo. Don't start
 links with `/`. This makes sure the links point to existing files regardless of
 where in the file system the docs are located, which makes it easier to find
 broken links. In text editors and in the GitHub user inteface, it's possible to
-click on the links to open the corresponding Markdown page. Here's a [starting point](
+click on the links to open the corresponding Markdown page.
 
 Examples: `../commands/get.md` or `replication.md`.
 
@@ -132,8 +132,6 @@ Please use the following formatting rules (aiming for smaller diffs that are eas
 * Start every sentence on a new line.
 
 ### Checking your work
-
-(This section may not be up do date.)
 
 After making changes to the documentation, you can use the [spellchecker-cli package](https://www.npmjs.com/package/spellchecker-cli)
 to validate your spelling as well as some minor grammatical errors. You can install the spellchecker locally by running:

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Please use the following formatting rules (aiming for smaller diffs that are eas
 
 (This section may not be up do date.)
 
-    After making changes to the documentation, you can use the [spellchecker-cli package](https://www.npmjs.com/package/spellchecker-cli)
+After making changes to the documentation, you can use the [spellchecker-cli package](https://www.npmjs.com/package/spellchecker-cli)
 to validate your spelling as well as some minor grammatical errors. You can install the spellchecker locally by running:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,8 +1,61 @@
 # Valkey documentation
 
-## Clients
+This repo contains the Valkey documentation in Markdown format, which is used
+for generating content for the website and man pages.
 
-**Important**:  Clients listed here, while fully compatible with Valkey, are not official clients for Valkey.
+## Installing man pages
+
+This repo comes with a Makefile to build and install man pages.
+
+    make VALKEY_ROOT=path/to/valkey
+    sudo make install INSTALL_MAN_DIR=/usr/local/share/man
+
+Prerequisites: GNU Make, Python 3, Pandoc. Additionally, the scripts need access
+to the valkey code repo, where metadata files about the commands are stored.
+
+The pages are generated under `_build/man/` by default. The default install
+location is `/usr/local/share/man` (in the appropriate subdirectories).
+
+To uninstall the man pages, run as root `make uninstall INSTALL_MAN_DIR=/usr/local/share/man`.
+
+It's also possible to build local HTML files for local usage, using `make html`.
+These HTML files are generated under `_build/html/` by default. The starting
+point of the documentation is `topics/index.html`.
+
+## Writing docs
+
+The content of this doc repo is backing the documentation on the website, man
+pages and potentially other formats. Links between pages are *relative* and
+point directly to the `.md` files as they are stored in this repo. Don't start
+links with `/`. This makes sure the links point to existing files regardless of
+where in the file system they docs are located, which makes it easier find
+broken links. In text editors and in the GitHub user inteface, it's possible to
+click on the links to open the corresponding Markdown page. Here's a [starting point](
+
+Examples: `../commands/get.md` or `replication.md`.
+
+A few exeptions are links to the `topics/`, `commands/`, `clients/` and
+`modules/` directories, which end with a slash. These pages are generated (with
+the exeption of `topics/` which is in `topics/index.md`).
+
+Examples: `../commands/#sorted-set`, `../topics/`, `./`.
+
+### Topics
+
+The files under `topics/` are generic documentation pages. The `index.md` page is a starting point.
+
+In the top of these files, there's a frontmatter metadata section, between two
+linkes of three dashes (`---`). These are YAML fields of which we use only the
+`title` field (and possibly `linkTitle`). The title field is used instead of an
+H1 heading in each of the pages.
+
+### Clients, modules, libraries, tools
+
+We maintain links to clients, module, libraries and tool in various langauges in
+JSON files stored under `clients/`, `modules/`, `libraries/` and `tools/`
+respectively.
+
+**Note**:  Clients listed here, while fully compatible with Valkey, are not all official clients for Valkey.
 They are maintained by their original developers.
 
 All clients are listed under language specific sub-folders of [clients](./clients)
@@ -11,40 +64,41 @@ The path follows the pattern: ``clients/{language}/github.com/{owner}/{repositor
 The ``{language}`` component of the path is the path-safe representation
 of the full language name which is mapped in [languages.json](./languages.json).
 
-Each client's JSON object represents the details displayed on the [clients documentation page](https://valkey.io/docs/clients).
+Each client's JSON object represents the details displayed on the [clients documentation page](https://valkey.io/clients/).
 
-For example [clients/python/github.com/placeholderkv](./clients/python/github.com/placeholderkv/placeholderkv-py.json):
+For example [clients/python/github.com/valkey-io/valkey-go.json](./clients/python/github.com/valkey-io/valkey-go.json):
 
-```
+```json
 {
-    "name": "placeholderkv-py",
-    "description": "Mature and supported. Currently the way to go for Python.",
+    "name": "valkey-go",
+    "description": "A fast Golang Valkey client that supports Client Side Caching and Auto Pipelining.",
     "recommended": true
 }
 ```
 
-## Commands
+Modules, libraries and tools follow a similar structure under their respective directories.
 
-Valkey commands are described in the `commands.json` file that is auto generated
-from the Valkey repo based on the JSON files in the commands folder.
-See: https://github.com/valkey-io/valkey/tree/unstable/src/commands
-See: https://github.com/valkey-io/valkey/tree/unstable/utils/generate-commands-json.py
+### Commands
+
+The command pages under `commands/` in this repo are not complete without some
+metadata from the Valkey repo, namely the JSON files in the `src/commands/`
+folder. The content of these JSON files is combined with the Markdown files in
+this repo when the documentation is rendered.
+
+See: https://github.com/valkey-io/valkey/tree/unstable/src/commands/
 
 For each command there's a Markdown file with a complete, human-readable
 description.
-We process this Markdown to provide a better experience, so some things to take
-into account:
+We process this files to provide a better experience.
 
 *   Inside text, all commands should be written in all caps, in between
     backticks.
     For example: `INCR`.
 
-*   You can use some magic keywords to name common elements in Valkey.
-    For example: `@multi-bulk-reply`.
-    These keywords will get expanded and auto-linked to relevant parts of the
-    documentation.
-
+The reply types and descriptsions are stored in separate JSON files in this doc repo.
 Each command will have a description and both RESP2 and RESP3 return values.
+When adding or editing return values, be sure to edit both files. Use the following
+links for the reply type.
 Regarding the return values, these are contained in the files:
 
 * `resp2_replies.json`
@@ -65,43 +119,21 @@ when processed, produce Markdown content. Here's an example:
 }
 ```
 
-**Important**: when adding or editing return values, be sure to edit both files. Use the following
-links for the reply type. Note: do not use `@reply-type` specifiers; use only the Markdown link.
-
-**Important**: all links below are under construction.
-
-```md
-@simple-string-reply: [Simple string reply](https://valkey.io/topics/protocol#simple-strings)
-@simple-error-reply: [Simple error reply](https://valkey.io/topics/protocol#simple-errors)
-@integer-reply: [Integer reply](https://valkey.io/topics/protocol#integers)
-@bulk-string-reply: [Bulk string reply](https://valkey.io/topics/protocol#bulk-strings)
-@array-reply: [Array reply](https://valkey.io/topics/protocol#arrays)
-@nil-reply: [Nil reply](https://valkey.io/topics/protocol#bulk-strings)
-@null-reply: [Null reply](https://valkey.io/topics/protocol#nulls)
-@boolean-reply: [Boolean reply](https://valkey.io/topics/protocol#booleans)
-@double-reply: [Double reply](https://valkey.io/topics/protocol#doubles)
-@big-number-reply: [Big number reply](https://valkey.io/topics/protocol#big-numbers)
-@bulk-error-reply: [Bulk error reply](https://valkey.io/topics/protocol#bulk-errors)
-@verbatim-string-reply: [Verbatim string reply](https://valkey.io/topics/protocol#verbatim-strings)
-@map-reply: [Map reply](https://valkey.io/topics/protocol#maps)
-@set-reply: [Set reply](https://valkey.io/topics/protocol#sets)
-@push-reply: [Push reply](https://valkey.io/topics/protocol#pushes)
-```
-
-## Styling guidelines
+### Styling guidelines
 
 Please use the following formatting rules (aiming for smaller diffs that are easier to review):
 
-* No need for manual lines wrapping at any specific length,
-  doing so usually means that adding a word creates a cascade effect and changes other lines.
-* Please avoid writing lines that are too long,
-  this makes the diff harder to review when only one word is changed.
-* Start every sentence on a new line.
+* Please avoid writing lines that are too long.
+  That makes the diff harder to review when only one word is changed.
+* Single linebreaks are not significant in Markdown, so when editing an existing
+  sentence or paragraph, don't change the existing linebreaks. That just makes
+  reviewing harding.
 
+### Checking your work
 
-## Checking your work
+(This section may not be up do date.)
 
-After making changes to the documentation, you can use the [spellchecker-cli package](https://www.npmjs.com/package/spellchecker-cli)
+    After making changes to the documentation, you can use the [spellchecker-cli package](https://www.npmjs.com/package/spellchecker-cli)
 to validate your spelling as well as some minor grammatical errors. You can install the spellchecker locally by running:
 
 ```bash

--- a/topics/benchmark.md
+++ b/topics/benchmark.md
@@ -11,41 +11,187 @@ aliases: [
 ]
 ---
 
+## Usage
+
+**`valkey-benchmark`** [ _OPTIONS_ ] [ _COMMAND_ _ARGS_... ]
+
+## Description
+
 Valkey includes the `valkey-benchmark` utility that simulates running commands done
 by N clients while at the same time sending M total queries. The utility provides
 a default set of tests, or you can supply a custom set of tests.
 
-The following options are supported:
+## Options
 
-    Usage: valkey-benchmark [-h <host>] [-p <port>] [-c <clients>] [-n <requests]> [-k <boolean>]
+**`-h`** _hostname_
+: Server hostname (default 127.0.0.1)
 
-     -h <hostname>      Server hostname (default 127.0.0.1)
-     -p <port>          Server port (default 6379)
-     -s <socket>        Server socket (overrides host and port)
-     -a <password>      Password for Valkey Auth
-     -c <clients>       Number of parallel connections (default 50)
-     -n <requests>      Total number of requests (default 100000)
-     -d <size>          Data size of SET/GET value in bytes (default 3)
-     --dbnum <db>       SELECT the specified db number (default 0)
-     -k <boolean>       1=keep alive 0=reconnect (default 1)
-     -r <keyspacelen>   Use random keys for SET/GET/INCR, random values for SADD
-      Using this option the benchmark will expand the string __rand_int__
-      inside an argument with a 12 digits number in the specified range
-      from 0 to keyspacelen-1. The substitution changes every time a command
-      is executed. Default tests use this to hit random keys in the
-      specified range.
-     -P <numreq>        Pipeline <numreq> requests. Default 1 (no pipeline).
-     -q                 Quiet. Just show query/sec values
-     --csv              Output in CSV format
-     -l                 Loop. Run the tests forever
-     -t <tests>         Only run the comma separated list of tests. The test
-                        names are the same as the ones produced as output.
-     -I                 Idle mode. Just open N idle connections and wait.
+**`-p`** _port_
+: Server port (default 6379)
 
-You need to have a running Valkey instance before launching the benchmark.
-You can run the benchmarking utility like so:
+**`-s`** _socket_
+: Server socket (overrides host and port)
 
-    valkey-benchmark -q -n 100000
+**`-a`** _password_
+: Password for Valkey Auth
+
+**`--user`** _username_
+: Used to send ACL style 'AUTH username pass'. Needs -a.
+
+**`-u`** _uri_
+: Server URI on format `valkey://user:password@host:port/dbnum`.
+  User, password and dbnum are optional. For authentication
+  without a username, use username 'default'. For TLS, use
+  the scheme 'valkeys'.
+
+**`-c`** _clients_
+: Number of parallel connections (default 50).
+  Note: If `--cluster` is used then number of clients has to be
+  the same or higher than the number of nodes.
+
+**`-n`** _requests_
+: Total number of requests (default 100000)
+
+**`-d`** _size_
+: Data size of SET/GET value in bytes (default 3)
+
+**`--dbnum`** _db_
+: SELECT the specified db number (default 0)
+
+**`-3`**
+: Start session in RESP3 protocol mode.
+
+**`--threads`** _num_
+: Enable multi-thread mode.
+
+**`--cluster`**
+: Enable cluster mode.
+  If the command is supplied on the command line in cluster
+  mode, the key must contain "{tag}". Otherwise, the
+  command will not be sent to the right cluster node.
+
+**`--enable-tracking`**
+: Send CLIENT TRACKING ON before starting benchmark.
+
+**`-k`** _boolean_
+: 1=keep alive 0=reconnect (default 1)
+
+**`-r`** _keyspacelen_
+: Use random keys for SET/GET/INCR, random values for SADD,
+  random members and scores for ZADD.
+  Using this option the benchmark will expand the string
+  `__rand_int__` inside an argument with a 12 digits number in
+  the specified range from 0 to keyspacelen - 1. The
+  substitution changes every time a command is executed.
+  Default tests use this to hit random keys in the specified
+  range.
+  Note: If `-r` is omitted, all commands in a benchmark will
+  use the same key.
+
+**`-P`** _numreq_
+: Pipeline _numreq_ requests. Default 1 (no pipeline).
+
+**`-q`**
+: Quiet. Just show query/sec values
+
+**`--precision`**
+: Number of decimal places to display in latency output (default 0)
+
+**`--csv`**
+: Output in CSV format
+
+**`-l`**
+: Loop. Run the tests forever
+
+**`-t`** _tests_
+: Only run the comma separated list of tests. The test
+  names are the same as the ones produced as output.
+  The `-t` option is ignored if a specific command is supplied
+  on the command line.
+
+**`-I`**
+: Idle mode. Just open N idle connections and wait.
+
+**`-x`**
+: Read last argument from STDIN.
+
+**`--seed`** _num_
+: Set the seed for random number generator. Default seed is based on time.
+
+**`--tls`**
+: Establish a secure TLS connection.
+
+**`--sni`** _host_
+: Server name indication for TLS.
+
+**`--cacert`** _file_
+: CA Certificate file to verify with.
+
+**`--cacertdir`** _dir_
+: Directory where trusted CA certificates are stored.
+  If neither cacert nor cacertdir are specified, the default
+  system-wide trusted root certs configuration will apply.
+
+**`--insecure`**
+: Allow insecure TLS connection by skipping cert validation.
+
+**`--cert`** _file_
+: Client certificate to authenticate with.
+
+**`--key`** _file_
+: Private key file to authenticate with.
+
+**`--tls-ciphers`** _list_
+: Sets the list of preferred ciphers (TLSv1.2 and below)
+  in order of preference from highest to lowest separated by colon (":").
+  See the **ciphers**(1ssl) manpage for more information about the syntax of this string.
+
+**`--tls-ciphersuites`** _list_
+: Sets the list of preferred ciphersuites (TLSv1.3)
+  in order of preference from highest to lowest separated by colon (":").
+  See the **ciphers**(1ssl) manpage for more information about the syntax of this string,
+  and specifically for TLSv1.3 ciphersuites.
+
+**`--help`**
+: Output help and exit.
+
+**`--version`**
+: Output version and exit.
+
+## Examples
+
+Run the benchmark with the default configuration against 127.0.0.1:6379. You
+need to have a running Valkey instance before launching the benchmark:
+
+    $ valkey-benchmark
+
+Rung a benchmark with 20 parallel clients, pipelining 10 commands at a time,
+using 2 threads and less verbose output:
+
+    $ valkey-benchmark -c 20 -P 10 --threads 2 -q
+
+Use 20 parallel clients, for a total of 100k requests, against 192.168.1.1:
+
+    $ valkey-benchmark -h 192.168.1.1 -p 6379 -n 100000 -c 20
+
+Fill 127.0.0.1:6379 with about 1 million keys only using the SET test:
+
+    $ valkey-benchmark -t set -n 1000000 -r 100000000
+
+Benchmark 127.0.0.1:6379 for a few commands producing CSV output:
+
+    $ valkey-benchmark -t ping,set,get -n 100000 --csv
+
+Benchmark a specific command line:
+
+    $ valkey-benchmark -r 10000 -n 10000 eval 'return redis.call("ping")' 0
+
+Fill a list with 10000 random elements:
+
+    $ valkey-benchmark -r 10000 -n 10000 lpush mylist __rand_int__
+
+On user specified command lines `__rand_int__` is replaced with a random integer
+with a range of values selected by the `-r` option.
 
 ### Running only a subset of the tests
 
@@ -282,6 +428,11 @@ the generated log file on a remote filesystem.
 + Avoid using monitoring tools which can alter the result of the benchmark. For
 instance using INFO at regular interval to gather statistics is probably fine,
 but MONITOR will impact the measured performance significantly.
++ When running `valkey-benchmark` on the same machine as the `valkey-server`
+being tested, you may need to run the benchmark with at least two threads
+(`--threads 2`) to prevent the benchmarking tool itself from being the
+bottleneck, i.e. prevent that `valkey-benchmark` is running on 100% CPU while
+`valkey-server` is using less than 100% CPU.
 
 ### Other Valkey benchmarking tools
 
@@ -291,3 +442,7 @@ documentation for more information about its goals and capabilities.
 * [memtier_benchmark](https://github.com/redislabs/memtier_benchmark) from [Redis Ltd.](https://twitter.com/RedisInc) is a NoSQL Valkey, Redis and Memcache traffic generation and benchmarking tool.
 * [rpc-perf](https://github.com/twitter/rpc-perf) from [Twitter](https://twitter.com/twitter) is a tool for benchmarking RPC services that supports Valkey and Memcache.
 * [YCSB](https://github.com/brianfrankcooper/YCSB) from [Yahoo @Yahoo](https://twitter.com/Yahoo) is a benchmarking framework with clients to many databases, including Valkey. 
+
+## See also
+
+[valkey-cli](cli.md), [valkey-server](server.md)

--- a/topics/benchmark.md
+++ b/topics/benchmark.md
@@ -165,7 +165,7 @@ need to have a running Valkey instance before launching the benchmark:
 
     $ valkey-benchmark
 
-Rung a benchmark with 20 parallel clients, pipelining 10 commands at a time,
+Run a benchmark with 20 parallel clients, pipelining 10 commands at a time,
 using 2 threads and less verbose output:
 
     $ valkey-benchmark -c 20 -P 10 --threads 2 -q

--- a/topics/cli.md
+++ b/topics/cli.md
@@ -3,12 +3,20 @@ title: "Valkey CLI"
 linkTitle: "CLI"
 weight: 1
 description: >
-    Overview of valkey-cli, the Valkey command line interface
+    Valkey command line interface
 aliases:
     - /docs/manual/cli
     - /docs/management/cli
     - /docs/ui/cli
 ---
+
+## Usage
+
+**`valkey-cli`** [_OPTIONS_] [_cmd_ [_arg_...]]
+
+## Description
+
+The Valkey command line interface is used for administration, troubleshooting and experimenting with Valkey.
 
 In interactive mode, `valkey-cli` has basic line editing capabilities to provide a familiar typing experience.
 
@@ -19,6 +27,296 @@ To launch the program in special modes, you can use several options, including:
 * Request ASCII-art spectrogram of latency samples and frequencies.
 
 This topic covers the different aspects of `valkey-cli`, starting from the simplest and ending with the more advanced features.
+
+## Options
+
+**`-h`** _hostname_
+: Server hostname (default: 127.0.0.1).
+
+**`-p`** _port_
+: Server port (default: 6379).
+
+**`-t`** _timeout_
+: Server connection timeout in seconds (decimals allowed).
+  Default timeout is 0, meaning no limit, depending on the OS.
+
+**`-s`** _socket_
+: Server socket (overrides hostname and port).
+
+**`-a`** _password_
+: Password to use when connecting to the server.
+  You can also use the `REDISCLI_AUTH` environment
+  variable to pass this password more safely.
+  (If both are used, this argument takes precedence.)
+
+**`--user`** _username_
+: Used to send ACL style 'AUTH username pass'. Needs `-a`.
+
+**`--pass`** _password_
+: Alias of -a for consistency with the new --user option.
+
+**`--askpass`**
+: Force user to input password with mask from STDIN.
+  If this argument is used, `-a` and the `REDISCLI_AUTH`
+  environment variable will be ignored.
+
+**`-u`** _uri_
+: Server URI on format `valkey://user:password@host:port/dbnum`.
+  User, password and dbnum are optional. For authentication
+  without a username, use username 'default'. For TLS, use
+  the scheme 'valkeys'.
+
+**`-r`** _repeat_
+: Execute specified command N times.
+
+**`-i`** _interval_
+: When `-r` is used, waits _interval_ seconds per command.
+  It is possible to specify sub-second times like `-i 0.1`.
+  This interval is also used in `--scan` and `--stat` per cycle.
+  and in `--bigkeys`, `--memkeys`, and `--hotkeys` per 100 cycles.
+
+**`-n`** _db_
+: Database number.
+
+**`-2`**
+: Start session in RESP2 protocol mode.
+
+**`-3`**
+: Start session in RESP3 protocol mode.
+
+**`-x`**
+: Read last argument from STDIN (see example below).
+
+**`-X`**
+: Read <tag> argument from STDIN (see example below).
+
+**`-d`** _delimiter_
+: Delimiter between response bulks for raw formatting (default: `\n`).
+
+**`-D`** _delimiter_
+: Delimiter between responses for raw formatting (default: `\n`).
+
+**`-c`**
+: Enable cluster mode (follow -ASK and -MOVED redirections).
+
+**`-e`**
+: Return exit error code when command execution fails.
+
+**`-4`**
+: Prefer IPv4 over IPv6 on DNS lookup.
+
+**`-6`**
+: Prefer IPv6 over IPv4 on DNS lookup.'
+
+**`--tls`**
+: Establish a secure TLS connection.
+
+**`--sni`** _host_
+: Server name indication for TLS.
+
+**`--cacert`** _file_
+: CA Certificate file to verify with.
+
+**`--cacertdir`** _dir_
+: Directory where trusted CA certificates are stored.
+  If neither cacert nor cacertdir are specified, the default
+  system-wide trusted root certs configuration will apply.
+
+**`--insecure`**
+: Allow insecure TLS connection by skipping cert validation.
+
+**`--cert`** _file_
+: Client certificate to authenticate with.
+
+**`--key`** _file_
+: Private key file to authenticate with.
+
+**`--tls-ciphers`** _list_
+: Sets the list of preferred ciphers (TLSv1.2 and below)
+  in order of preference from highest to lowest separated by colon (":").
+  See the **ciphers**(1ssl) manpage for more information about the syntax of this string.
+
+**`--tls-ciphersuites`** _list_
+: Sets the list of preferred ciphersuites (TLSv1.3)
+  in order of preference from highest to lowest separated by colon (":").
+  See the **ciphers**(1ssl) manpage for more information about the syntax of this string,
+  and specifically for TLSv1.3 ciphersuites.
+
+**`--raw`**
+: Use raw formatting for replies (default when STDOUT is
+  not a tty).
+
+**`--no-raw`**
+: Force formatted output even when STDOUT is not a tty.
+
+**`--quoted-input`**
+: Force input to be handled as quoted strings.
+
+**`--csv`**
+: Output in CSV format.
+
+**`--json`**
+: Output in JSON format (default RESP3, use -2 if you want to use with RESP2).
+
+**`--quoted-json`**
+: Same as --json, but produce ASCII-safe quoted strings, not Unicode.
+
+**`--show-pushes`** **`yes`**|**`no`**
+: Whether to print RESP3 PUSH messages.  Enabled by default when
+  STDOUT is a tty but can be overridden with --show-pushes no.
+
+**`--stat`**
+: Print rolling stats about server: mem, clients, ...
+
+**`--latency`**
+: Enter a special mode continuously sampling latency.
+  If you use this mode in an interactive session it runs
+  forever displaying real-time stats. Otherwise if `--raw` or
+  `--csv` is specified, or if you redirect the output to a non
+  TTY, it samples the latency for 1 second (you can use
+  `-i` to change the interval), then produces a single output
+  and exits.
+
+**`--latency-history`**
+: Like `--latency` but tracking latency changes over time.
+  Default time interval is 15 sec. Change it using `-i`.
+
+**`--latency-dist`**
+: Shows latency as a spectrum, requires xterm 256 colors.
+  Default time interval is 1 sec. Change it using `-i`.
+
+**`--lru-test`** _keys_
+: Simulate a cache workload with an 80-20 distribution.
+
+**`--replica`**
+: Simulate a replica showing commands received from the master.
+
+**`--rdb`** _filename_
+: Transfer an RDB dump from remote server to local file.
+  Use filename of "-" to write to stdout.
+
+**`--functions-rdb`** _filename_
+: Like `--rdb` but only get the functions (not the keys)
+  when getting the RDB dump file.
+
+**`--pipe`**
+: Transfer raw RESP protocol from stdin to server.
+
+**`--pipe-timeout`** _n_
+: In `--pipe` mode, abort with error if after sending all data.
+  no reply is received within _n_ seconds.
+  Default timeout: 30. Use 0 to wait forever.
+
+**`--bigkeys`**
+: Sample keys looking for keys with many elements (complexity).
+
+**`--memkeys`**
+: Sample keys looking for keys consuming a lot of memory.
+
+**`--memkeys-samples`** _n_
+: Sample keys looking for keys consuming a lot of memory.
+  And define number of key elements to sample
+
+**`--hotkeys`**
+: Sample keys looking for hot keys.
+  only works when maxmemory-policy is `*lfu`.
+
+**`--scan`**
+: List all keys using the SCAN command.
+
+**`--pattern`** _pat_
+: Keys pattern when using the `--scan`, `--bigkeys` or `--hotkeys`
+  options (default: `*`).
+
+**`--count`** _count_
+: Count option when using the `--scan`, `--bigkeys` or `--hotkeys` (default: 10).
+
+**`--quoted-pattern`** _pat_
+: Same as `--pattern`, but the specified string can be
+  quoted, in order to pass an otherwise non binary-safe string.
+
+**`--intrinsic-latency`** _sec_
+: Run a test to measure intrinsic system latency.
+  The test will run for the specified amount of seconds.
+
+**`--eval`** _file_
+: Send an EVAL command using the Lua script at _file_.
+
+**`--ldb`**
+: Used with `--eval` enable the Server Lua debugger.
+
+**`--ldb-sync-mode`**
+: Like `--ldb` but uses the synchronous Lua debugger, in
+  this mode the server is blocked and script changes are
+  not rolled back from the server memory.
+
+**`--cluster`** _command_ [_args_...] [_opts_...]
+: Cluster Manager command and arguments (see below).
+
+**`--verbose`**
+: Verbose mode.
+
+**`--no-auth-warning`**
+: Don't show warning message when using password on command
+  line interface.
+
+**`--help`**
+: Output help and exit.
+
+**`--version`**
+: Output version and exit.
+
+## Cluster Manager commands
+
+For management of [Valkey Cluster](cluster-tutorial.md), the following syntax is used:
+
+**`valkey-cli`** **`--cluster`** _command_ [_args_...] [_opts_...]
+
+```
+  Command        Args
+  --------------------------------------------------------------------------------
+  create         host1:port1 ... hostN:portN
+                 --cluster-replicas <arg>
+  check          <host:port> or <host> <port> - separated by either colon or space
+                 --cluster-search-multiple-owners
+  info           <host:port> or <host> <port> - separated by either colon or space
+  fix            <host:port> or <host> <port> - separated by either colon or space
+                 --cluster-search-multiple-owners
+                 --cluster-fix-with-unreachable-masters
+  reshard        <host:port> or <host> <port> - separated by either colon or space
+                 --cluster-from <arg>
+                 --cluster-to <arg>
+                 --cluster-slots <arg>
+                 --cluster-yes
+                 --cluster-timeout <arg>
+                 --cluster-pipeline <arg>
+                 --cluster-replace
+  rebalance      <host:port> or <host> <port> - separated by either colon or space
+                 --cluster-weight <node1=w1...nodeN=wN>
+                 --cluster-use-empty-masters
+                 --cluster-timeout <arg>
+                 --cluster-simulate
+                 --cluster-pipeline <arg>
+                 --cluster-threshold <arg>
+                 --cluster-replace
+  add-node       new_host:new_port existing_host:existing_port
+                 --cluster-slave
+                 --cluster-master-id <arg>
+  del-node       host:port node_id
+  call           host:port command arg arg .. arg
+                 --cluster-only-masters
+                 --cluster-only-replicas
+  set-timeout    host:port milliseconds
+  import         host:port
+                 --cluster-from <arg>
+                 --cluster-from-user <arg>
+                 --cluster-from-pass <arg>
+                 --cluster-from-askpass
+                 --cluster-copy
+                 --cluster-replace
+  backup         host:port backup_directory
+  help
+```
 
 ## Command line usage
 

--- a/topics/index.md
+++ b/topics/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Documentation"
+title: "Valkey Documentation"
 linkTitle: "Documentation"
 weight: 20
 aliases:
@@ -13,6 +13,8 @@ The Valkey documentation is managed in markdown files in the
 [valkey-doc repository](http://github.com/valkey-io/valkey-doc).
 It's released under the
 [Creative Commons Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/).
+
+What is Valkey? See [Introduction](introduction.md).
 
 Programming with Valkey
 ---

--- a/topics/index.md
+++ b/topics/index.md
@@ -42,6 +42,7 @@ Administration
 ---
 * [Installation](installation.md): How to install and configure Valkey. This targets people without prior experience with Valkey.
 * [valkey-cli](cli.md): The Valkey command line interface, used for administration, troubleshooting and experimenting with Valkey.
+* [valkey-server](server.md): How to run the Valkey server.
 * [Configuration](valkey.conf.md): How to configure Valkey.
 * [Replication](replication.md): What you need to know to set up primary-replica replication.
 * [Persistence](persistence.md): Options for configuring durability using disk backups.

--- a/topics/license.md
+++ b/topics/license.md
@@ -86,60 +86,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 ```
 
-#### Acceptance
-
-By using the software, you agree to all of the terms and conditions below.
- 
-#### Copyright License
-
-The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable license to use, copy, distribute, make available, and prepare derivative works of the software, in each case subject to the limitations and conditions below.
-
-#### Limitations
-
-You may not make the functionality of the software or a modified version available to third parties as a service, or distribute the software or a modified version in a manner that makes the functionality of the software available to third parties. 
-Making the functionality of the software or modified version available to third parties includes, without limitation, enabling third parties to interact with the functionality of the software or modified version in distributed form or remotely through a computer network, offering a product or service the value of which entirely or primarily derives from the value of the software or modified version, or offering a product or service that accomplishes for users the primary purpose of the software or modified version.
-
-You may not alter, remove, or obscure any licensing, copyright, or other notices of the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
- 
-#### Patents
-
-The licensor grants you a license, under any patent claims the licensor can license, or becomes able to license, to make, have made, use, sell, offer for sale, import and have imported the software, in each case subject to the limitations and conditions in this license. This license does not cover any patent claims that you cause to be infringed by modifications or additions to the software. If you or your company make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
-
-#### Notices
-
-You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms.
-If you modify the software, you must include in any modified copies of the software prominent notices stating that you have modified the software.
-
-#### No Other Rights
-
-These terms do not imply any licenses other than those expressly granted in these terms.
-
-#### Termination
-
-If you use the software in violation of these terms, such use is not licensed, and your licenses will automatically terminate. If the licensor provides you with a notice of your violation, and you cease all violations of this license no later than 30 days after you receive that notice, your licenses will be reinstated retroactively. However, if you violate these terms after such reinstatement, any additional violation of these terms will cause your licenses to terminate automatically and permanently.
-
-#### No Liability
-
-_**As far as the law allows, the **software** comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.**_
-
-#### Definitions
-
-The **licensor** is the entity offering these terms, and the software is the software the licensor makes available under these terms, including any portion of it.
-
-To **modify** a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission other than making an exact copy. The resulting work is called a **modified version** of the earlier work.
-
-**you** refers to the individual or entity agreeing to these terms.
-
-**your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization. 
-
-**control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise. Control can be direct or indirect.
-
-**your licenses** are all the licenses granted to you for the software under these terms.
-use means anything you do with the software requiring one of your licenses.
-
-**trademark** means trademarks, service marks, and similar rights.
-
-
 ### Third-party files and licenses
 
 Valkey uses source code from third parties. All this code contains a BSD or BSD-compatible license. The following is a list of third-party files and information about their copyright.

--- a/topics/sentinel.md
+++ b/topics/sentinel.md
@@ -10,6 +10,14 @@ aliases: [
 ]
 ---
 
+## Usage
+
+**`valkey-sentinel`** _/path/to/sentinel.conf_
+
+**`valkey-server`** _/path/to/sentinel.conf_ **`--sentinel`**
+
+## Description
+
 Valkey Sentinel provides high availability for Valkey when not using [Valkey Cluster](cluster-tutorial.md). 
 
 Valkey Sentinel also provides other collateral tasks such as monitoring,

--- a/topics/server.md
+++ b/topics/server.md
@@ -1,0 +1,86 @@
+---
+title: "Valkey Server"
+linkTitle: "Valkey Server"
+weight: 1
+description: >
+    Manual for valkey-server, the Valkey server program
+---
+
+## Usage
+
+**`valkey-server`** [ _/path/to/valkey.conf_ ] [ _OPTIONS_ ] [**`-`**]\
+**`valkey-server`** **`-`**\
+**`valkey-server`** **`-v`** | **`--version`**\
+**`valkey-server`** **`-h`** | **`--help`**\
+**`valkey-server`** **`--test-memory`** _megabytes_\
+**`valkey-server`** **`--check-system`**
+
+## Description
+
+`valkey-server` is the Valkey database program. It's typically started by an init script, rather than manually.
+
+## Options
+
+The configuration file and the configuration directives are in documented in
+[Configuration](valkey.conf.md). Use `-` to read configuration from stdin.
+
+Each of the configuration directives can be provided on the command line
+with its name prefixed by two dashes. For example, `--port 6380` on the command
+line is equivalent to `port 6380` in the config file.
+
+Additional options:
+
+**`-v`**, **`--version`**
+: Output version and exit.
+
+**`-h`**, **`--help`**
+: Output help and exit.
+
+**`--test-memory`** _megabytes_
+: Run a memory test and exit.
+
+**`--check-sytem`**
+: Output some operating system properties relevant for running Valkey and exit.
+
+**`--sentinel`**
+: Start in [sentinel](sentinel.md) mode
+
+## Examples
+
+Run the server with default config:
+
+    valkey-server
+
+Read configuration from stdin:
+
+    echo 'maxmemory 128mb' | valkey-server -
+
+Start with a configuration file:
+
+    valkey-server /etc/valkey/6379.conf
+
+Start with configuration as command line options:
+
+    valkey-server --port 7777
+
+Start as a replica of another node running on the same machine:
+
+    valkey-server --port 7777 --replicaof 127.0.0.1 8888
+
+Start with a config file, then some additional options overriding the ones in
+the config file, and finally some more options from stdin:
+
+    valkey-server /etc/myvalkey.conf --loglevel verbose -
+
+Start with a config file and some additional options overriding the ones in
+the config file:
+
+    valkey-server /etc/myvalkey.conf --loglevel verbose
+
+Start in [sentinel](sentinel.md) mode:
+
+    valkey-server /etc/sentinel.conf --sentinel
+
+## See also
+
+[Valkey documentation](./), [Configuration](valkey.conf.md), [Installation](installation.md), [valkey-cli](cli.md)

--- a/topics/server.md
+++ b/topics/server.md
@@ -9,7 +9,6 @@ description: >
 ## Usage
 
 **`valkey-server`** [ _/path/to/valkey.conf_ ] [ _OPTIONS_ ] [**`-`**]\
-**`valkey-server`** **`-`**\
 **`valkey-server`** **`-v`** | **`--version`**\
 **`valkey-server`** **`-h`** | **`--help`**\
 **`valkey-server`** **`--test-memory`** _megabytes_\
@@ -21,7 +20,7 @@ description: >
 
 ## Options
 
-The configuration file and the configuration directives are in documented in
+The configuration file and the configuration directives are documented in
 [Configuration](valkey.conf.md). Use `-` to read configuration from stdin.
 
 Each of the configuration directives can be provided on the command line
@@ -63,7 +62,7 @@ Start with configuration as command line options:
 
     valkey-server --port 7777
 
-Start as a replica of another node running on the same machine:
+Start as a replica of another Valkey server that can accessed at 127.0.0.1:8888:
 
     valkey-server --port 7777 --replicaof 127.0.0.1 8888
 
@@ -76,10 +75,6 @@ Start with a config file and some additional options overriding the ones in
 the config file:
 
     valkey-server /etc/myvalkey.conf --loglevel verbose
-
-Start in [sentinel](sentinel.md) mode:
-
-    valkey-server /etc/sentinel.conf --sentinel
 
 ## See also
 

--- a/topics/server.md
+++ b/topics/server.md
@@ -16,7 +16,9 @@ description: >
 
 ## Description
 
-`valkey-server` is the Valkey database program. It's typically started by an init script, rather than manually.
+`valkey-server` is the Valkey database program.
+
+What is Valkey? See [Introduction](introduction.md).
 
 ## Options
 
@@ -78,4 +80,4 @@ the config file:
 
 ## See also
 
-[Valkey documentation](./), [Configuration](valkey.conf.md), [Installation](installation.md), [valkey-cli](cli.md)
+[Valkey documentation](./), [Introduction](introduction.md), [Configuration](valkey.conf.md), [Installation](installation.md), [valkey-cli](cli.md)

--- a/utils/build-command-groups.py
+++ b/utils/build-command-groups.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import json
+import argparse
+import sys
+import re
+
+parser = argparse.ArgumentParser(prog="build-command-groups.py",
+                                 description='creates a JSON file categorizing commands per group')
+parser.add_argument('filename', nargs='+', help='JSON files')
+args = parser.parse_args()
+
+groups = {}
+
+for filename in args.filename:
+    with open(filename, "r") as f:
+        j = json.load(f)
+
+    name0 = re.sub(r'^.*/([^/]+)\.json$', r'\1', filename)    # "client-kill"
+    name  = name0.replace("-", " ", 1).upper()                # "CLIENT KILL"
+    name1 = name.split(' ', maxsplit=1)[-1]                   # "KILL"
+    if name1 not in j:
+        # Some commands' filenames look like subcommands, but they're not.
+        name  = name0.upper()                                 # "RESTORE-ASKING"
+        name1 = name
+
+    cmd = j[name1]
+
+    g = cmd["group"] if "group" in cmd else "other"
+    if g not in groups:
+        groups[g] = {}
+
+    obj = {
+        "name": name,
+        "summary": cmd.get("summary")
+    }
+    if "deprecated_since" in cmd:
+        obj["deprecated"] = True
+    if "doc_flags" in j:
+        if "DEPRECATED" in cmd["doc_flags"]:
+            obj["deprecated"] = True # Just in case "deprecated_since" wasn't set
+        if "SYSCMD" in cmd["doc_flags"]:
+            obj["syscmd"] = True
+
+    groups[g][name] = obj
+
+print(json.dumps(groups, indent=4, sort_keys=True))

--- a/utils/build-command-groups.py
+++ b/utils/build-command-groups.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# Copyright (C) 2024, The Valkey contributors
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/utils/build-command-groups.py
+++ b/utils/build-command-groups.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import json
 import argparse
 import sys

--- a/utils/build-command-index.py
+++ b/utils/build-command-index.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# Copyright (C) 2024, The Valkey contributors
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/utils/build-command-index.py
+++ b/utils/build-command-index.py
@@ -33,7 +33,6 @@ if args.man:
     print("title: VALKEY-COMMANDS(7)")
     print('header: Valkey Command Manual')
     print('footer: Valkey Documentation')
-    #print('date: %s' % self.date)
     print('adjusting: left')
     print("---")
     print('# NAME', end="\n\n")

--- a/utils/build-command-index.py
+++ b/utils/build-command-index.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+import re
+import json
+import argparse
+import sys
+import yaml
+from datetime import date
+
+import command_syntax
+
+parser = argparse.ArgumentParser(prog="build-command-index.py",
+                                 description='Create an overview page of all commands, commands/index.md')
+parser.add_argument('--suffix', default='.md',
+                    help='Suffix to use in internal links instead of .md for non-manpage usage')
+parser.add_argument('--man', action='store_true', help='Generate markdown for man page')
+parser.add_argument('--groups-json', help='groups.json')
+parser.add_argument('--commands-per-group-json', help='commands-per-groups.json')
+args = parser.parse_args()
+
+with open(args.groups_json, "r") as f:
+    groups = json.load(f)
+with open(args.commands_per_group_json, "r") as f:
+    commands_per_group = json.load(f)
+
+if args.man:
+    print("---")
+    print("title: VALKEY-COMMANDS(7)")
+    print('header: Valkey Command Manual')
+    print('footer: Valkey Documentation')
+    #print('date: %s' % self.date)
+    print('adjusting: left')
+    print("---")
+    print('# NAME', end="\n\n")
+    print("valkey-commands - The full list of Valkey commands", end="\n\n")
+    print("# DESCRIPTION", end="\n\n")
+    print("Commands per group.", end="\n\n")
+else:
+    print("---")
+    print('title: Commands &middot; Valkey')
+    print("---")
+    print("# Valkey Commands", end="\n\n")
+
+if not args.man:
+    # Links to groups within the page
+    print("Commands groups:")
+    for (groupname, groupobj) in groups.items():
+        if groupname not in commands_per_group:
+            continue # No commands in this group
+        anchor = groupname.replace(' ', '-').replace('_', '-')
+        print("[%s](#%s)" % (groupobj["display"], anchor))
+    print()
+
+for (groupname, commands) in commands_per_group.items():
+    if groupname not in groups and groupname.replace('_', '-') in groups:
+        groupname = groupname.replace('_', '-')
+    if groupname in groups:
+        g = groups[groupname]
+        if g["display"].lower().replace(' ', '-') == groupname:
+            print('## %s' % g["display"], end="\n\n")
+        else:
+            print('## <a name="%s">%s</a>' % (groupname, g["display"]), end="\n\n")
+        description = g["description"]
+    else:
+        print("## %s" % groupname.replace('_', ' '), end="\n\n")
+        description = ''
+
+    if args.man:
+        for (name, obj) in commands.items():
+            summary = obj["summary"]
+            if obj.get("deprecated"):
+                summary = summary + " Deprecated."
+            pagename = name.replace(' ', '-').lower()
+            print("**%s**(3valkey): %s" % (pagename, summary), end="\n\n")
+    else:
+        print(description)
+        print("<table>")
+        for (name, obj) in commands.items():
+            summary = obj["summary"]
+            if obj.get("deprecated"):
+                summary = summary + " Deprecated."
+            pagename = name.replace(' ', '-').lower()
+            print("<tr><td>")
+            url = pagename + args.suffix
+            print("[`%s`](%s)" % (name, url))
+            print("</td><td>%s</td></tr>" % summary)
+        print("</table>")
+    print()
+
+if args.man:
+    print("# SEE ALSO", end="\n\n")
+    print("**valkey**(7), **valkey-data-types**(7)")

--- a/utils/check-links.pl
+++ b/utils/check-links.pl
@@ -1,9 +1,11 @@
 #!/usr/bin/perl
 
-#
+# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause#
+
 # Checks for intenal broken links. Checks some other things too, like orphan
 # pages (nobody links to the orphan page) and the number of external links.
-#
 
 use warnings;
 use strict;

--- a/utils/check-links.pl
+++ b/utils/check-links.pl
@@ -1,0 +1,121 @@
+#!/usr/bin/perl
+
+#
+# Checks for intenal broken links. Checks some other things too, like orphan
+# pages (nobody links to the orphan page) and the number of external links.
+#
+
+use warnings;
+use strict;
+
+my $dry = 1; # dry run (enable for debugging)
+
+my $root = __FILE__ =~ s![^/]*$!!r . "../";
+$root =~ s%[^/\.]+/\.\./$%%;
+my @files = glob("${root}{topics,commands}/*");
+
+my %targets;
+for (@files) {
+    s/^$root//;
+    $targets{$_} = 0;
+}
+
+my %generated_targets = ("commands/" => 0,
+                         "clients/" => 0,
+                         "modules/" => 0);
+
+my ($num_abs_url, $num_abs_path, $num_broken, $num_valid, $num_generated) = (0,0,0,0,0);
+for (@files) {
+    my $filename = $root . $_;
+    next unless m!([^/]*)/([^/]*\.md)$!;
+    my ($dir, $basename) = ($1, $2);
+
+    #print "$dir / $basename\n";
+    #exit;
+
+    open(my $in, "<", $filename) or die "Can't open $filename: $!";
+    open(my $out, ">", "$filename~~~") or die "Can't create $filename~~~: $!" unless $dry;
+    my $n = 0;
+    for my $line (<$in>) {
+        $n++;
+        my @links = ();
+        if ($line =~ /^\[[^\]]+\]:\s*(\S+)/) {
+            push @links, $1;
+        } else {
+            @links = $line =~ /\]\(([^\)]+)\)/g;
+        }
+
+        for (@links) {
+            if (/^\w+:/) {
+                # Skip absolute URL with a scheme.
+                $num_abs_url++;
+                next;
+            }
+            next if /^#/;       # Skip links within the page
+            s/[\?\#].*$//;      # Strip ?foo and #foo
+            if (m!^/!) {
+                $num_abs_path++;
+                print "$filename:$n: Link with absolute path: $_\n";
+                next;
+            }
+
+            if (/^$/) {
+                print "$filename:$n: Empty? $line\n";
+                exit;
+            }
+            my $target;
+            if (m!^../(.*)$!) {
+                $target = $1;
+            } else {
+                $target = "$dir/$_";
+            }
+
+            if (!defined $targets{$target}) {
+                if (defined $generated_targets{$target}) {
+                    $generated_targets{$target}++;
+                    $num_generated++;
+                    next;
+                }
+                $num_broken++;
+                print "$filename:$n: Broken link: $_\n";
+                next;
+            }
+            $num_valid++;
+            $targets{$target}++;
+        }
+    }
+    close $in;
+    close $out unless $dry;
+    rename "$filename~~~", $filename unless $dry;
+}
+
+# Count orphans
+my $num_orphans = 0;
+for (keys %targets) {
+    $num_orphans++ if $targets{$_} == 0 && /^topics/;
+}
+
+print "---\n",
+    "Internal absolute links  : $num_abs_path\n",
+    "Internal broken links    : $num_broken\n",
+    "Links to generated pages : $num_generated\n",
+    "Links to existing pages  : $num_valid\n",
+    "External links           : $num_abs_url\n",
+    "Orphan pages             : $num_orphans\n";
+print "---\n";
+print "Links to generated pages (not in this repo):\n";
+for (sort keys %generated_targets) {
+    printf("[%2d] %s\n", $generated_targets{$_}, $_);
+}
+if ($num_orphans) {
+    print "---\n";
+    print "Orphans:\n";
+    for (sort keys %targets) {
+        if ($targets{$_} == 0 && /^topics/) {
+            print("  $_\n");
+        }
+    }
+}
+print "---\n";
+
+exit($num_broken || $num_abs_path ? 1 : 0);

--- a/utils/command_syntax.py
+++ b/utils/command_syntax.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
-"""
-Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
-All rights reserved.
-SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 
+"""
 This file can be used in two ways:
 
 1. As a standalone script. Try --help for help.

--- a/utils/command_syntax.py
+++ b/utils/command_syntax.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+
+"""
+Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+
+This file can be used in two ways:
+
+1. As a standalone script. Try --help for help.
+
+2. As a Python module.
+
+       import command_syntax
+       json = json.load(f)
+
+       # All commands in the file
+       print(command_syntax.render_all(json))
+
+       # A specific command in the file
+       print(command_syntax.render("HSET", json["HSET"]))
+"""
+
+import json
+import argparse
+import sys
+
+info = '''\
+Arguments syntax rendering:
+
+  simple                       foo
+  optional                     [foo]
+  multiple                     foo [foo...]
+  multiple + optional          [foo...]
+
+  oneof                        <foo | bar>
+  oneof + optional             [foo | bar]
+  oneof + multiple             <foo | bar> [<foo | bar>...]
+  oneof + multiple + optional  [<foo | bar>...]
+
+  block                        foo bar
+  block + optional             [foo bar]
+  block + multiple             foo bar [foo bar ...]
+  block + multiple + optional  [foo bar [foo bar ...]]
+
+Note: This help text uses "foo" and "bar" as the first and second metasyntactic
+variables in syntax examples as described in RFC3092.
+'''
+
+def render(name, body, conf={}):
+    """Render and print the syntax(es) of a command.
+
+    A JSON file is an object with one key entry on the form {name: body}.
+
+    The conf object is to control some details of the rendering.
+    """
+
+    # Set defaults for missing conf fields.
+    defaults = {'<': '<', '>': '>',
+                '[': '[', ']': ']',
+                'markdown': False,
+                'split': False,
+                'simplify': True}
+    defaults.update(conf)
+    conf = defaults
+
+    # Some internal helper functions. They depend on the conf object.
+    def rewrite(arg):
+        """slightly rearrange json object for consistency and simplicity"""
+        # Repair: Token type without token? Use name as token.
+        if arg["type"] == "pure-token" and "token" not in arg and "name" in arg:
+            arg["token"] = arg["name"]
+    
+        # Rewrite "one of multiple optional alternatives" to "optional alternatives".
+        # <[foo] | [bar] | [baz]>  ==>  [foo | bar | baz]
+        if conf['simplify'] and arg["type"] == "oneof" and all(subarg.get("optional") for subarg in arg["arguments"]):
+            arg["optional"] = True
+            for subarg in arg["arguments"]:
+                del subarg["optional"]
+    
+        # Rewrite for simpler rendering: Turn combined token-arg into a block of
+        # two: A pure-token arg followed by an arg without token.
+        if "token" in arg and arg["type"] != "pure-token":
+            tokenarg = {"type": "pure-token",
+                        "token": arg["token"]}
+            del arg["token"]
+            wrapper = {"type": "block",
+                       "arguments": [tokenarg, arg]}
+            if arg.get("multiple_token"):
+                # The whole thing is repeated. Move "multiple" to the wrapper.
+                wrapper["multiple"] = True
+                if "multiple" in arg:
+                    del arg["multiple"]
+            if arg.get("optional"):
+                # The whole thing is optional. Move "optional" to the wrapper.
+                wrapper["optional"] = True
+                del arg["optional"]
+                # Replace arg with the wrapper.
+            arg = wrapper
+    
+        return arg
+    
+    def fmt1(s):
+        """Format 1, used for fixed tokens (uppercase)"""
+        s = s.upper()
+        return "**`" + s + "`**" if conf['markdown'] else s
+    
+    def fmt2(s):
+        """Format 2, used for variables (lowercase, italic)"""
+        return "_" + s + "_" if conf['markdown'] else s
+    
+    def arg_syntax(arg):
+        """Render the syntax of one argument (JSON object)"""
+        syntax = ''
+        arg = rewrite(arg)
+        type = arg["type"]
+    
+        if type == "oneof":
+            # foo | bar
+            subsyntax = " | ".join([arg_syntax(subarg) for subarg in arg["arguments"]])
+            if arg.get("multiple") and arg.get("optional"):
+                # [<foo | bar>...]
+                syntax = conf['<'] + subsyntax + conf['>']
+                syntax = conf['['] + syntax + "..." + conf[']']
+            elif arg.get("multiple"):
+                # <foo | bar> [<foo | bar>...]
+                syntax = conf['<'] + subsyntax + conf['>']
+                syntax = syntax + " " + conf['['] + syntax + "..." + conf[']']
+            elif arg.get("optional"):
+                # [foo | bar]
+                syntax = conf['['] + subsyntax + conf[']']
+            else:
+                # <foo | bar>
+                syntax = conf['<'] + subsyntax + conf['>']
+        elif type == "block":
+            # foo bar
+            syntax = args_syntax(arg["arguments"])
+            if arg.get("multiple"):
+                # foo bar [foo bar ...]
+                syntax = syntax + " " + conf['['] + syntax + " ..." + conf[']']
+            if arg.get("optional"):
+                # [foo bar]
+                # [foo bar [foo bar ...]]
+                syntax = conf['['] + syntax + conf[']']
+        else:
+            # Simple arg (token or variable)
+            # foo
+            if type == "pure-token":
+                syntax = fmt1(arg["token"])
+            else:
+                syntax = fmt2(arg["display"] if "display" in arg else arg["name"])
+    
+            if arg.get("multiple") and arg.get("optinoal"):
+                # [foo...]
+                syntax = conf['['] + syntax + "..." + conf[']']
+            elif arg.get("multiple"):
+                # foo [foo...]
+                syntax = syntax + " " + conf['['] + syntax + "..." + conf[']']
+            elif arg.get("optional"):
+                # [foo]
+                syntax = conf['['] + syntax + conf[']']
+        return syntax
+    
+    def args_syntax(args):
+        """Render the syntax of a list of arguments"""
+        return " ".join([arg_syntax(arg) for arg in args])
+
+    def command_syntax_clause(name, body, arguments):
+        """Render a syntax line using the given arguments"""
+        syntax = fmt1(name)
+        if 'container' in body:
+            syntax = fmt1(body["container"]) + ' ' + syntax
+        if len(arguments) > 0:
+            syntax = syntax + " " + args_syntax(arguments)
+        return syntax
+    
+    def use_multiline(body):
+        """Determines whether to split the syntax into multiple lines/usages"""
+        if not conf['split']:
+            return False
+        if "arguments" not in body or len(body["arguments"]) != 1:
+            return False
+        arg = body["arguments"][0]
+        if not "arguments" in arg or arg.get("type") != "oneof" or arg.get("optional"):
+            return False
+        # Split into multiple lines if one of them is complex (has subargs).
+        for subarg in arg["arguments"]:
+            if "arguments" in subarg:
+                return True
+            # All subargs are simple, so we still want them on one line, e.g.
+            # CLIENT CACHING <YES | NO>
+        return False
+
+    # Now the actual work.
+    syntax = ''
+    if "arguments" not in body:
+        return command_syntax_clause(name, body, [])
+    elif use_multiline(body):
+        # Multiple variants on top level = multiple syntaxes of the
+        # command as a whole. Display them one by one.
+        syntaxes = [command_syntax_clause(name, body, [variant]) for variant in body["arguments"][0]["arguments"]]
+        return "\n".join(syntaxes)
+    else:
+        return command_syntax_clause(name, body, body["arguments"])
+
+def render_all(json, conf={}):
+    """Return syntaxes for all commands in a parsed commands JSON file"""
+    # syntaxes = []
+    # for name, body in json.items():
+    #     syntaxes.append(one(name, body, conf))
+    syntaxes = [render(name, body, conf) for name, body in json.items()]
+    return "\n".join(syntaxes)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog="command-syntax.py",
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     description='Render "Usage" syntax from JSON files.',
+                                     epilog=info)
+    parser.add_argument('--oneof-left', default = '<', metavar='STR', help='Default "<"')
+    parser.add_argument('--oneof-right', default = '>', metavar='STR', help='Default ">"')
+    parser.add_argument('--optional-left', default = '[', metavar='STR', help='Default "["')
+    parser.add_argument('--optional-right', default = ']', metavar='STR', help='Default "]"')
+    parser.add_argument('--markdown', action='store_true', help='Insert markdown bold and italics')
+    parser.add_argument('--split', action='store_true', help='Split into multiple lines if possible')
+    parser.add_argument('--no-simplify', action='store_true', help="Disable rewrite to simpler syntax")
+    parser.add_argument('filename', nargs='+', help='Command JSON file(s)')
+    args = parser.parse_args()
+    conf = {'<': args.oneof_left,
+            '>': args.oneof_right,
+            '[': args.optional_left,
+            ']': args.optional_right,
+            'markdown': args.markdown,
+            'split': args.split,
+            'simplify': not args.no_simplify}
+    for filename in args.filename:
+        try:
+            with open(filename, "r") as f:
+                d = json.load(f)
+                syntax = render_all(d, conf)
+                print(syntax)
+        except json.decoder.JSONDecodeError as err:
+            print("Error processing %s: %s" % (filename, err), file=sys.stderr)
+            exit(1)
+        except FileNotFoundError as err:
+            print(err, file=sys.stderr)
+            exit(1)

--- a/utils/command_syntax.py
+++ b/utils/command_syntax.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# Copyright (C) 2024, The Valkey contributors
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/utils/links-to-man.py
+++ b/utils/links-to-man.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# Copyright (C) 2024, The Valkey contributors
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/utils/links-to-man.py
+++ b/utils/links-to-man.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+
+info = """
+This markdown-to-markdown preprocessing script replaces links like
+../commands/info.md, ../topics/transactions.md with manpage style references
+like **info**(3valkey), **valkey-transactions**(7), etc.
+"""
+
+parser = argparse.ArgumentParser(prog="links-to-man.py",
+                                 description='Replace some links in markdown with manpage references',
+                                 epilog=info)
+parser.add_argument('--is-command-page', action='store_true',
+                    help="""If specied, the current page is a command page.
+                            Otherwise, it's assumed to be a topic page.""")
+parser.add_argument('filename', help='Markdown file, or - for stdin')
+args = parser.parse_args()
+
+filename = 0 if args.filename == '-' else args.filename
+with open(filename, "r") as f:
+    content = f.read()
+
+linklabels = {} # label => URL, for links on the form [text][label] where label is defined elsewhere.
+
+def normalize_label(label):
+    return label.strip().casefold()
+
+
+# Collect link labels (inspired by https://github.github.com/gfm/#link-reference-definition)
+for match in re.finditer(r'^ {0,3}\[([^\[\]]+)\]: *(\S+) +("[^"]*")? *$', content, re.MULTILINE):
+    label = normalize_label(match.group(1))
+    if label in linklabels:
+        continue
+    url = match.group(2)
+    #title = match.group(3)
+    linklabels[label] = url
+
+def page_to_man(text, dir, name):
+    """dir/name.md or dir/(empty name)"""
+    name = name.lower()
+    if dir == 'commands':
+        if name == '' or name == '.':
+            return '**valkey-commands**(7) %s' % text
+        else:
+            return '**%s**(3valkey)' % name
+    elif dir == 'topics':
+        if name == '' or name == '.':
+            return '**valkey**(7)'
+        elif name == 'valkey.conf':
+            return '**valkey.conf**(4)'
+        elif name in ['cli', 'check-aof', 'check-rdb', 'benchmark', 'server', 'sentinel']:
+            return '**valkey-%s**(1)' % name
+        elif text == '':
+            return '**valkey-%s**(7)' % name
+        else:
+            return '**valkey-%s**(7) %s' % (name, text)
+    elif dir == 'clients' and name == '':
+        return '[%s](https://valkey.io/clients/)' % text
+    elif dir == 'modules' and name == '':
+        return '[%s](https://valkey.io/modules/)' % text
+
+    return None
+
+def link_to_man(text, url):
+    """Returns a replacement for a link [text](url), or None"""
+    if text == url:
+        text = '' # Don't print a label if it's identical to the URL (for autolinked URLs)
+    elif text.lower().replace(' ', '-').removeprefix('valkey-') == url.removesuffix('.md').strip('/.').removeprefix('commands/').removeprefix('topics/'):
+        text = '' # Text is close enough to the page name. Show only page name.
+    url = re.sub(r'#.*$', '', url) # strip URL fragment
+    match = re.search(r'^../(commands|topics)/([^/]+)\.md$', url)
+    if match:
+        return page_to_man(text, match.group(1), match.group(2))
+    if url == './':
+        return page_to_man(text, 'commands' if args.is_command_page else 'topics', '')
+    match = re.search('https?://valkey.io/(commands|topics)/([^/]+)$', url)
+    if match:
+        return page_to_man(text, match.group(1), match.group(2))
+    match = re.search(r'^([^/]+)\.md$', url)
+    if match:
+        dir = 'commands' if args.is_command_page else 'topics'
+        return page_to_man(text, dir, match.group(1))
+    match = re.search(r'^(?:..|https?://valkey.io)/(commands|topics|clients|modules)/$', url)
+    if match:
+        return page_to_man(text, match.group(1), '')
+    # https://man7.org/linux/man-pages/man5/proc.5.html ==> proc(5)
+    match = re.search(r'^https?://man7\.org/linux/man-pages/man\d/([^/\.]+)\.(\d)\.html$', url)
+    if match:
+        return '**%s**(%s)' % (match.group(1), match.group(2))
+    # https://linux.die.net/man/2/fsync ==> fsync(2)
+    match = re.search(r'^https?://linux.die.net/man/(\d)/([^/\.]+)$', url)
+    if match:
+        return '**%s**(%s)' % (match.group(2), match.group(1))
+    # https://man.cx/accept%282%29 where %28 = "(", %29 = ")" ==> accept(2)
+    match = re.search(r'^https?://man.cx/([^/\.%]+)%28(\d)%29$', url)
+    if match:
+        return '**%s**(%s)' % (match.group(1), match.group(2))
+    # https://man.cx/epoll_ctl, https://man.cx/accept ==> epoll_ctl(2), etc.
+    match = re.search(r'^https?://man.cx/(accept|epoll_\w+)$', url)
+    if match:
+        return '**%s**(2)' % match.group(1)
+    return None
+
+# Inline links: [text](url)
+
+def inline_link_repl_callback(match):
+    text = match.group(1)
+    url = match.group(2).strip()
+    repl = link_to_man(text, url)
+    return repl if repl else match.group(0) # Keep original
+
+content = re.sub(r'\[([^\[\]\n]+)\]\(([^\(\)\n]+)(?: +"([^\(\)\"\n]+)")?\)', inline_link_repl_callback, content)
+
+# Ref style links: [text][label]
+
+def ref_link_repl_callback(match):
+    text = match.group(1)
+    label = normalize_label(match.group(2))
+    if label not in linklabels:
+        return match.group(0) # Keep original
+    url = linklabels[label]
+    repl = link_to_man(text, url)
+    return repl if repl else match.group(0)
+
+content = re.sub(r'\[([^\[\]+])\]\[([^\[\]]+)\]', ref_link_repl_callback, content)
+
+print(content)

--- a/utils/links-to-man.py
+++ b/utils/links-to-man.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import argparse
 import re
 

--- a/utils/preprocess-markdown.py
+++ b/utils/preprocess-markdown.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+import re
+import json
+import argparse
+import sys
+import yaml
+from datetime import date
+
+import command_syntax
+
+# Standard man page headings according to 'man man-pages', in standard order
+standard_headings = {
+    'NAME',                     # Inserted automatically
+    'LIBRARY',                  # Not used (possibly use module API functions)
+    'SYNOPSIS',                 # Inserted automatically for commands. Written
+                                # explicitly as "## Usage" for programs.
+    'CONFIGURATION',            # Explicit for valkey.conf(4)
+    'DESCRIPTION',              # Inserted automatically before any text unless
+                                # another standard heading starts the text
+    'OPTIONS',                  # Uses for programs
+    'EXIT STATUS',              # [Normally only in Sections 1, 8]
+    'RETURN VALUE',             # We use REPLY instead, automatic for commands
+    'ERRORS',
+    'ENVIRONMENT',
+    'FILES',
+    'VERSIONS',                 # We use HISTORY instead, automatic for commands
+    'ATTRIBUTES',               # [Normally only in Sections 2, 3]
+    'STANDARDS',
+    'NOTES',                    # Inserted automatically for deprecated commands
+    'CAVEATS',
+    'BUGS',
+    'EXAMPLES',
+    'AUTHORS',                  # Discouraged
+    'REPORTING BUGS',
+    'COPYRIGHT',
+    'SEE ALSO'                  # Inserted automatically for commands
+}
+
+class ManStructure:
+    """Render markdown with H1 for the standard man-page headings and some other quirks."""
+    def __init__(self, data):
+        self.__dict__.update(data)
+    def __getattr__(self, prop):
+        return self.__dict__.get(prop)
+
+    def print_top(self):
+        print('---')
+        print('title: %s' % self.name.upper())
+        if self.pagetype == 'command':
+            print('section: 3valkey')
+            print('header: Valkey Command Manual')
+        elif self.pagetype == 'program':
+            print('section: 1')
+            print('header: Valkey Manual')
+        elif self.pagetype == 'config':
+            print('section: 4')
+            print('header: Valkey Configuration Manual')
+        else:
+            print('section: 7')
+            print('header: Valkey Manual')
+        print('footer: Valkey Documentation')
+        print('date: %s' % self.date)
+        print('adjusting: left')
+        print('---')
+        print('# NAME', end="\n\n")
+        if self.summary:
+            print('%s - %s' % (self.name, self.summary), end="\n\n")
+        elif self.title:
+            print('%s - %s' % (self.name, self.title), end="\n\n")
+        else:
+            print('%s' % (self.name), end="\n\n")
+        if self.syntax:
+            print("# SYNOPSIS", end="\n\n")
+            print(self.syntax, end="\n\n")
+
+    def print_middle(self):
+        if self.pagetype != 'command':
+            return
+        if self.resp2 or self.resp3:
+            print("# REPLY", end="\n\n")
+            if self.resp2 == self.resp3:
+                print(self.resp2, end="\n\n")
+            else:
+                if self.resp2:
+                    print("## RESP2", end="\n\n")
+                    print(self.resp2, end="\n\n")
+                if self.resp3:
+                    print("## RESP3", end="\n\n")
+                    print(self.resp3, end="\n\n")
+            
+        if self.complexity:
+            print("# COMPLEXITY", end="\n\n")
+            print(self.complexity, end="\n\n")
+        if self.acl_categories:
+            acl = " ".join(self.acl_categories)
+            print("# ACL CATEGORIES", end="\n\n")
+            print(acl, end="\n\n")
+
+        if self.since or self.history:
+            print("# HISTORY", end="\n\n")
+            if self.since:
+                print("* Available since: %s" % self.since)
+            if self.history:
+                for entry in self.history:
+                    print("* Changed in %s: %s" % (entry[0], entry[1]))
+            print()
+
+        if self.deprecated_since:
+            print("# NOTES", end="\n\n")
+            if self.replaced_by:
+                print("This command is deprecated (since %s) and replaced by %s." %
+                      (self.deprecated_since, self.replaced_by), end="\n\n")
+            else:
+                print("This command is deprecated since %s." % self.deprecated_since, end="\n\n")
+
+    def print_bottom(self):
+        if self.see_also_commands:
+            print("# SEE ALSO", end="\n\n")
+            see_also = ", ".join(["**" + cmd.lower().replace(' ', '-') + "**(3valkey)"
+                                  for cmd in self.see_also_commands.keys()])
+            print(see_also + ".", end="\n\n")
+
+    def rewrite_heading(self, heading):
+        heading = heading.strip()
+        if heading == "## Usage":
+            heading = "# SYNOPSIS"
+        elif heading.startswith("##") and heading[2:].strip().upper() in standard_headings:
+            # If any of the standard headings are used explicitly as H2, we
+            # format them as man page standard headings with H1 and in all-caps.
+            # This is the case for valkey-server, valkey-cli, valkey-benchmark,
+            # etc. where we write out Options, Description, etc. explicitly.
+            heading = heading[1:].upper()
+        elif heading.startswith("# "):
+            heading = heading.upper()
+        return heading + "\n"
+
+    def rewrite_link(self, url, fragment):
+        # Don't edit links. Another script rewrites them to manpage references.
+        return url + fragment
+
+class WebStructure:
+    """This one uses H2 headings. There's only one H1 on web pages."""
+    def __init__(self, data):
+        self.__dict__.update(data)
+    def __getattr__(self, prop):
+        return self.__dict__.get(prop)
+
+    def print_top(self):
+        title = self.title if self.title else self.name
+        print('---')
+        print('title: %s &middot; Valkey' % title)
+        print('---')
+        print("# %s" % title, end="\n\n")
+        if self.summary:
+            print(self.summary, end="\n\n")
+        if self.pagetype == 'command':
+            if self.syntax:
+                print("## Usage", end="\n\n")
+                print(self.syntax, end="\n\n")
+
+    def print_middle(self):
+        if self.resp2 or self.resp3:
+            if self.resp2 == self.resp3:
+                print("## Reply", end="\n\n")
+                print(rewrite_links(self.resp2, self), end="\n\n")
+            else:
+                if self.resp2:
+                    print("## Reply RESP2", end="\n\n")
+                    print(rewrite_links(self.resp2, self), end="\n\n")
+                if self.resp3:
+                    print("## Reply RESP3", end="\n\n")
+                    print(rewrite_links(self.resp3, self), end="\n\n")
+        if self.complexity:
+            print("## Complexity", end="\n\n")
+            print(self.complexity, end="\n\n")
+        if self.acl_categories:
+            acl = " ".join(self.acl_categories)
+            print("## ACL Categories", end="\n\n")
+            print(acl, end="\n\n")
+
+    def print_bottom(self):
+        if self.history or self.since or self.deprecated_since:
+            print("## History", end="\n\n")
+            if self.since:
+                print("* %s: Introduced." % self.since)
+            if self.history:
+                for entry in self.history:
+                    print("* %s: %s" % (entry[0], entry[1]))
+            if self.deprecated_since:
+                if self.replaced_by:
+                    print("* %s: Deprecated; replaced by %s." % (self.deprecated_since, self.replaced_by))
+                else:
+                    print("* %s: Deprecated." % self.deprecated_since)
+            print()
+        if self.see_also_commands:
+            print("## See also", end="\n\n")
+            see_also = ", ".join(['[%s](%s "%s")' % (cmd, cmd.lower().replace(' ', '-') + self.suffix, summary)
+                                  for (cmd, summary) in self.see_also_commands.items()])
+            print(see_also + '.', end="\n\n")
+
+    def rewrite_heading(self, heading):
+        return heading
+
+    def rewrite_link(self, url, fragment):
+        # This is internal links only
+        if url.endswith(".md"):
+            url = url[0:-3] + self.suffix
+        elif url.endswith("/"):
+            url = url + 'index' + self.suffix
+        return url + fragment
+
+def loadjson(filename):
+    """Loads a JSON file or exits the program"""
+    try:
+        with open(filename, "r") as f:
+            return json.load(f)
+    except json.decoder.JSONDecodeError as err:
+        print("Error processing %s: %s" % (filename, err), file=sys.stderr)
+        exit(1)
+    except FileNotFoundError as err:
+        print(err, file=sys.stderr)
+        exit(1)
+
+def get_reply(name, resp_json_file):
+    json = loadjson(resp_json_file)
+    if name in json:
+        return "\n\n".join(json[name])
+    else:
+        return None
+
+def acl_categories(json):
+    flags = set(json["command_flags"] if "command_flags" in json else [])
+    acl   = set(json["acl_categories"] if "acl_categories" in json else [])
+    if "WRITE" in flags:
+        acl.add("WRITE")
+    if "READONLY" in flags and "SCRIPTING" not in acl:
+        acl.add("READ")
+    if "ADMIN" in flags:
+        acl.add("ADMIN")
+        acl.add("DANGEROUS")
+    if "PUBSUB" in flags:
+        acl.add("PUBSUB")
+    if "FAST" in flags:
+        acl.add("FAST")
+    if "BLOCKING" in flags:
+        acl.add("BLOCKING")
+    if "FAST" not in acl:
+        acl.add("SLOW")
+    return ["@" + cat.lower() for cat in sorted(acl)]
+
+def command_see_also(group, commands_per_group_file):
+    """Returns a dict {command: summary} of the commands in the given group"""
+    commands_per_group = loadjson(commands_per_group_file)
+    commands = commands_per_group.get(group)
+    if not commands:
+        return []
+    return {k: v.get("summary") for (k, v) in commands.items() if not v.get("deprecated")}
+
+def rewrite_links(text, renderer):
+    def repl_link_match(match):
+        # Match groups: 1 = before link, 2 = URL without fragment, 3 = URL fragment if any, 4 = after link
+        url = match.group(2)
+        # Rewrite external links to internal ones.
+        url = re.sub(r'^https?://valkey\.io/(commands|topics)/([^/]+)$', r'../\1/\2.md', url)
+        url = re.sub(r'^https?://valkey\.io/(commands|topics|clients|modules)/$', r'../$1/', url)
+        fragment = match.group(3) if match.group(3) else ''
+        link = renderer.rewrite_link(url, fragment)
+        return match.group(1) + link + match.group(4)
+    # inline links [text](url)
+    text = re.sub(r'(\]\()((?:../\w+/|./)?(?:[^/\)\#]+\.md)?)(#[^\)]*)?(\))', repl_link_match, text)
+    # link labels [label]: url
+    text = re.sub(r'^(\[[\w\d-]+\]: *)((?:../\w+/|./)?(?:[^/\)\#]+\.md)?)(#[^\)\s]*)?()\s*$', repl_link_match, text)
+    return text
+
+def main():
+    docdir = os.path.dirname(os.path.abspath(__file__)) + "/../"
+    resp2_default = docdir + "resp2_replies.json"
+    resp3_default = docdir + "resp3_replies.json"
+    parser = argparse.ArgumentParser(prog="preprocess-markdown.py",
+                                     description='Build a complete markdown page from input markdown and JSON files.',
+                                     epilog="")
+    parser.add_argument('--page-type', default='topic', choices=['topic', 'command', 'program', 'config'])
+    parser.add_argument('--valkey-root', help='Root directory of the code repo')
+    parser.add_argument('--command-json', help='Command JSON file in code repo')
+    parser.add_argument('--commands-per-group-json', help='JSON file generated by build-command-groups.py')
+    parser.add_argument('--resp2-replies-json', default=resp2_default, help='RESP2 replies JSON file')
+    parser.add_argument('--resp3-replies-json', default=resp3_default, help='RESP2 replies JSON file')
+    parser.add_argument('--suffix', default='.md',
+                        help='Suffix to use in internal links instead of .md for non-manpage usage')
+    parser.add_argument('--base-url', default='https://valkey.io/', help='Used for transforming absolute links to relative ones.')
+    parser.add_argument('--man', action='store_true', help='Generate markdown for man page')
+    parser.add_argument('filename', help='Markdown file')
+    args = parser.parse_args()
+
+    # We can use git to find the last change of the file, but only if we're in a git repo.
+    # yyyymmdd = os.popen('git log -1 --pretty="format:%cs" ' + args.filename).read()
+    mtime = os.stat(args.filename).st_mtime
+    yyyymmdd = date.fromtimestamp(mtime).isoformat()
+
+    name0 = re.sub(r'^.*/([^/]+)\.md$', r'\1', args.filename) # "client-kill"
+
+    # Pagename = name of man page excluding section. (Only used for man pages.)
+    if args.page_type == 'command':
+        pagename = name0
+    elif args.page_type == 'topic' and name0 == 'index':
+        pagename = 'valkey'
+    else:
+        pagename = 'valkey-' + name0
+    data = {
+        "name": pagename,
+        "date": yyyymmdd,
+        "suffix": args.suffix,
+        "pagetype": args.page_type
+    }
+
+    if args.page_type == 'command':
+        if args.command_json:
+            command_json = args.command_json
+        elif args.valkey_root:
+            command_json = args.valkey_root + '/src/commands/' + name0 + '.json'
+        else:
+            print("I need --command-json or --valkey-root", file=sys.stderr)
+            exit(1)
+
+        command_metadata = loadjson(command_json)
+        name  = name0.replace("-", " ", 1).upper()                # "CLIENT KILL"
+        name1 = name.split(' ', maxsplit=1)[-1]                   # "KILL"
+        if name1 not in command_metadata:
+            # Some commands' filenames look like subcommands, but they're not.
+            name  = name0.upper()                                 # "RESTORE-ASKING"
+            name1 = name
+
+        command_metadata = command_metadata[name1]
+
+        syntax = command_syntax.render(name1, command_metadata, {'split': True, 'markdown': True})
+        syntax = syntax.replace("\n", "\\\n") # Explicit linebreak between the clauses.
+
+        data.update({
+            "title": name,    # e.g. "CLIENT KILL"
+            "syntax": syntax,
+            "resp2": get_reply(name, args.resp2_replies_json),
+            "resp3": get_reply(name, args.resp3_replies_json),
+            "summary": command_metadata.get("summary"),
+            "complexity": command_metadata.get("complexity"),
+            "since": command_metadata.get("since"),
+            "history": command_metadata.get("history"),
+            "acl_categories": acl_categories(command_metadata),
+            "group": command_metadata.get("group"),
+            "see_also_commands": command_see_also(command_metadata.get("group"), args.commands_per_group_json)
+        })
+        if "deprecated_since" in command_metadata:
+            data["deprecated_since"] = command_metadata["deprecated_since"]
+        if "replaced_by" in command_metadata:
+            # Remove old marks that something is NOT a command, e.g. `!GET`.
+            replaced_by = re.sub(r'`!([A-Z -]+)`', r'`\1`', command_metadata["replaced_by"])
+            data["replaced_by"] = replaced_by
+
+    r = None # Populate it later, when we have parsed frontmatter.
+
+    # Encoding "utf-8-sig" deletes the silly UTF-8 BOM added by MS Notepad.
+    with open(args.filename, "r", encoding="utf-8-sig") as f:
+        lines = [line for line in f]
+    frontmatter_str = ''
+    frontmatter = {}
+    middle_stuff_printed = False
+    state = 0 # 0 = start of file, 1 = in yaml metadata, 2 = start of body, 3 = before description, 4 = in or after description
+    prevline = None
+    for line in lines:
+        if state == 0:
+            if line.startswith("---"):
+                state = 1
+                continue
+            else:
+                state = 2
+        elif state == 1:
+            if line.startswith("---"):
+                state = 2
+                frontmatter = yaml.safe_load(frontmatter_str)
+            else:
+                frontmatter_str = frontmatter_str + line
+            continue
+
+        # If we're here, the frontmatter has been parsed and the actual
+        # markdown starts.
+        if (state == 2):
+            # Start of body. Init the renderer.
+            if "title" in frontmatter and "title" not in data:
+                data["title"] = frontmatter["title"]
+            r = ManStructure(data) if args.man else WebStructure(data)
+            # Before the start of the body, we print some stuff.
+            r.print_top()
+            state = 3
+
+        # Now we're in the body of the file
+
+        # Remove old marks that something is NOT a command, e.g. `!GET`.
+        line = re.sub(r'`!([A-Z -]+)`', r'`\1`', line)
+
+        # Rewrite links
+        line = rewrite_links(line, r)
+
+        # Rewrite underlined headings to ATX style headings, for later processing.
+        if prevline is not None:
+            if line.startswith('---'):
+                line = '## ' + prevline
+                prevline = None
+            elif line.startswith('==='):
+                line = '# ' + prevline
+                prevline = None
+
+        # Print the previous line. We do this to be able to detect two-line
+        # markdown things like headering with underline.
+        if prevline is not None:
+            if state == 3 and prevline.strip() != "":
+                state = 4
+                # Insert a Description heading after the page header, unless the
+                # text already starts with a heading.
+                if not prevline.startswith("#"):
+                    print(r.rewrite_heading("## Description"))
+            if prevline.startswith("#"):
+                print(r.rewrite_heading(prevline))
+            else:
+                print(prevline, end='')
+
+        # Insert some stuff before the Notes or Example(s) section.
+        if not middle_stuff_printed:
+            if line.startswith("## Notes") or line.startswith("## Example"):
+                r.print_middle()
+                middle_stuff_printed = True
+
+        prevline = line
+
+    # The last line that hasn't yet been printed.
+    print(prevline);
+
+    if not middle_stuff_printed:
+        print()
+        r.print_middle()
+
+    print()
+    r.print_bottom()
+
+main()
+
+# If we want Authors, we can get it from git blame:
+# git blame --line-porcelain FILE | sed -n 's/^author //p' | sort | uniq -c | sort -rn

--- a/utils/preprocess-markdown.py
+++ b/utils/preprocess-markdown.py
@@ -310,6 +310,8 @@ def main():
         pagename = name0
     elif args.page_type == 'topic' and name0 == 'index':
         pagename = 'valkey'
+    elif args.page_type == 'config' and name0 == 'valkey.conf':
+        pagename = name0
     else:
         pagename = 'valkey-' + name0
     data = {

--- a/utils/preprocess-markdown.py
+++ b/utils/preprocess-markdown.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Viktor Söderqvist <viktor.soderqvist@est.tech>
+# Copyright (C) 2024, The Valkey contributors
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/wordlist
+++ b/wordlist
@@ -661,6 +661,7 @@ OR-ing
 ORed
 ORM
 OSGEO:41001
+OSS
 overcommit
 p50
 p999
@@ -1045,6 +1046,7 @@ UTF-8
 utf8
 utils
 v9
+Valkey
 value-ptr
 ValueN
 Variadic


### PR DESCRIPTION
A Makefile provides 'make' and 'make install' to generate and install man pages.

Man pages are built for the binaries (valkey-cli, etc. prefixed by "valkey-",
section 1), Config (valkey.conf, section 4), Valkey commands (section 3valkey),
documentation overview page ("valkey", section 7) and tutorials and everything
else (prefixed by "valkey-", section 7).

Scripts in Python are used for preprocessing and pandoc is used to convert
markdown to man pages, stored under utils/.

A target 'make html' is also provided, to build HTML pages to use locally.
This is also using pandoc.

The documentation pages for `valkey-cli`, `valkey-benchmark` and `valkey-sentinel` are expanded with usage and options to match what's expected from a man page for a program. A page for `valkey-server` is added. (We didn't have one.)

README.md is update with info on how to build and install man pages. Other info regarding the doc repo is slightly updated.

Fixes #69.

**Reviewers:** I suggest checking out my branch and trying `make -j10 VALKEY_ROOT=path/to/valkey` and `sudo make install`. Then `man valkey` to start with.