### PR TITLE
When building man pages, ignore a command if it's json file is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,12 @@ endif
 
 # ---- Source files ----
 
+documented_commands = $(wildcard commands/*.md)
+commands_json_files = $(wildcard $(VALKEY_ROOT)/src/commands/*.json)
+existing_commands = $(commands_json_files:$(VALKEY_ROOT)/src/commands/%.json=commands/%.md)
+
 topics   = $(wildcard topics/*)
-commands = $(wildcard commands/*.md)
+commands = $(filter $(existing_commands),$(documented_commands))
 
 topics_md   = $(filter %.md,$(topics))
 topics_pics = $(filter-out %.md,$(topics))
@@ -64,7 +68,8 @@ topics_pics = $(filter-out %.md,$(topics))
 json_for_documented_commands = $(commands:commands/%.md=$(VALKEY_ROOT)/src/commands/%.json)
 
 $(BUILD_DIR)/.commands-per-group.json: $(VALKEY_ROOT)/src/commands/. utils/build-command-groups.py | $(BUILD_DIR)
-	utils/build-command-groups.py $(json_for_documented_commands) > $@
+	utils/build-command-groups.py $(json_for_documented_commands) > $@~~
+	mv $@~~ $@
 $(BUILD_DIR):
 	mkdir -p $@
 


### PR DESCRIPTION
For building man pages for a version other than the latest, the docs are always the latest but the code can be a checked out older version that doesn't contain all commands present in the docs.

This patch skips such commands when building the command man pages.