### PR TITLE
Document duplicate options in ZUNIONSTORE

### DIFF
--- a/commands/zunionstore.md
+++ b/commands/zunionstore.md
@@ -21,6 +21,11 @@ the minimum or maximum score of an element across the inputs where it exists.
 
 If `destination` already exists, it is overwritten.
 
+## Notes
+
+If an option `WEIGHTS` or `AGGREGATE` is given multiple times, it is undefined
+which option takes precedence.
+
 ## Examples
 
 ```


### PR DESCRIPTION
The docs for ZINTER, ZDIFF, etc. all refer to ZUNIONSTORE for the options.

Related to valkey-io/valkey#571.