### PR TITLE
Introduce import-mode and client import-source

### DIFF
--- a/commands/client-import-source.md
+++ b/commands/client-import-source.md
@@ -1,6 +1,10 @@
-When the client sync data from the Redis-Like server to Valkey using some sync tools like [RedisShake](https://github.com/tair-opensource/RedisShake), Valkey performs expiration and eviction as usual because it's a primary, which may cause data corruption. For example, the client calls `set key 1 ex 1` on the source server and this command is transferred to the destination server. Then the client calls `incr key` on the source server before the key expired, there will be a key on the source server with the value of 2. But when the command arrived at the destination server, the key may be expired and has deleted. So there will be a key on the destination server with the value of 1, which is inconsistent with the source server. Sync tools can solve this problem by setting ` IMPORT-MODE` config to yes and declaring their connections as  `IMPORT-SOURCE`.
+When the client sync data from a Redis-like server to Valkey using some sync tools like [RedisShake](https://github.com/tair-opensource/RedisShake), Valkey performs expiration and eviction as usual because it's a primary, which may cause data corruption. For example, the client calls `set key 1 ex 1` on the source server and this command is transferred to the destination server. Then the client calls `incr key` on the source server before the key expired, there will be a key on the source server with the value of 2. But when the command arrived at the destination server, the key may be expired and has deleted. So there will be a key on the destination server with the value of 1, which is inconsistent with the source server. Sync tools can solve this problem by setting `import-mode` config to `yes` and declaring their connections as `IMPORT-SOURCE`.
 
 The `CLIENT IMPORT-SOURCE` command mark this client as an import source if import-mode is enabled and can visit expired keys. The following modes are available:
 
 * `ON`. In this mode the client can visit expired keys.
 * `OFF`. This is the default mode in which the client works as a normal client.
+
+## Notes
+
+The server needs to be configured with `import-mode yes` before marking a client connection as an import source.

--- a/commands/client-import-source.md
+++ b/commands/client-import-source.md
@@ -1,0 +1,6 @@
+When the client sync data from the Redis-Like server to Valkey using some sync tools like [RedisShake](https://github.com/tair-opensource/RedisShake), Valkey performs expiration and eviction as usual because it's a primary, which may cause data corruption. For example, the client calls `set key 1 ex 1` on the source server and this command is transferred to the destination server. Then the client calls `incr key` on the source server before the key expired, there will be a key on the source server with the value of 2. But when the command arrived at the destination server, the key may be expired and has deleted. So there will be a key on the destination server with the value of 1, which is inconsistent with the source server. Sync tools can solve this problem by setting ` IMPORT-MODE` config to yes and declaring their connections as  `IMPORT-SOURCE`.
+
+The `CLIENT IMPORT-SOURCE` command mark this client as an import source if import-mode is enabled and can visit expired keys. The following modes are available:
+
+* `ON`. In this mode the client can visit expired keys.
+* `OFF`. This is the default mode in which the client works as a normal client.

--- a/commands/client-list.md
+++ b/commands/client-list.md
@@ -62,6 +62,7 @@ t: the client enabled keys tracking in order to perform client side caching
 T: the client will not touch the LRU/LFU of the keys it accesses
 R: the client tracking target client is invalid
 B: the client enabled broadcast tracking mode
+I: the client is an import source
 ```
 
 The file descriptor events can be:


### PR DESCRIPTION
This PR is for https://github.com/valkey-io/valkey/pull/1185 and https://github.com/valkey-io/valkey/pull/1398.

By far, RedisShake doesn't support `import-mode` and `client import-source` yet. So I don't add a new migration guide in migration.md. If any sync tools support import-mode, I'm willing to supplement it.