### PR TITLE
fixes malformed YAML frontmatter in `installation.md`

### DIFF
--- a/topics/installation.md
+++ b/topics/installation.md
@@ -3,8 +3,6 @@ title: "Install Valkey"
 linkTitle: "Install Valkey"
 description: >
     Install Valkey on Linux, macOS, and Windows
-- /docs/getting-started/installation
-- /docs/getting-started/tutorial
 ---
 
 This is a an installation guide. You'll learn how to install, run, and experiment with the Valkey server process.


### PR DESCRIPTION
The changes in #118 pushed in malformed YAML frontmatter to [`/topics/installation.md`](https://github.com/valkey-io/valkey-doc/blob/main/topics/installation.md). 

This is causing an error message here on GitHub and the website build to choke.

This PR removes the orphaned array items when `aliases:` was removed by the script.


