### PR TITLE
Mention that eviction policies use approximated randomized algorithms

### DIFF
--- a/topics/lru-cache.md
+++ b/topics/lru-cache.md
@@ -57,7 +57,7 @@ The following policies are available:
 
 The policies **volatile-lru**, **volatile-lfu**, **volatile-random**, and **volatile-ttl** behave like **noeviction** if there are no keys to evict matching the prerequisites.
 
-Both **LRU**, **LFU** and **volatile-ttl** are implemented using approximated randomized algorithms.
+**LRU**, **LFU** and **volatile-ttl** are implemented using approximated randomized algorithms.
 
 Picking the right eviction policy is important depending on the access pattern
 of your application, however you can reconfigure the policy at runtime while

--- a/topics/lru-cache.md
+++ b/topics/lru-cache.md
@@ -57,6 +57,8 @@ The following policies are available:
 
 The policies **volatile-lru**, **volatile-lfu**, **volatile-random**, and **volatile-ttl** behave like **noeviction** if there are no keys to evict matching the prerequisites.
 
+Both **LRU**, **LFU** and **volatile-ttl** are implemented using approximated randomized algorithms.
+
 Picking the right eviction policy is important depending on the access pattern
 of your application, however you can reconfigure the policy at runtime while
 the application is running, and monitor the number of cache misses and hits


### PR DESCRIPTION
We clearly indicate in the documentation that LRU / LFU are using
approximated randomized algorithms. Some people think volatile-ttl
is accurate, i suppose adding this sentence will be helpful, the text
is from valkey.conf