### PR TITLE
Update cluster-spec with Valkey 8.0 cluster improvements

### DIFF
--- a/commands/cluster-setslot.md
+++ b/commands/cluster-setslot.md
@@ -79,3 +79,12 @@ Notes:
   If the source node is informed before the destination node and the destination node crashes before it is set as new slot owner, the slot is left with no owner, even after a successful failover.
 * Step 6, sending `SETSLOT` to the nodes not involved in the resharding, is not technically necessary since the configuration will eventually propagate itself.
   However, it is a good idea to do so in order to stop nodes from pointing to the wrong node for the hash slot moved as soon as possible, resulting in less redirections to find the right node.
+* Starting from Valkey 8.0, `CLUSTER SETSLOT` is synchronously replicated to all healthy replicas
+  running Valkey version 8.0+. By default, this synchronous replication must complete within 2 seconds.
+  If the replication fails, the primary does not execute the command, and the client receives a
+  `NOREPLICAS Not enough good replicas to write` error. Operators can retry the command or customize the
+  timeout using the `TIMEOUT` parameter to further increase the reliability of live reconfiguration:
+
+    CLUSTER SETSLOT slot [MIGRATING|IMPORTING|NODE] node-id [TIMEOUT timeout]
+
+  Here, `timeout` is measured in seconds, with 0 meaning to wait indefinitely.

--- a/commands/cluster-setslot.md
+++ b/commands/cluster-setslot.md
@@ -85,6 +85,8 @@ Notes:
   `NOREPLICAS Not enough good replicas to write` error. Operators can retry the command or customize the
   timeout using the `TIMEOUT` parameter to further increase the reliability of live reconfiguration:
 
-    CLUSTER SETSLOT slot [MIGRATING|IMPORTING|NODE] node-id [TIMEOUT timeout]
+  ```
+  CLUSTER SETSLOT slot [MIGRATING|IMPORTING|NODE] node-id [TIMEOUT timeout]
+  ```
 
   Here, `timeout` is measured in seconds, with 0 meaning to wait indefinitely.

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -531,7 +531,7 @@ replicated to all replicas. This prevents loss of state if the primary fails aft
 
 Consider a scenario where the target primary node `B` is finalizing a slot migration.
 Before the `SETSLOT` command is replicated to its replica node `B’`, `B` might send a cluster `PONG`
-message to the source primary node `A`, promoting `A` to relinguish its ownership of the slot in question.
+message to the source primary node `A`, promoting `A` to relinquish its ownership of the slot in question.
 If `B` crashes right after this point, the replica node `B’`, which could be elected as the new primary,
 would not be aware of the slot ownership transfer without the synchronous replication of `SETSLOT`.
 This would leave the slot without an owner, leading to potential data loss and cluster topology inconsistency.

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -589,7 +589,7 @@ the interrupted slot migration by running the command `valkey-cli --cluster fix 
 
 Additionally, since Valkey 8.0, replicas are now able to return `ASK` redirects during slot migrations.
 This capability was previously unavailable, as replicas were not aware of ongoing slot migrations in earlier versions.
-It's worth noting that this change has already been documented in the READONLY command section.
+See the [READONLY](../commands/readonly.md) command.
 
 ### Client connections and redirection handling
 

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -585,7 +585,7 @@ Starting from Valkey 8.0, when the primary in either the source or target shard 
 the primary in the other shard will automatically attempt to update its migrating/importing state to correctly pair
 with the newly elected primary. If this update is successful, the ASK redirection will continue functioning without
 requiring administrator intervention. In the event that slot migration fails, administrators can manually resume
-the process by running the command `valkey-cli --cluster fix <ip:port>`.
+the interrupted slot migration by running the command `valkey-cli --cluster fix <ip:port>`.
 
 Additionally, since Valkey 8.0, replicas are now able to return `ASK` redirects during slot migrations.
 This capability was previously unavailable, as replicas were not aware of ongoing slot migrations in earlier versions.

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -517,7 +517,7 @@ propagation of the new configuration across the cluster.
 
 Starting from Valkey 8.0, the `CLUSTER SETSLOT` command is replicated if the replicas are running Valkey version 8.0+.
 The primary node waits up to 2 seconds, by default, for all healthy replicas to acknowledge the replication.
-If not all health replicas acknowledge the replication within this timeframe, the primary aborts the command,
+If not all health replicas acknowledge the replication within this time frame, the primary aborts the command,
 and the client receives a `NOREPLICAS Not enough good replicas to write` error.
 Operators can retry the command or customize the timeout using the `TIMEOUT` parameter to further increase the
 reliability of live resharding:
@@ -527,7 +527,7 @@ reliability of live resharding:
 The `timeout` is specified in seconds, where a value of 0 indicates an indefinite wait time.
 
 Replicating the slot information and ensuring acknowledgement from health replicas significantly reduces
-the likelihookd of losing replication states if the primary fails after executing the command.
+the likelihood of losing replication states if the primary fails after executing the command.
 For example, consider a scenario where the target primary node `B` is finalizing a slot migration.
 Before the `SETSLOT` command is replicated to its replica node `B’`, `B` might send a cluster `PONG`
 message to the source primary node `A`, promoting `A` to relinquish its ownership of the slot in question.

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -525,10 +525,7 @@ timeout using the `TIMEOUT` parameter to further increase the reliability of liv
 
 Here, `timeout` is measured in seconds, with 0 meaning to wait indefinitely.
 
-Synchronous replication is critical for maintaining cluster consistency during live reconfiguration.
-Before applying changes like slot ownership and migrating states to the primary, these must be fully
-replicated to all replicas. This prevents loss of state if the primary fails after executing the command.
-
+Replicating the slot information prevents loss of state if the primary fails after executing the command.
 Consider a scenario where the target primary node `B` is finalizing a slot migration.
 Before the `SETSLOT` command is replicated to its replica node `B’`, `B` might send a cluster `PONG`
 message to the source primary node `A`, promoting `A` to relinquish its ownership of the slot in question.


### PR DESCRIPTION
Update cluster specification document to clarify shard migration process changes in Valkey 8.0 and include detailed descriptions of shard replication and failover mechanism improvements. 

Fix #76 
