### PR TITLE
Moves links to wayback machine, fixes one bad `s/redis/valkey/`

### DIFF
--- a/commands/pfcount.md
+++ b/commands/pfcount.md
@@ -58,4 +58,4 @@ The HyperLogLog, being a String, can be retrieved with `GET` and restored with `
 
 The representation is neutral from the point of view of the processor word size and endianness, so the same representation is used by 32 bit and 64 bit processor, big endian or little endian.
 
-More details about the HyperLogLog implementation can be found in [this blog post](http://antirez.com/news/75). The source code of the implementation in the `hyperloglog.c` file is also easy to read and understand, and includes a full specification for the exact encoding used for the sparse and dense representations.
+More details about the HyperLogLog implementation can be found in [this blog post](https://web.archive.org/web/20241019222035/http://antirez.com/news/75). The source code of the implementation in the `hyperloglog.c` file is also easy to read and understand, and includes a full specification for the exact encoding used for the sparse and dense representations.

--- a/topics/admin.md
+++ b/topics/admin.md
@@ -38,7 +38,7 @@ description: Advice for configuring and managing Valkey in production
 
 ### Security
 
-* By default, Valkey does not require any authentication and listens to all the network interfaces. This is a big security issue if you leave Valkey exposed on the internet or other places where attackers can reach it. See for example [this attack](http://antirez.com/news/96) to see how dangerous it can be. Please check our [security page](security.md) and the [quick start](quickstart.md) for information about how to secure Valkey.
+* By default, Valkey does not require any authentication and listens to all the network interfaces. This is a big security issue if you leave Valkey exposed on the internet or other places where attackers can reach it. See for example [this attack](https://web.archive.org/web/20241019230117/http://www.antirez.com/news/96) to see how dangerous it can be. Please check our [security page](security.md) and the [quick start](quickstart.md) for information about how to secure Valkey.
 
 ## Running Valkey on EC2
 

--- a/topics/admin.md
+++ b/topics/admin.md
@@ -38,7 +38,7 @@ description: Advice for configuring and managing Valkey in production
 
 ### Security
 
-* By default, Valkey does not require any authentication and listens to all the network interfaces. This is a big security issue if you leave Valkey exposed on the internet or other places where attackers can reach it. See for example [this attack](https://web.archive.org/web/20241019230117/http://www.antirez.com/news/96) to see how dangerous it can be. Please check our [security page](security.md) and the [quick start](quickstart.md) for information about how to secure Valkey.
+* By default, Valkey does not require any authentication and listens to all the network interfaces. This is a big security issue if you leave Valkey exposed on the internet or other places where attackers can reach it. See for example [this attack](https://web.archive.org/web/20241019230117/http://antirez.com/news/96) to see how dangerous it can be. Please check our [security page](security.md) and the [quick start](quickstart.md) for information about how to secure Valkey.
 
 ## Running Valkey on EC2
 

--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -228,4 +228,4 @@ Thanks in advance!
 ## Analysis of Redlock
 ---
 
-1. Martin Kleppmann [analyzed Redlock here](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html). A counterpoint to this analysis can be [found here](http://antirez.com/news/101).
+1. Martin Kleppmann [analyzed Redlock here](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html). A counterpoint to this analysis can be [found here](https://web.archive.org/web/20241209045142/https://antirez.com/news/101).

--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -228,4 +228,4 @@ Thanks in advance!
 ## Analysis of Redlock
 ---
 
-1. Martin Kleppmann [analyzed Redlock here](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html). A counterpoint to this analysis can be [found here](https://web.archive.org/web/20241209045142/https://antirez.com/news/101).
+1. Martin Kleppmann [analyzed Redlock here](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html). A counterpoint to this analysis can be [found here](https://web.archive.org/web/20241209045142/http://antirez.com/news/101).

--- a/topics/history.md
+++ b/topics/history.md
@@ -53,7 +53,7 @@ In March, 2010, Sanfilippo was hired by [VMware](https://vmware.com) to work on
 Redis and Redis Tools. In his blog post [VMware: the new Redis
 home][antirez-vmware], he writes:
 
-[antirez-vmware]: http://oldblog.antirez.com/post/vmware-the-new-redis-home.html
+[antirez-vmware]: https://web.archive.org/web/20241017012850/http://oldblog.antirez.com/post/vmware-the-new-redis-home.html
 
 > Not only Redis will remain a totally open source project, but Redis Tools will
 > be open sourced also (and this was an idea I got from VMware itself!).
@@ -93,7 +93,7 @@ The following year, 2014, Garantia Data [changed its name to Redis Labs][redisla
 [redislabs]: https://techcrunch.com/2014/01/29/database-provider-garantia-data-makes-another-name-change-this-time-to-redis-labs/
 
 In 2015, Salvatore left Pivotal for Redis Labs. He writes in his blog post
-[Thanks Pivotal, Hello Redis Labs](http://antirez.com/news/91):
+[Thanks Pivotal, Hello Redis Labs](https://web.archive.org/web/20241123010805/http://antirez.com/news/91):
 
 > Redis Labs was willing to continue what VMware and Pivotal started. I'll be
 > able to work as I do currently, spending all my time in the open source side
@@ -114,12 +114,12 @@ BSD][will-remain-bsd]. He repeated this promise in [a comment on Hacker
 News][hn-always-bsd], writing “let me assure you that Redis remains and always
 will remain, open source, BSD license”.
 
-[antirez-remain-bsd]: http://antirez.com/news/120
+[antirez-remain-bsd]: https://web.archive.org/web/20241111062719/http://antirez.com/news/120
 [will-remain-bsd]: https://redis.io/blog/redis-license-bsd-will-remain-bsd/
 [hn-always-bsd]: https://news.ycombinator.com/item?id=17819392
 
 In 2020, Salvatore Sanfilippo announced in his blog post [The end of the Redis
-adventure](http://antirez.com/news/133) that he was stepping back as the Redis
+adventure](https://web.archive.org/web/20241123005834/http://antirez.com/news/133) that he was stepping back as the Redis
 maintainer, handing over the maintenance to Yossi Gottlieb and Oran Agra at
 Redis Labs. The two created a “core team” to maintain the project and invited
 Itamar Haber from Redis Labs, Zhao Zhao from Alibaba and Madelyn Olson from

--- a/topics/hyperloglogs.md
+++ b/topics/hyperloglogs.md
@@ -89,4 +89,4 @@ The HyperLogLog can estimate the cardinality of sets with up to 18,446,744,073,7
 
 ## Learn more
 
-* [Valkey new data structure: the HyperLogLog](http://antirez.com/news/75) has a lot of details about the data structure and its implementation in Valkey.
+* This blog post on [the HyperLogLog data structure](https://web.archive.org/web/20241019222035/http://antirez.com/news/75) has a lot of details about the data structure and its implementation in Valkey.

--- a/topics/installation.md
+++ b/topics/installation.md
@@ -76,7 +76,7 @@ By default Valkey binds to **all the interfaces** and has no authentication at a
 3. Use the `requirepass` option to add an additional layer of security so that clients will be required to authenticate using the `AUTH` command.
 4. Use [spiped](https://www.tarsnap.com/spiped.html) or another SSL tunneling software to encrypt traffic between Valkey servers and Valkey clients if your environment requires encryption.
 
-Note that a Valkey instance exposed to the internet without any security [is very simple to exploit](http://antirez.com/news/96), so make sure you understand the above and apply **at least** a firewall layer. After the firewall is in place, try to connect with `valkey-cli` from an external host to confirm that the instance is not reachable.
+Note that a Valkey instance exposed to the internet without any security [is very simple to exploit](https://web.archive.org/web/20241119215618/http://antirez.com/news/96), so make sure you understand the above and apply **at least** a firewall layer. After the firewall is in place, try to connect with `valkey-cli` from an external host to confirm that the instance is not reachable.
 
 ## Use Valkey from your application
 

--- a/topics/lru-cache.md
+++ b/topics/lru-cache.md
@@ -133,7 +133,7 @@ the `CONFIG SET maxmemory-samples <count>` command, is very simple.
 
 ## The LFU mode
 
-The [Least Frequently Used eviction mode](http://antirez.com/news/109) is available as an alternative to LRU.
+The [Least Frequently Used eviction mode](https://web.archive.org/web/20241019222228/http://antirez.com/news/109) is available as an alternative to LRU.
 This mode may work better (provide a better
 hits/misses ratio) in certain cases. In LFU mode, Valkey will try to track
 the frequency of access of items, so the ones used rarely are evicted. This means


### PR DESCRIPTION
This PR moves links to antriez.com to the most recent wayback machine links. This ensures that the content that the docs point to is the intended content, it has proper https, and doesn't unexpectedly forward.

Additionally, there was one improper search/replace that was reworded when the link was changed. 

Fixes #188 

