### PR TITLE
Improve docs for rolling upgrade of a cluster

### DIFF
--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -727,11 +727,11 @@ This is what you see in the replica log when you perform a manual failover:
     # Failover election won: I'm the new primary.
 
 Clients sending write commands to the primary are blocked during the failover.
-When the primary sends its replication offset to the replica, the replica waits
-to reach the offset on its side. When the replication offset is reached, the
-failover starts, and the old primary is informed about the configuration switch.
-When the switch is complete, the clients are unblocked on the old primary and
-they are redirected to the new primary.
+When the primary sends its replication offset to the replica, the replica
+waits to reach the offset on its side. When the replication offset is reached,
+the failover starts, and the old primary is informed about the configuration
+switch. When the switch is complete, the clients are unblocked on the old
+primary and they are redirected to the new primary.
 
 **Note:**
 To promote a replica to primary, it must first be known as a replica by a majority of the primaries in the cluster.

--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -939,8 +939,8 @@ repeating the following procedure for each shard (a primary and its replicas):
    the rolling upgrade. An alternative is to upgrade one replica at a time and
    have fewer replicas online during the upgrade. To add a new node, use
    [`CLUSTER MEET`](../commands/cluster-meet.md) and [`CLUSTER
-   REPLICATE`](../commands/cluster-replicate.md) or use `valkey-cli` as descibed
-   under [Add a new node as a replica](#add-a-new-node-as-a-replica).
+   REPLICATE`](../commands/cluster-replicate.md) or use `valkey-cli` as
+   described under [Add a new node as a replica](#add-a-new-node-as-a-replica).
 
 2. Upgrade the existing replicas you want to keep by restarting them with the
    updated version of Valkey. If you're replacing all the old nodes with new

--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -726,12 +726,12 @@ This is what you see in the replica log when you perform a manual failover:
     # Starting a failover election for epoch 7545.
     # Failover election won: I'm the new primary.
 
-Clients sending commands to the primary are blocked during the failover.
-When the primary sends its replication offset to the replica, the replica
-waits to reach the offset on its side. When the replication offset is reached,
-the failover starts, and the old primary is informed about the configuration
-switch. When the switch is complete, the clients are unblocked on the old
-primary and they are redirected to the new primary.
+Clients sending write commands to the primary are blocked during the failover.
+When the primary sends its replication offset to the replica, the replica waits
+to reach the offset on its side. When the replication offset is reached, the
+failover starts, and the old primary is informed about the configuration switch.
+When the switch is complete, the clients are unblocked on the old primary and
+they are redirected to the new primary.
 
 **Note:**
 To promote a replica to primary, it must first be known as a replica by a majority of the primaries in the cluster.


### PR DESCRIPTION
Upgrading a cluster is described very briefly in the Cluster tutorial. This PR expands this with a more thorough step-by-step procedure for a rolling upgrade.

If there are better ways e.g. to check if a replica is ready, please let me know.