### PR TITLE
Add workflow for deploying website after updating the documentation

### DIFF
--- a/.github/workflows/trigger-build.yml
+++ b/.github/workflows/trigger-build.yml
@@ -1,18 +1,16 @@
-name: Trigger master website deploy
+name: Trigger website deploy
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
-  trigger:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "'$DATA'" | xargs \
-          curl \
-          -X POST https://api.netlify.com/build_hooks/${NETLIFY_BUILD_HOOK_ID} \
-          -d
-        env:
-          NETLIFY_BUILD_HOOK_ID: ${{ secrets.NETLIFY_BUILD_HOOK_ID }}
-          DATA: '{"type": "core", "id": "redis_docs", "repository":"${{ github.repository }}", "sha":"${{ github.sha }}", "ref":"${{ github.ref }}"}}'
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
+          repository: valkey-io/valkey-io.github.io
+          event-type: deploy


### PR DESCRIPTION
This will allow the website to automatically get updated when we update the doc pages is updated. I setup a repository action on the website github, which allows incoming events to trigger the build and deploy action. 

Some notes about security. The credential being used has write permission the website repository, so to compensate I locked down all the branches to require PRs, which should prevent any malicious attackers if they get access to the credentials. The downside is no more directly pushing to the website, which I think is an OK tradeoff. 

This PR is dependent on this PR getting merged first: https://github.com/valkey-io/valkey-io.github.io/pull/214. 