### PR TITLE
Update PHP Redlock impl. doc

### DIFF
--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -28,8 +28,8 @@ already available that can be used for reference.
 * [Redlock-py](https://github.com/SPSCommerce/redlock-py) (Python implementation).
 * [Pottery](https://github.com/brainix/pottery#redlock) (Python implementation).
 * [Aioredlock](https://github.com/joanvila/aioredlock) (Asyncio Python implementation).
+* [RedisMutex](https://github.com/malkusch/lock#redismutex) (PHP implementation with both [Redis extension](https://github.com/phpredis/phpredis) and [Predis library](https://github.com/predis/predis) clients support).
 * [Redlock-php](https://github.com/ronnylt/redlock-php) (PHP implementation).
-* [PHPRedisMutex](https://github.com/malkusch/lock#phpredismutex) (further PHP implementation).
 * [cheprasov/php-redis-lock](https://github.com/cheprasov/php-redis-lock) (PHP library for locks).
 * [rtckit/react-redlock](https://github.com/rtckit/reactphp-redlock) (Async PHP implementation).
 * [Redsync](https://github.com/go-redsync/redsync) (Go implementation).


### PR DESCRIPTION
Fix the PHP Redlock impl. link and move it as the 1st mentioned PHP impl. as it is the most popular and the only library which supports both https://github.com/phpredis/phpredis and https://github.com/predis/predis clients.

PR for Redis docs: https://github.com/redis/docs/pull/964