### PR TITLE
Update lists.md

### DIFF
--- a/topics/lists.md
+++ b/topics/lists.md
@@ -156,7 +156,7 @@ multiple elements into a list in a single call:
 127.0.0.1:6379> RPUSH bikes:repairs bike:1 bike:2 bike:3
 (integer) 3
 127.0.0.1:6379> LPUSH bikes:repairs bike:important_bike bike:very_important_bike
-127.0.0.1:6379> LRANGE mylist 0 -1
+127.0.0.1:6379> LRANGE bikes:repairs 0 -1
 1) "bike:very_important_bike"
 2) "bike:important_bike"
 3) "bike:1"


### PR DESCRIPTION
The example showing that RPUSH and LPUSH are variadic commands is incorrectly returning data from the wrong list name. The list name should be bikes:repairs, but the current example uses LRANGE on mylist.