### PR TITLE
fixes annoying http->https forward

### DIFF
--- a/topics/index.md
+++ b/topics/index.md
@@ -4,7 +4,7 @@ linkTitle: "Documentation"
 ---
 
 The Valkey documentation is managed in markdown files in the
-[valkey-doc repository](http://github.com/valkey-io/valkey-doc).
+[valkey-doc repository](https://github.com/valkey-io/valkey-doc).
 It's released under the
 [Creative Commons Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/).
 


### PR DESCRIPTION
I was doing some link checking and found incorrect URL. Github defaults to https, so this fixes a tiny issue (which is a part of a larger side quest).