### PR TITLE
Cleanup: Delete frontmatter keys 'aliases' and 'weight'

### DIFF
--- a/topics/ARM.md
+++ b/topics/ARM.md
@@ -1,11 +1,8 @@
 ---
 title: "ARM support"
 linkTitle: "ARM support"
-weight: 11
 description: >
     Exploring Valkey on the ARM CPU Architecture
-aliases:
-    - /topics/ARM
 ---
 
 Valkey supports the ARM processor, for example

--- a/topics/acl.md
+++ b/topics/acl.md
@@ -1,13 +1,7 @@
 ---
 title: "ACL"
 linkTitle: "ACL"
-weight: 1
 description: Valkey Access Control List
-aliases: [
-    /topics/acl,
-    /docs/manual/security/acl,
-    /docs/manual/security/acl.md
-]
 ---
 
 The Valkey ACL, short for Access Control List, is a feature that allows certain connections to be limited in terms of the commands that can be executed and the keys that can be accessed.

--- a/topics/admin.md
+++ b/topics/admin.md
@@ -1,14 +1,7 @@
 ---
 title: Valkey administration
 linkTitle: Administration
-weight: 1
 description: Advice for configuring and managing Valkey in production
-aliases: [
-    /topics/admin,
-    /topics/admin.md,
-    /manual/admin,
-    /manual/admin.md
-]
 ---
 
 ## Valkey setup tips

--- a/topics/benchmark.md
+++ b/topics/benchmark.md
@@ -1,14 +1,8 @@
 ---
 title: "Valkey benchmark"
 linkTitle: "Benchmarking"
-weight: 1
 description: >
     Using the valkey-benchmark utility on a Valkey server
-aliases: [
-    /topics/benchmarks,
-    /docs/reference/optimization/benchmarks,
-    /docs/reference/optimization/benchmarks.md
-]
 ---
 
 ## Usage

--- a/topics/bitfields.md
+++ b/topics/bitfields.md
@@ -1,7 +1,6 @@
 ---
 title: "Bitfields"
 linkTitle: "Bitfields"
-weight: 130
 description: >
     Introduction to Bitfields
 ---

--- a/topics/bitmaps.md
+++ b/topics/bitmaps.md
@@ -1,7 +1,6 @@
 ---
 title: "Bitmaps"
 linkTitle: "Bitmaps"
-weight: 120
 description: >
     Introduction to Bitmaps
 ---

--- a/topics/cli.md
+++ b/topics/cli.md
@@ -1,13 +1,8 @@
 ---
 title: "Valkey CLI"
 linkTitle: "CLI"
-weight: 1
 description: >
     Valkey command line interface
-aliases:
-    - /docs/manual/cli
-    - /docs/management/cli
-    - /docs/ui/cli
 ---
 
 ## Usage

--- a/topics/client-side-caching.md
+++ b/topics/client-side-caching.md
@@ -1,11 +1,8 @@
 ---
 title: "Client-side caching in Valkey"
 linkTitle: "Client-side caching"
-weight: 2
 description: >
     Server-assisted, client-side caching in Valkey
-aliases:
-    - /topics/client-side-caching
 ---
 
 Client-side caching is a technique used to create high performance services.

--- a/topics/clients.md
+++ b/topics/clients.md
@@ -1,11 +1,8 @@
 ---
 title: "Valkey client handling"
 linkTitle: "Client handling"
-weight: 5
 description: >
     How the Valkey server manages client connections
-aliases:
-    - /topics/clients
 ---
 
 This document provides information about how Valkey handles clients at the network layer level: connections, timeouts, buffers, and other similar topics are covered here.

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -1,11 +1,8 @@
 ---
 title: Valkey cluster specification
 linkTitle: Cluster spec
-weight: 9
 description: >
     Detailed specification for Valkey cluster
-aliases:
-  - /topics/cluster-spec
 ---
 
 Welcome to the **Valkey Cluster Specification**. Here you'll find information

--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -1,14 +1,7 @@
 ---
 title: Scale with Valkey Cluster
 linkTitle: Scale with Valkey Cluster
-weight: 6
 description: Horizontal scaling with Valkey Cluster
-aliases: [
-    /topics/cluster-tutorial,
-    /topics/partitioning,
-    /docs/manual/scaling,
-    /docs/manual/scaling.md
-]
 ---
 
 Valkey scales horizontally with a deployment topology called Valkey Cluster. 

--- a/topics/command-arguments.md
+++ b/topics/command-arguments.md
@@ -1,10 +1,7 @@
 ---
 title: "Valkey command arguments"
 linkTitle: "Command arguments"
-weight: 7
 description: How Valkey commands expose their documentation programmatically
-aliases:
-    - /topics/command-arguments
 ---
 
 The `COMMAND DOCS` command returns documentation-focused information about available Valkey commands.

--- a/topics/command-tips.md
+++ b/topics/command-tips.md
@@ -1,10 +1,7 @@
 ---
 title: "Valkey command tips"
 linkTitle: "Command tips"
-weight: 1
 description: Get additional information about a command
-aliases:
-    - /topics/command-tips
 ---
 
 Command tips are an array of strings.

--- a/topics/data-types.md
+++ b/topics/data-types.md
@@ -2,11 +2,6 @@
 title: "Valkey data types"
 linkTitle: "Data types"
 description: Overview of data types supported by Valkey
-weight: 35
-aliases:
-    - /docs/manual/data-types
-    - /topics/data-types
-    - /docs/data-types/tutorial
 ---
 
 Valkey is a data structure server.

--- a/topics/debugging.md
+++ b/topics/debugging.md
@@ -1,14 +1,8 @@
 ---
 title: "Debugging"
 linkTitle: "Debugging"
-weight: 10
 description: >
     A guide to debugging Valkey server processes
-aliases: [
-    /topics/debugging,
-    /docs/reference/debugging,
-    /docs/reference/debugging.md
-]
 ---
 
 Valkey is developed with an emphasis on stability. We do our best with

--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -1,14 +1,8 @@
 ---
 title: "Distributed Locks with Valkey"
 linkTitle: "Distributed locks"
-weight: 1
 description: >
     A distributed lock pattern with Valkey
-aliases: [
-    /topics/distlock,
-    /docs/reference/patterns/distributed-locks,
-    /docs/reference/patterns/distributed-locks.md
-]
 ---
 Distributed locks are a very useful primitive in many environments where
 different processes must operate with shared resources in a mutually

--- a/topics/encryption.md
+++ b/topics/encryption.md
@@ -1,13 +1,7 @@
 ---
 title: "TLS"
 linkTitle: "TLS"
-weight: 1
 description: Valkey TLS support
-aliases: [
-    /topics/encryption,
-    /docs/manual/security/encryption,
-    /docs/manual/security/encryption.md
-]
 ---
 
 SSL/TLS is supported by Valkey as an optional feature

--- a/topics/eval-intro.md
+++ b/topics/eval-intro.md
@@ -1,12 +1,8 @@
 ---
 title: "Scripting with Lua"
 linkTitle: "Lua scripting"
-weight: 2
 description: >
    Executing Lua in Valkey
-aliases:
-    - /topics/eval-intro
-    - /docs/manual/programmability/eval-intro/
 ---
 
 Valkey lets users upload and execute Lua scripts on the server.

--- a/topics/faq.md
+++ b/topics/faq.md
@@ -1,11 +1,8 @@
 ---
 title: "Valkey FAQ"
 linkTitle: "FAQ"
-weight: 100
 description: >
     Commonly asked questions when getting started with Valkey
-aliases:
-    - /docs/getting-started/faq
 ---
 ## How is Valkey different from other key-value stores?
 

--- a/topics/functions-intro.md
+++ b/topics/functions-intro.md
@@ -1,12 +1,8 @@
 ---
 title: "Valkey functions"
 linkTitle: "Functions"
-weight: 1
 description: >
    Scripting with Redis OSS 7 and beyond
-aliases:
-    - /topics/functions-intro
-    - /docs/manual/programmability/functions-intro/
 ---
 
 Valkey Functions is an API for managing code to be executed on the server. This feature, which became available in Redis OSS 7, supersedes the use of [EVAL](eval-intro.md) in prior versions of Valkey.

--- a/topics/geospatial.md
+++ b/topics/geospatial.md
@@ -1,7 +1,6 @@
 ﻿---
 title: "Valkey geospatial"
 linkTitle: "Geospatial"
-weight: 80
 description: >
     Introduction to the Valkey Geospatial data type
 ---

--- a/topics/get-started.md
+++ b/topics/get-started.md
@@ -2,11 +2,8 @@
 title: "Quick starts"
 linkTitle: "Quick starts"
 hideListLinks: true
-weight: 20
 description: >
     Valkey quick start guides
-aliases:
-  - /docs/getting-started/
 ---
 
 Valkey can be used as a database, cache, streaming engine, message broker, and more. The following quick start guides will show you how to use Valkey for the following specific purposes:

--- a/topics/hashes.md
+++ b/topics/hashes.md
@@ -1,7 +1,6 @@
 ﻿---
 title: "Hashes"
 linkTitle: "Hashes"
-weight: 40
 description: >
     Introduction to Hashes
 ---

--- a/topics/history.md
+++ b/topics/history.md
@@ -1,10 +1,7 @@
 ---
 title: "Valkey history"
 linkTitle: "History"
-weight: 4
 description: How the Valkey project started
-aliases:
-    - /topics/history
 ---
 
 Valkey is a fork of the open-source Redis (REmote DIctionary Server) database

--- a/topics/hyperloglogs.md
+++ b/topics/hyperloglogs.md
@@ -1,11 +1,8 @@
 ---
 title: "HyperLogLog"
 linkTitle: "HyperLogLog"
-weight: 1
 description: >
     HyperLogLog is a probabilistic data structure that estimates the cardinality of a set.
-aliases:
-    - /docs/data-types/hyperloglogs/
 ---
 
 HyperLogLog is a probabilistic data structure that estimates the cardinality of a set. As a probabilistic data structure, HyperLogLog trades perfect accuracy for efficient space utilization.

--- a/topics/index.md
+++ b/topics/index.md
@@ -1,12 +1,6 @@
 ---
 title: "Valkey Documentation"
 linkTitle: "Documentation"
-weight: 20
-aliases:
-    - /documentation
-    - /documentation/
-    - /topics
-    - /topics/
 ---
 
 The Valkey documentation is managed in markdown files in the

--- a/topics/indexing.md
+++ b/topics/indexing.md
@@ -1,13 +1,8 @@
 ---
 title: Secondary indexing
 linkTitle: Secondary indexing
-weight: 1
 description: >
     Building secondary indexes in Valkey
-aliases: [
-    /topics/indexing,
-    /docs/reference/patterns/indexes
-]
 ---
 
 Valkey is not exactly a key-value store, since values can be complex data structures. However it has an external key-value shell: at API level data is addressed by the key name. It is fair to say that, natively, Valkey only offers *primary key access*. However since Valkey is a data structures server, its capabilities can be used for indexing, in order to create secondary indexes of different kinds, including composite (multi-column) indexes.

--- a/topics/installation.md
+++ b/topics/installation.md
@@ -1,10 +1,8 @@
 ---
 title: "Install Valkey"
 linkTitle: "Install Valkey"
-weight: 1
 description: >
     Install Valkey on Linux, macOS, and Windows
-aliases:
 - /docs/getting-started/installation
 - /docs/getting-started/tutorial
 ---

--- a/topics/internals-eventlib.md
+++ b/topics/internals-eventlib.md
@@ -1,11 +1,7 @@
 ﻿---
 title: "Event library"
 linkTitle: "Event library"
-weight: 1
 description: What's an event library, and how was the original Valkey event library implemented?
-aliases:
-  - /topics/internals-eventlib
-  - /topics/internals-rediseventlib
 ---
 
 **Note: this document was written by the creator of Valkey, Salvatore Sanfilippo, early in the development of Valkey (c. 2010), and does not necessarily reflect the latest Valkey implementation.**

--- a/topics/internals-sds.md
+++ b/topics/internals-sds.md
@@ -1,10 +1,7 @@
 ---
 title: "String internals"
 linkTitle: "String internals"
-weight: 1
 description: Guide to the original implementation of Strings
-aliases:
-  - /topics/internals-sds
 ---
 
 **Note: this document was written by the creator of Valkey, Salvatore Sanfilippo, early in the development of Valkey (c. 2010). Virtual Memory has been deprecated since Redis OSS 2.6, so this documentation

--- a/topics/internals-vm.md
+++ b/topics/internals-vm.md
@@ -1,11 +1,7 @@
 ---
 title: "Virtual memory (deprecated)"
 linkTitle: "Virtual memory"
-weight: 1
 description: A description of the Valkey virtual memory system that was deprecated in 2.6. This document exists for historical interest.
-aliases:
-  - /topics/internals-vm
-  - /topics/virtual-memory
 ---
 
 **Note: this document was written by the creator of Valkey, Salvatore Sanfilippo, early in the development of Valkey (c. 2010). Virtual Memory has been deprecated since Redis OSS 2.6, so this documentation

--- a/topics/internals.md
+++ b/topics/internals.md
@@ -1,10 +1,7 @@
 ---
 title: "Valkey internals"
 linkTitle: "Internals"
-weight: 12
 description: Documents describing internals in early Valkey implementations
-aliases:
-  - /topics/internals
 ---
 
 **The following Valkey documents were written by the creator of Valkey, Salvatore Sanfilippo, early in the development of Valkey (c. 2010), and do not necessarily reflect the latest Valkey implementation.**

--- a/topics/introduction.md
+++ b/topics/introduction.md
@@ -1,11 +1,7 @@
 ---
 title: Introduction to Valkey
 linkTitle: "About"
-weight: 10
 description: Learn about the Valkey open source project
-aliases:
-  - /topics/introduction
-  - /buzz
 ---
 
 Valkey is an open source (BSD licensed), in-memory __data structure store__ used as a database, cache, message broker, and streaming engine. Valkey provides [data structures](data-types.md) such as

--- a/topics/keyspace.md
+++ b/topics/keyspace.md
@@ -1,11 +1,8 @@
 ---
 title: "Keyspace"
 linkTitle: "Keyspace"
-weight: 1
 description: >
     Managing keys in Valkey: Key expiration, scanning, altering and querying the key space
-aliases:
-  - /docs/manual/the-redis-keyspace    
 ---
 
 Valkey keys are binary safe; this means that you can use any binary sequence as a

--- a/topics/latency-monitor.md
+++ b/topics/latency-monitor.md
@@ -1,12 +1,7 @@
 ---
 title: "Valkey latency monitoring"
 linkTitle: "Latency monitoring"
-weight: 1
 description: Discovering slow server events in Valkey
-aliases: [
-    /topics/latency-monitor,
-    /docs/reference/optimization/latency-monitor
-]
 ---
 
 Valkey is often used for demanding use cases, where it

--- a/topics/latency.md
+++ b/topics/latency.md
@@ -1,12 +1,7 @@
 ---
 title: "Diagnosing latency issues"
 linkTitle: "Latency diagnosis"
-weight: 1
 description: Finding the causes of slow responses
-aliases: [
-    /topics/latency,
-    /docs/reference/optimization/latency
-]
 ---
 
 This document will help you understand what the problem could be if you

--- a/topics/ldb.md
+++ b/topics/ldb.md
@@ -2,10 +2,6 @@
 title: Debugging Lua scripts in Valkey
 linkTitle: Debugging Lua
 description: How to use the built-in Lua debugger
-weight: 4
-aliases:
-  - /topics/ldb
-  - /docs/manual/programmability/lua-debugging/
 ---
 
 Valkey includes a complete Lua debugger, that can be

--- a/topics/license.md
+++ b/topics/license.md
@@ -1,11 +1,8 @@
 ---
 title: "Valkey license"
 linkTitle: "License"
-weight: 5
 description: >
     License and trademark information
-aliases:
-    - /topics/license
 ---
 
 

--- a/topics/lists.md
+++ b/topics/lists.md
@@ -1,7 +1,6 @@
 ﻿---
 title: "Lists"
 linkTitle: "Lists"
-weight: 20
 description: >
     Introduction to Lists
 ---

--- a/topics/lru-cache.md
+++ b/topics/lru-cache.md
@@ -1,13 +1,7 @@
 ---
 title: Key eviction
 linkTitle: Eviction
-weight: 6
 description: Overview of Valkey key eviction policies (LRU, LFU, etc.)
-aliases: [
-    /topics/lru_cache,
-    /topics/lru_cache.md,
-    /docs/manual/eviction
-]
 ---
 
 When Valkey is used as a cache, it is often convenient to let it automatically

--- a/topics/lua-api.md
+++ b/topics/lua-api.md
@@ -1,12 +1,8 @@
 ---
 title: "Valkey Lua API reference"
 linkTitle: "Lua API"
-weight: 3
 description: >
    Executing Lua in Valkey
-aliases:
-    - /topics/lua-api
-    - /docs/manual/programmability/lua-api/
 ---
 
 Valkey includes an embedded [Lua 5.1](https://www.lua.org/) interpreter.

--- a/topics/mass-insertion.md
+++ b/topics/mass-insertion.md
@@ -1,13 +1,8 @@
 ---
 title: "Bulk loading"
 linkTitle: "Bulk loading"
-weight: 1
 description: >
     Writing data in bulk using the Valkey protocol
-aliases: [
-    /topics/mass-insertion,
-    /docs/reference/patterns/bulk-loading
-]
 ---
 
 Bulk loading is the process of loading Valkey with a large amount of pre-existing data. Ideally, you want to perform this operation quickly and efficiently. This document describes some strategies for bulk loading data in Valkey.

--- a/topics/memory-optimization.md
+++ b/topics/memory-optimization.md
@@ -2,11 +2,6 @@
 title: Memory optimization
 linkTitle: Memory optimization
 description: Strategies for optimizing memory usage in Valkey
-weight: 1
-aliases: [
-    /topics/memory-optimization,
-    /docs/reference/optimization/memory-optimization
-]
 ---
 
 ## Special encoding of small aggregate data types

--- a/topics/modules-api-ref.md
+++ b/topics/modules-api-ref.md
@@ -1,7 +1,6 @@
 ---
 title: "Modules API reference"
 linkTitle: "API reference"
-weight: 1
 description: >
     Reference for the Valkey Modules API
 ---

--- a/topics/modules-blocking-ops.md
+++ b/topics/modules-blocking-ops.md
@@ -1,11 +1,8 @@
 ---
 title: "Valkey modules and blocking commands"
 linkTitle: "Blocking commands"
-weight: 1
 description: >
     How to implement blocking commands in a Valkey module
-aliases:
-    - /topics/modules-blocking-ops
 ---
 
 Valkey has a few blocking commands among the built-in set of commands.

--- a/topics/modules-intro.md
+++ b/topics/modules-intro.md
@@ -1,11 +1,8 @@
 ---
 title: "Valkey modules API"
 linkTitle: "Modules API"
-weight: 2
 description: >
     Introduction to writing Valkey modules
-aliases:
-    - /topics/modules-intro
 ---
 
 The modules documentation is composed of the following pages:

--- a/topics/modules-native-types.md
+++ b/topics/modules-native-types.md
@@ -1,11 +1,8 @@
 ---
 title: "Modules API for native types"
 linkTitle: "Native types API"
-weight: 1
 description: >
     How to use native types in a Valkey module
-aliases:
-    - /topics/modules-native-types
 ---
 
 Valkey modules can access Valkey built-in data structures both at high level,

--- a/topics/notifications.md
+++ b/topics/notifications.md
@@ -1,11 +1,8 @@
 ---
 title: "Valkey keyspace notifications"
 linkTitle: "Keyspace notifications"
-weight: 4
 description: >
     Monitor changes to Valkey keys and values in real time
-aliases:
-    - /topics/notifications
 ---
 
 Keyspace notifications allow clients to subscribe to Pub/Sub channels in order

--- a/topics/performance-on-cpu.md
+++ b/topics/performance-on-cpu.md
@@ -1,13 +1,8 @@
 ---
 title: "Valkey CPU profiling"
 linkTitle: "CPU profiling"
-weight: 1
 description: >
     Performance engineering guide for on-CPU profiling and tracing
-aliases: [
-    /topics/performance-on-cpu,
-    /docs/reference/optimization/cpu-profiling
-]
 ---
 
 ## Filling the performance checklist

--- a/topics/persistence.md
+++ b/topics/persistence.md
@@ -1,14 +1,7 @@
 ---
 title: Valkey persistence
 linkTitle: Persistence
-weight: 7
 description: How Valkey writes data to disk
-aliases: [
-    /topics/persistence,
-    /topics/persistence.md,
-    /docs/manual/persistence,
-    /docs/manual/persistence.md
-]
 ---
 
 Persistence refers to the writing of data to durable storage, such as a solid-state disk (SSD). Valkey provides a range of persistence options. These include:

--- a/topics/pipelining.md
+++ b/topics/pipelining.md
@@ -1,10 +1,7 @@
 ---
 title: "Valkey pipelining"
 linkTitle: "Pipelining"
-weight: 2
 description: How to optimize round-trip times by batching Valkey commands
-aliases:
-  - /topics/pipelining
 ---
 
 Valkey pipelining is a technique for improving performance by issuing multiple commands at once without waiting for the response to each individual command. Pipelining is supported by most Valkey clients. This document describes the problem that pipelining is designed to solve and how pipelining works in Valkey.

--- a/topics/problems.md
+++ b/topics/problems.md
@@ -1,13 +1,7 @@
 ---
 title: "Troubleshooting Valkey"
 linkTitle: "Troubleshooting"
-weight: 9
 description: Problems with Valkey? Start here.
-aliases: [
-    /topics/problems,
-    /docs/manual/troubleshooting,
-    /docs/manual/troubleshooting.md
-]
 ---
 
 This page tries to help you with what to do if you have issues with Valkey. Part of the Valkey project is helping people that are experiencing problems because we don't like to leave people alone with their issues.

--- a/topics/programmability.md
+++ b/topics/programmability.md
@@ -1,12 +1,8 @@
 ---
 title: "Valkey programmability"
 linkTitle: "Programmability"
-weight: 20
 description: >
    Extending Valkey with Lua and Valkey Functions
-aliases:
-    - /topics/programmability
-    - /docs/manual/programmability/
 ---
 
 Valkey provides a programming interface that lets you execute custom scripts on the server itself. In Redis OSS 7 and beyond, you can use [Valkey Functions](functions-intro.md) to manage and run your scripts. In Redis OSS 6.2 and below, you use [Lua scripting with the EVAL command](eval-intro.md) to program the server.

--- a/topics/protocol.md
+++ b/topics/protocol.md
@@ -1,10 +1,7 @@
 ---
 title: "Valkey serialization protocol specification"
 linkTitle: "Protocol spec"
-weight: 4
 description: Valkey serialization protocol (RESP) is the wire protocol that clients implement
-aliases:
-    - /topics/protocol
 ---
 
 To communicate with the Valkey server, Valkey clients use a protocol called REdis Serialization Protocol (RESP).

--- a/topics/pubsub.md
+++ b/topics/pubsub.md
@@ -1,12 +1,7 @@
 ---
 title: Valkey Pub/Sub
 linkTitle: "Pub/sub"
-weight: 40
 description: How to use pub/sub channels in Valkey
-aliases:
-  - /topics/pubsub
-  - /docs/manual/pub-sub
-  - /docs/manual/pubsub
 ---
 
 `SUBSCRIBE`, `UNSUBSCRIBE` and `PUBLISH` implement the [Publish/Subscribe messaging paradigm](https://en.wikipedia.org/wiki/Publish/subscribe) where publishers send their messages to channels, without knowledge of what receivers (subscribers) there may be.

--- a/topics/quickstart.md
+++ b/topics/quickstart.md
@@ -1,7 +1,6 @@
 ---
 title: "Valkey as an in-memory data structure store quick start guide"
 linkTitle: "Data structure store"
-weight: 1
 description: Understand how to use basic Valkey data types
 ---
 

--- a/topics/rdd.md
+++ b/topics/rdd.md
@@ -1,12 +1,7 @@
 ---
 title: "Valkey design draft #2 (historical)"
 linkTitle: "Valkey design draft"
-weight: 2
 description: A design for the RDB format written in the early days of Valkey
-aliases:
-  - /topics/rdd
-  - /topics/rdd-1
-  - /topics/rdd-2
 ---
 
 **Note: this document was written by the creator of Valkey, Salvatore Sanfilippo, early in the development of Valkey (c. 2013), as part of a series of design drafts. This is preserved for historical interest.**

--- a/topics/releases.md
+++ b/topics/releases.md
@@ -1,10 +1,7 @@
 ---
 title: "Valkey release cycle"
 linkTitle: "Release cycle"
-weight: 4
 description: How are new versions of Valkey released?
-aliases:
-    - /topics/releases
 ---
 
 Valkey is system software and a type of system software that holds user data, so

--- a/topics/replication.md
+++ b/topics/replication.md
@@ -1,14 +1,7 @@
 ---
 title: Valkey replication
 linkTitle: Replication
-weight: 5
 description: How Valkey supports high availability and failover with replication
-aliases: [
-    /topics/replication,
-    /topics/replication.md,
-    /docs/manual/replication,
-    /docs/manual/replication.md
-]
 ---
 
 At the base of Valkey replication (excluding the high availability features provided as an additional layer by Valkey Cluster or Valkey Sentinel) there is a *leader follower* (master-replica) replication that is simple to use and configure. It allows replica Valkey instances to be exact copies of master instances. The replica will automatically reconnect to the master every time the link breaks, and will attempt to be an exact copy of it *regardless* of what happens to the master.

--- a/topics/security.md
+++ b/topics/security.md
@@ -1,13 +1,7 @@
 ---
 title: "Valkey security"
 linkTitle: "Security"
-weight: 1
 description: Security model and features in Valkey
-aliases: [
-    /topics/security,
-    /docs/manual/security,
-    /docs/manual/security.md
-]
 ---
 
 This document provides an introduction to the topic of security from the point of

--- a/topics/sentinel-clients.md
+++ b/topics/sentinel-clients.md
@@ -1,10 +1,7 @@
 ---
 title: "Sentinel client spec"
 linkTitle: "Sentinel clients"
-weight: 2
 description: How to build clients for Valkey Sentinel
-aliases:
-  - /topics/sentinel-clients
 ---
 
 Valkey Sentinel is a monitoring solution for Valkey instances that handles

--- a/topics/sentinel.md
+++ b/topics/sentinel.md
@@ -1,13 +1,7 @@
 ---
 title: "High availability with Valkey Sentinel"
 linkTitle: "High availability with Sentinel"
-weight: 4
 description: High availability for non-clustered Valkey
-aliases: [
-    /topics/sentinel,
-    /docs/manual/sentinel,
-    /docs/manual/sentinel.md
-]
 ---
 
 ## Usage

--- a/topics/server.md
+++ b/topics/server.md
@@ -1,7 +1,6 @@
 ---
 title: "Valkey Server"
 linkTitle: "Valkey Server"
-weight: 1
 description: >
     Manual for valkey-server, the Valkey server program
 ---

--- a/topics/sets.md
+++ b/topics/sets.md
@@ -1,7 +1,6 @@
 ﻿---
 title: "Sets"
 linkTitle: "Sets"
-weight: 30
 description: >
     Introduction to Sets
 ---

--- a/topics/signals.md
+++ b/topics/signals.md
@@ -1,10 +1,7 @@
 ---
 title: "Valkey signal handling"
 linkTitle: "Signal handling"
-weight: 8
 description: How Valkey handles common Unix signals
-aliases:
-    - /topics/signals
 ---
 
 This document provides information about how Valkey reacts to different POSIX signals such as `SIGTERM` and `SIGSEGV`.

--- a/topics/sorted-sets.md
+++ b/topics/sorted-sets.md
@@ -1,7 +1,6 @@
 ---
 title: "Sorted Sets"
 linkTitle: "Sorted sets"
-weight: 50
 description: >
     Introduction to Sorted Sets
 ---

--- a/topics/streams-intro.md
+++ b/topics/streams-intro.md
@@ -1,13 +1,8 @@
 ---
 title: "Streams"
 linkTitle: "Streams"
-weight: 60
 description: >
     Introduction to Streams
-aliases:
-    - /topics/streams-intro
-    - /docs/manual/data-types/streams    
-    - /docs/data-types/streams-tutorial/ 
 ---
 
 A Stream is a data structure that acts like an append-only log but also implements several operations to overcome some of the limits of a typical append-only log. These include random access in O(1) time and complex consumption strategies, such as consumer groups.

--- a/topics/strings.md
+++ b/topics/strings.md
@@ -1,7 +1,6 @@
 ﻿---
 title: "Strings"
 linkTitle: "Strings"
-weight: 10
 description: >
     Introduction to Strings
 ---

--- a/topics/transactions.md
+++ b/topics/transactions.md
@@ -1,11 +1,7 @@
 ---
 title: Transactions
 linkTitle: Transactions
-weight: 30
 description: How transactions work in Valkey
-aliases:
-  - /topics/transactions
-  - /docs/manual/transactions/
 ---
 
 Valkey Transactions allow the execution of a group of commands

--- a/topics/twitter-clone.md
+++ b/topics/twitter-clone.md
@@ -2,10 +2,6 @@
 title: "Valkey patterns example"
 linkTitle: "Patterns example"
 description: Learn several Valkey patterns by building a Twitter clone
-weight: 20
-aliases: [
-    /docs/reference/patterns/twitter-clone
-]
 ---
 
 This article describes the design and implementation of a [very simple Twitter clone](https://github.com/antirez/retwis) written using PHP with Valkey as the only database. The programming community has traditionally considered key-value stores as a special purpose database that couldn't be used as a drop-in replacement for a relational database for the development of web applications. This article will try to show that Valkey data structures on top of a key-value layer are an effective data model to implement many kinds of applications.

--- a/topics/valkey.conf.md
+++ b/topics/valkey.conf.md
@@ -1,12 +1,8 @@
 ---
 title: "Valkey configuration"
 linkTitle: "Configuration"
-weight: 2
 description: >
     Overview of valkey.conf, the Valkey configuration file
-aliases: [
-    /docs/manual/config
-    ]
 
 ---
 


### PR DESCRIPTION
I've cleared with @stockholmux that these frontmatter metadata keys are not useful to keep. They are leftovers from Redis website toolchain.

Deleted using

    cd topics
    perl -i -ne '$on = 1 if !$on && /^aliases: *\[/; print if !$on; $on = 0 if $on && /^ *\]/' *.md
    perl -i -ne '$on = 0 if $on && !/^ /; $on = 1 if !$on && /^aliases:/; print if !$on' *.md
    perl -i -ne 'print unless /^weight: *\d+/' *.md