### PR TITLE
No valkey in titles

### DIFF
--- a/topics/ARM.md
+++ b/topics/ARM.md
@@ -1,6 +1,5 @@
 ---
 title: "ARM support"
-linkTitle: "ARM support"
 description: >
     Exploring Valkey on the ARM CPU Architecture
 ---

--- a/topics/RDMA.md
+++ b/topics/RDMA.md
@@ -1,6 +1,5 @@
 ---
 title: "RDMA experimental support"
-linkTitle: "RDMA support"
 description: Valkey Over RDMA experimental support
 ---
 

--- a/topics/acl.md
+++ b/topics/acl.md
@@ -1,6 +1,5 @@
 ---
 title: "ACL"
-linkTitle: "ACL"
 description: Valkey Access Control List
 ---
 

--- a/topics/admin.md
+++ b/topics/admin.md
@@ -1,6 +1,5 @@
 ---
 title: Administration
-linkTitle: Administration
 description: Advice for configuring and managing Valkey in production
 ---
 

--- a/topics/admin.md
+++ b/topics/admin.md
@@ -1,5 +1,5 @@
 ---
-title: Valkey administration
+title: Administration
 linkTitle: Administration
 description: Advice for configuring and managing Valkey in production
 ---

--- a/topics/benchmark.md
+++ b/topics/benchmark.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey benchmark"
+title: "Benchmarking tool"
 linkTitle: "Benchmarking"
 description: >
     Using the valkey-benchmark utility on a Valkey server

--- a/topics/benchmark.md
+++ b/topics/benchmark.md
@@ -1,6 +1,5 @@
 ---
 title: "Benchmarking tool"
-linkTitle: "Benchmarking"
 description: >
     Using the valkey-benchmark utility on a Valkey server
 ---

--- a/topics/bitfields.md
+++ b/topics/bitfields.md
@@ -1,6 +1,5 @@
 ---
 title: "Bitfields"
-linkTitle: "Bitfields"
 description: >
     Introduction to Bitfields
 ---

--- a/topics/bitmaps.md
+++ b/topics/bitmaps.md
@@ -1,6 +1,5 @@
 ---
 title: "Bitmaps"
-linkTitle: "Bitmaps"
 description: >
     Introduction to Bitmaps
 ---

--- a/topics/cli.md
+++ b/topics/cli.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey CLI"
+title: "CLI"
 linkTitle: "CLI"
 description: >
     Valkey command line interface

--- a/topics/cli.md
+++ b/topics/cli.md
@@ -1,6 +1,5 @@
 ---
 title: "CLI"
-linkTitle: "CLI"
 description: >
     Valkey command line interface
 ---

--- a/topics/client-side-caching.md
+++ b/topics/client-side-caching.md
@@ -1,5 +1,5 @@
 ---
-title: "Client-side caching in Valkey"
+title: "Client-side caching"
 description: >
     Server-assisted, client-side caching in Valkey
 ---

--- a/topics/client-side-caching.md
+++ b/topics/client-side-caching.md
@@ -1,6 +1,5 @@
 ---
 title: "Client-side caching in Valkey"
-linkTitle: "Client-side caching"
 description: >
     Server-assisted, client-side caching in Valkey
 ---

--- a/topics/clients.md
+++ b/topics/clients.md
@@ -1,6 +1,5 @@
 ---
 title: "Client handling"
-linkTitle: "Client handling"
 description: >
     How the Valkey server manages client connections
 ---

--- a/topics/clients.md
+++ b/topics/clients.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey client handling"
+title: "Client handling"
 linkTitle: "Client handling"
 description: >
     How the Valkey server manages client connections

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -1,5 +1,5 @@
 ---
-title: Valkey cluster specification
+title: Cluster specification
 linkTitle: Cluster spec
 description: >
     Detailed specification for Valkey cluster

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -1,6 +1,5 @@
 ---
 title: Cluster specification
-linkTitle: Cluster spec
 description: >
     Detailed specification for Valkey cluster
 ---

--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -1,6 +1,5 @@
 ---
 title: Scale with Valkey Cluster
-linkTitle: Scale with Valkey Cluster
 description: Horizontal scaling with Valkey Cluster
 ---
 

--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: Scale with Valkey Cluster
+title: Cluster tutorial
 description: Horizontal scaling with Valkey Cluster
 ---
 

--- a/topics/command-arguments.md
+++ b/topics/command-arguments.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey command arguments"
+title: "Command arguments"
 linkTitle: "Command arguments"
 description: How Valkey commands expose their documentation programmatically
 ---

--- a/topics/command-arguments.md
+++ b/topics/command-arguments.md
@@ -1,6 +1,5 @@
 ---
 title: "Command arguments"
-linkTitle: "Command arguments"
 description: How Valkey commands expose their documentation programmatically
 ---
 

--- a/topics/command-tips.md
+++ b/topics/command-tips.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey command tips"
+title: "Command tips"
 linkTitle: "Command tips"
 description: Get additional information about a command
 ---

--- a/topics/command-tips.md
+++ b/topics/command-tips.md
@@ -1,6 +1,5 @@
 ---
 title: "Command tips"
-linkTitle: "Command tips"
 description: Get additional information about a command
 ---
 

--- a/topics/data-types.md
+++ b/topics/data-types.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey data types"
+title: "Data types"
 linkTitle: "Data types"
 description: Overview of data types supported by Valkey
 ---

--- a/topics/data-types.md
+++ b/topics/data-types.md
@@ -1,6 +1,5 @@
 ---
 title: "Data types"
-linkTitle: "Data types"
 description: Overview of data types supported by Valkey
 ---
 

--- a/topics/debugging.md
+++ b/topics/debugging.md
@@ -1,6 +1,5 @@
 ---
 title: "Debugging"
-linkTitle: "Debugging"
 description: >
     A guide to debugging Valkey server processes
 ---

--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -1,5 +1,5 @@
 ---
-title: "Distributed Locks with Valkey"
+title: "Distributed Locks"
 description: >
     A distributed lock pattern with Valkey
 ---

--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -1,6 +1,5 @@
 ---
 title: "Distributed Locks with Valkey"
-linkTitle: "Distributed locks"
 description: >
     A distributed lock pattern with Valkey
 ---

--- a/topics/encryption.md
+++ b/topics/encryption.md
@@ -1,6 +1,5 @@
 ---
 title: "TLS"
-linkTitle: "TLS"
 description: Valkey TLS support
 ---
 

--- a/topics/eval-intro.md
+++ b/topics/eval-intro.md
@@ -1,6 +1,5 @@
 ---
 title: "Scripting with Lua"
-linkTitle: "Lua scripting"
 description: >
    Executing Lua in Valkey
 ---

--- a/topics/faq.md
+++ b/topics/faq.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey FAQ"
+title: "FAQ"
 linkTitle: "FAQ"
 description: >
     Commonly asked questions when getting started with Valkey

--- a/topics/faq.md
+++ b/topics/faq.md
@@ -1,6 +1,5 @@
 ---
 title: "FAQ"
-linkTitle: "FAQ"
 description: >
     Commonly asked questions when getting started with Valkey
 ---

--- a/topics/functions-intro.md
+++ b/topics/functions-intro.md
@@ -1,6 +1,5 @@
 ---
 title: "Functions"
-linkTitle: "Functions"
 description: >
    Scripting with Redis OSS 7 and beyond
 ---

--- a/topics/functions-intro.md
+++ b/topics/functions-intro.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey functions"
+title: "Functions"
 linkTitle: "Functions"
 description: >
    Scripting with Redis OSS 7 and beyond

--- a/topics/geospatial.md
+++ b/topics/geospatial.md
@@ -1,6 +1,5 @@
 ﻿---
 title: "Geospatial"
-linkTitle: "Geospatial"
 description: >
     Introduction to the Valkey Geospatial data type
 ---

--- a/topics/geospatial.md
+++ b/topics/geospatial.md
@@ -1,5 +1,5 @@
 ﻿---
-title: "Valkey geospatial"
+title: "Geospatial"
 linkTitle: "Geospatial"
 description: >
     Introduction to the Valkey Geospatial data type

--- a/topics/get-started.md
+++ b/topics/get-started.md
@@ -1,6 +1,5 @@
 ﻿---
 title: "Quick starts"
-linkTitle: "Quick starts"
 hideListLinks: true
 description: >
     Valkey quick start guides

--- a/topics/hashes.md
+++ b/topics/hashes.md
@@ -1,6 +1,5 @@
 ﻿---
 title: "Hashes"
-linkTitle: "Hashes"
 description: >
     Introduction to Hashes
 ---

--- a/topics/history.md
+++ b/topics/history.md
@@ -1,6 +1,5 @@
 ---
 title: "History"
-linkTitle: "History"
 description: How the Valkey project started
 ---
 

--- a/topics/history.md
+++ b/topics/history.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey history"
+title: "History"
 linkTitle: "History"
 description: How the Valkey project started
 ---

--- a/topics/hyperloglogs.md
+++ b/topics/hyperloglogs.md
@@ -1,6 +1,5 @@
 ---
 title: "HyperLogLog"
-linkTitle: "HyperLogLog"
 description: >
     HyperLogLog is a probabilistic data structure that estimates the cardinality of a set.
 ---

--- a/topics/index.md
+++ b/topics/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Valkey Documentation"
-linkTitle: "Documentation"
 ---
 
 The Valkey documentation is managed in markdown files in the

--- a/topics/indexing.md
+++ b/topics/indexing.md
@@ -1,6 +1,5 @@
 ---
 title: Secondary indexing
-linkTitle: Secondary indexing
 description: >
     Building secondary indexes in Valkey
 ---

--- a/topics/installation.md
+++ b/topics/installation.md
@@ -1,5 +1,5 @@
 ---
-title: "Install Valkey"
+title: "Installation"
 description: >
     Install Valkey on Linux, macOS, and Windows
 ---

--- a/topics/installation.md
+++ b/topics/installation.md
@@ -1,6 +1,5 @@
 ---
 title: "Install Valkey"
-linkTitle: "Install Valkey"
 description: >
     Install Valkey on Linux, macOS, and Windows
 ---

--- a/topics/introduction.md
+++ b/topics/introduction.md
@@ -1,6 +1,5 @@
 ---
 title: Introduction to Valkey
-linkTitle: "About"
 description: Learn about the Valkey open source project
 ---
 

--- a/topics/introduction.md
+++ b/topics/introduction.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Valkey
+title: Introduction
 description: Learn about the Valkey open source project
 ---
 

--- a/topics/keyspace.md
+++ b/topics/keyspace.md
@@ -1,6 +1,5 @@
 ---
 title: "Keyspace"
-linkTitle: "Keyspace"
 description: >
     Managing keys in Valkey: Key expiration, scanning, altering and querying the key space
 ---

--- a/topics/latency-monitor.md
+++ b/topics/latency-monitor.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey latency monitoring"
+title: "Latency monitoring"
 linkTitle: "Latency monitoring"
 description: Discovering slow server events in Valkey
 ---

--- a/topics/latency-monitor.md
+++ b/topics/latency-monitor.md
@@ -1,6 +1,5 @@
 ---
 title: "Latency monitoring"
-linkTitle: "Latency monitoring"
 description: Discovering slow server events in Valkey
 ---
 

--- a/topics/latency.md
+++ b/topics/latency.md
@@ -1,6 +1,5 @@
 ---
 title: "Diagnosing latency issues"
-linkTitle: "Latency diagnosis"
 description: Finding the causes of slow responses
 ---
 

--- a/topics/ldb.md
+++ b/topics/ldb.md
@@ -1,6 +1,5 @@
 ---
 title: Debugging Lua scripts in Valkey
-linkTitle: Debugging Lua
 description: How to use the built-in Lua debugger
 ---
 

--- a/topics/ldb.md
+++ b/topics/ldb.md
@@ -1,5 +1,5 @@
 ---
-title: Debugging Lua scripts in Valkey
+title: Debugging Lua scripts
 description: How to use the built-in Lua debugger
 ---
 

--- a/topics/license.md
+++ b/topics/license.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey license"
+title: "License"
 linkTitle: "License"
 description: >
     License and trademark information

--- a/topics/license.md
+++ b/topics/license.md
@@ -1,6 +1,5 @@
 ---
 title: "License"
-linkTitle: "License"
 description: >
     License and trademark information
 ---

--- a/topics/lists.md
+++ b/topics/lists.md
@@ -1,6 +1,5 @@
 ﻿---
 title: "Lists"
-linkTitle: "Lists"
 description: >
     Introduction to Lists
 ---

--- a/topics/lru-cache.md
+++ b/topics/lru-cache.md
@@ -1,6 +1,5 @@
 ---
 title: Key eviction
-linkTitle: Eviction
 description: Overview of Valkey key eviction policies (LRU, LFU, etc.)
 ---
 

--- a/topics/lua-api.md
+++ b/topics/lua-api.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey Lua API reference"
+title: "Lua API reference"
 linkTitle: "Lua API"
 description: >
    Executing Lua in Valkey

--- a/topics/lua-api.md
+++ b/topics/lua-api.md
@@ -1,6 +1,5 @@
 ---
 title: "Lua API reference"
-linkTitle: "Lua API"
 description: >
    Executing Lua in Valkey
 ---

--- a/topics/mass-insertion.md
+++ b/topics/mass-insertion.md
@@ -1,6 +1,5 @@
 ---
 title: "Bulk loading"
-linkTitle: "Bulk loading"
 description: >
     Writing data in bulk using the RESP protocol
 ---

--- a/topics/memory-optimization.md
+++ b/topics/memory-optimization.md
@@ -1,6 +1,5 @@
 ---
 title: Memory optimization
-linkTitle: Memory optimization
 description: Strategies for optimizing memory usage in Valkey
 ---
 

--- a/topics/migration.md
+++ b/topics/migration.md
@@ -1,6 +1,5 @@
 ---
 title: Migration from Redis to Valkey
-linkTitle: Migration
 description: How to migrate from Redis to Valkey
 ---
 

--- a/topics/modules-api-ref.md
+++ b/topics/modules-api-ref.md
@@ -1,6 +1,5 @@
 ---
 title: "Modules API reference"
-linkTitle: "API reference"
 description: >
     Reference for the Valkey Modules API
 ---

--- a/topics/modules-blocking-ops.md
+++ b/topics/modules-blocking-ops.md
@@ -1,6 +1,5 @@
 ---
 title: "Modules and blocking commands"
-linkTitle: "Blocking commands"
 description: >
     How to implement blocking commands in a Valkey module
 ---

--- a/topics/modules-blocking-ops.md
+++ b/topics/modules-blocking-ops.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey modules and blocking commands"
+title: "Modules and blocking commands"
 linkTitle: "Blocking commands"
 description: >
     How to implement blocking commands in a Valkey module

--- a/topics/modules-intro.md
+++ b/topics/modules-intro.md
@@ -1,6 +1,5 @@
 ---
 title: "Modules API"
-linkTitle: "Modules API"
 description: >
     Introduction to writing Valkey modules
 ---

--- a/topics/modules-intro.md
+++ b/topics/modules-intro.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey modules API"
+title: "Modules API"
 linkTitle: "Modules API"
 description: >
     Introduction to writing Valkey modules

--- a/topics/modules-native-types.md
+++ b/topics/modules-native-types.md
@@ -1,6 +1,5 @@
 ---
 title: "Modules API for native types"
-linkTitle: "Native types API"
 description: >
     How to use native types in a Valkey module
 ---

--- a/topics/notifications.md
+++ b/topics/notifications.md
@@ -1,6 +1,5 @@
 ---
 title: "Keyspace notifications"
-linkTitle: "Keyspace notifications"
 description: >
     Monitor changes to Valkey keys and values in real time
 ---

--- a/topics/notifications.md
+++ b/topics/notifications.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey keyspace notifications"
+title: "Keyspace notifications"
 linkTitle: "Keyspace notifications"
 description: >
     Monitor changes to Valkey keys and values in real time

--- a/topics/performance-on-cpu.md
+++ b/topics/performance-on-cpu.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey CPU profiling"
+title: "CPU profiling"
 linkTitle: "CPU profiling"
 description: >
     Performance engineering guide for on-CPU profiling and tracing

--- a/topics/performance-on-cpu.md
+++ b/topics/performance-on-cpu.md
@@ -1,6 +1,5 @@
 ---
 title: "CPU profiling"
-linkTitle: "CPU profiling"
 description: >
     Performance engineering guide for on-CPU profiling and tracing
 ---

--- a/topics/persistence.md
+++ b/topics/persistence.md
@@ -1,5 +1,5 @@
 ---
-title: Valkey persistence
+title: Persistence
 linkTitle: Persistence
 description: How Valkey writes data to disk
 ---

--- a/topics/persistence.md
+++ b/topics/persistence.md
@@ -1,6 +1,5 @@
 ---
 title: Persistence
-linkTitle: Persistence
 description: How Valkey writes data to disk
 ---
 

--- a/topics/pipelining.md
+++ b/topics/pipelining.md
@@ -1,6 +1,5 @@
 ---
 title: "Pipelining"
-linkTitle: "Pipelining"
 description: How to optimize round-trip times by batching Valkey commands
 ---
 

--- a/topics/pipelining.md
+++ b/topics/pipelining.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey pipelining"
+title: "Pipelining"
 linkTitle: "Pipelining"
 description: How to optimize round-trip times by batching Valkey commands
 ---

--- a/topics/problems.md
+++ b/topics/problems.md
@@ -1,6 +1,5 @@
 ---
 title: "Troubleshooting Valkey"
-linkTitle: "Troubleshooting"
 description: Problems with Valkey? Start here.
 ---
 

--- a/topics/programmability.md
+++ b/topics/programmability.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey programmability"
+title: "Programmability"
 linkTitle: "Programmability"
 description: >
    Extending Valkey with Lua and Valkey Functions

--- a/topics/programmability.md
+++ b/topics/programmability.md
@@ -1,6 +1,5 @@
 ---
 title: "Programmability"
-linkTitle: "Programmability"
 description: >
    Extending Valkey with Lua and Valkey Functions
 ---

--- a/topics/protocol.md
+++ b/topics/protocol.md
@@ -1,6 +1,5 @@
 ---
 title: "Serialization protocol specification"
-linkTitle: "Protocol spec"
 description: Valkey's serialization protocol (RESP) is the wire protocol that clients implement
 ----
 

--- a/topics/pubsub.md
+++ b/topics/pubsub.md
@@ -1,6 +1,5 @@
 ---
 title: Pub/Sub
-linkTitle: "Pub/sub"
 description: How to use pub/sub channels in Valkey
 ---
 

--- a/topics/pubsub.md
+++ b/topics/pubsub.md
@@ -1,5 +1,5 @@
 ---
-title: Valkey Pub/Sub
+title: Pub/Sub
 linkTitle: "Pub/sub"
 description: How to use pub/sub channels in Valkey
 ---

--- a/topics/quickstart.md
+++ b/topics/quickstart.md
@@ -1,6 +1,5 @@
 ---
 title: "Quick start guide"
-linkTitle: "Data structure store"
 description: Understand how to use basic Valkey data types
 ---
 

--- a/topics/quickstart.md
+++ b/topics/quickstart.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey as an in-memory data structure store quick start guide"
+title: "Quick start guide"
 linkTitle: "Data structure store"
 description: Understand how to use basic Valkey data types
 ---

--- a/topics/releases.md
+++ b/topics/releases.md
@@ -1,6 +1,5 @@
 ---
 title: "Releases and versioning"
-linkTitle: "Valkey releases"
 description: How new versions of Valkey are released and supported
 ---
 

--- a/topics/releases.md
+++ b/topics/releases.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey releases and versioning"
+title: "Releases and versioning"
 linkTitle: "Valkey releases"
 description: How new versions of Valkey are released and supported
 ---

--- a/topics/replication.md
+++ b/topics/replication.md
@@ -1,5 +1,5 @@
 ---
-title: Valkey replication
+title: Replication
 linkTitle: Replication
 description: How Valkey supports high availability and failover with replication
 ---

--- a/topics/replication.md
+++ b/topics/replication.md
@@ -1,6 +1,5 @@
 ---
 title: Replication
-linkTitle: Replication
 description: How Valkey supports high availability and failover with replication
 ---
 

--- a/topics/security.md
+++ b/topics/security.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey security"
+title: "Security"
 linkTitle: "Security"
 description: Security model and features in Valkey
 ---

--- a/topics/security.md
+++ b/topics/security.md
@@ -1,6 +1,5 @@
 ---
 title: "Security"
-linkTitle: "Security"
 description: Security model and features in Valkey
 ---
 

--- a/topics/sentinel-clients.md
+++ b/topics/sentinel-clients.md
@@ -1,6 +1,5 @@
 ---
 title: "Sentinel client spec"
-linkTitle: "Sentinel clients"
 description: How to build clients for Valkey Sentinel
 ---
 

--- a/topics/sentinel.md
+++ b/topics/sentinel.md
@@ -1,6 +1,5 @@
 ---
 title: "High availability with Valkey Sentinel"
-linkTitle: "High availability with Sentinel"
 description: High availability for non-clustered Valkey
 ---
 

--- a/topics/server.md
+++ b/topics/server.md
@@ -1,6 +1,5 @@
 ---
 title: "The Valkey server"
-linkTitle: "Valkey Server"
 description: >
     Manual for valkey-server, the Valkey server program
 ---

--- a/topics/server.md
+++ b/topics/server.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey Server"
+title: "The Valkey server"
 linkTitle: "Valkey Server"
 description: >
     Manual for valkey-server, the Valkey server program

--- a/topics/sets.md
+++ b/topics/sets.md
@@ -1,6 +1,5 @@
 ﻿---
 title: "Sets"
-linkTitle: "Sets"
 description: >
     Introduction to Sets
 ---

--- a/topics/signals.md
+++ b/topics/signals.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey signal handling"
+title: "Signal handling"
 linkTitle: "Signal handling"
 description: How Valkey handles common Unix signals
 ---

--- a/topics/signals.md
+++ b/topics/signals.md
@@ -1,6 +1,5 @@
 ---
 title: "Signal handling"
-linkTitle: "Signal handling"
 description: How Valkey handles common Unix signals
 ---
 

--- a/topics/sorted-sets.md
+++ b/topics/sorted-sets.md
@@ -1,6 +1,5 @@
 ---
 title: "Sorted Sets"
-linkTitle: "Sorted sets"
 description: >
     Introduction to Sorted Sets
 ---

--- a/topics/streams-intro.md
+++ b/topics/streams-intro.md
@@ -1,6 +1,5 @@
 ---
 title: "Streams"
-linkTitle: "Streams"
 description: >
     Introduction to Streams
 ---

--- a/topics/strings.md
+++ b/topics/strings.md
@@ -1,6 +1,5 @@
 ﻿---
 title: "Strings"
-linkTitle: "Strings"
 description: >
     Introduction to Strings
 ---

--- a/topics/transactions.md
+++ b/topics/transactions.md
@@ -1,6 +1,5 @@
 ---
 title: Transactions
-linkTitle: Transactions
 description: How transactions work in Valkey
 ---
 

--- a/topics/twitter-clone.md
+++ b/topics/twitter-clone.md
@@ -1,6 +1,5 @@
 ---
 title: "Patterns example"
-linkTitle: "Patterns example"
 description: Learn several Valkey patterns by building a Twitter clone
 ---
 

--- a/topics/twitter-clone.md
+++ b/topics/twitter-clone.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey patterns example"
+title: "Patterns example"
 linkTitle: "Patterns example"
 description: Learn several Valkey patterns by building a Twitter clone
 ---

--- a/topics/valkey.conf.md
+++ b/topics/valkey.conf.md
@@ -1,5 +1,5 @@
 ---
-title: "Valkey configuration"
+title: "Configuration"
 linkTitle: "Configuration"
 description: >
     Overview of valkey.conf, the Valkey configuration file

--- a/topics/valkey.conf.md
+++ b/topics/valkey.conf.md
@@ -1,6 +1,5 @@
 ---
 title: "Configuration"
-linkTitle: "Configuration"
 description: >
     Overview of valkey.conf, the Valkey configuration file
 


### PR DESCRIPTION
* Deletes "Valkey" in titles, because "Valkey" or "Valkey documentation" is added to each page title when the page is rendered.
* Deletes unused `linkTitle` frontmatter field.