### PR TITLE
Amend note about valkey-cli about testing RDMA

### DIFF
--- a/topics/RDMA.md
+++ b/topics/RDMA.md
@@ -40,7 +40,7 @@ Or append `loadmodule src/valkey-rdma.so bind=192.168.122.100 port=6379` in valk
 
     ./src/valkey-server valkey.conf
 
-To test whether the RDMA server is working properly, do not use `valkey-cli`, which actually uses IPoIB. Instead, there is a shell script `./runtest-rdma`, which simply wraps a Python script `./tests/rdma/run.py`. The Python script would start a server locally, start a client locally and test for ~6000 KVs using RDMA write/read operations. To test remote RDMA connections, specify `./tests/rdma/rdma-test -h $remote_rdma_ip`.
+To test whether the RDMA server is working properly, do not use `valkey-cli`, which does not yet support RDMA. Instead, there is a shell script `./runtest-rdma`, which simply wraps a Python script `./tests/rdma/run.py`. The Python script would start a server locally, start a client locally and test for ~6000 KVs using RDMA write/read operations. To test remote RDMA connections, specify `./tests/rdma/rdma-test -h $remote_rdma_ip`.
 
 ### Prerequisites
 Note that the network interface (192.168.122.100 of this example) should support

--- a/topics/RDMA.md
+++ b/topics/RDMA.md
@@ -40,7 +40,7 @@ Or append `loadmodule src/valkey-rdma.so bind=192.168.122.100 port=6379` in valk
 
     ./src/valkey-server valkey.conf
 
-To test whether the RDMA server is working properly, do not use `valkey-cli`, which does not yet support RDMA. Instead, there is a shell script `./runtest-rdma`, which simply wraps a Python script `./tests/rdma/run.py`. The Python script would start a server locally, start a client locally and test for ~6000 KVs using RDMA write/read operations. To test remote RDMA connections, specify `./tests/rdma/rdma-test -h $remote_rdma_ip`.
+To test whether the RDMA server is working properly, do not use `valkey-cli`, which (as of Valkey 8.1) does not yet support RDMA. Instead, there is a shell script `./runtest-rdma`, which simply wraps a Python script `./tests/rdma/run.py`. The Python script would start a server locally, start a client locally and test for ~6000 key-value pairs using RDMA write/read operations. To test remote RDMA connections, specify `./tests/rdma/rdma-test -h $remote_rdma_ip`.
 
 ### Prerequisites
 Note that the network interface (192.168.122.100 of this example) should support


### PR DESCRIPTION
Incorrect information about valkey-cli using IPoIB was introduced in #217.