### PR TITLE
Update doc for new valkey-cli option --hotkeys-count

### DIFF
--- a/topics/cli.md
+++ b/topics/cli.md
@@ -215,6 +215,10 @@ This topic covers the different aspects of `valkey-cli`, starting from the simpl
 : Sample keys looking for hot keys.
   only works when maxmemory-policy is `*lfu`.
 
+**`--hotkeys-count`**
+: Number of Sample keys looking for hot keys.
+  only works when maxmemory-policy is `*lfu`.
+
 **`--scan`**
 : List all keys using the SCAN command.
 

--- a/topics/cli.md
+++ b/topics/cli.md
@@ -216,7 +216,7 @@ This topic covers the different aspects of `valkey-cli`, starting from the simpl
   Only works when maxmemory-policy is `*lfu`.
   This is equivalent to --hotkeys-count 16.
 
-**`--hotkeys-count`**
+**`--hotkeys-count`** _n_
 : Sample keys looking for the n most hot keys.
   Only works when maxmemory-policy is `*lfu`.
 

--- a/topics/cli.md
+++ b/topics/cli.md
@@ -213,11 +213,12 @@ This topic covers the different aspects of `valkey-cli`, starting from the simpl
 
 **`--hotkeys`**
 : Sample keys looking for hot keys.
-  only works when maxmemory-policy is `*lfu`.
+  Only works when maxmemory-policy is `*lfu`.
+  This is equivalent to --hotkeys-count 16.
 
 **`--hotkeys-count`**
-: Number of Sample keys looking for hot keys.
-  only works when maxmemory-policy is `*lfu`.
+: Sample keys looking for the n most hot keys.
+  Only works when maxmemory-policy is `*lfu`.
 
 **`--scan`**
 : List all keys using the SCAN command.


### PR DESCRIPTION
The default value is 16, and if clients use --hotkeys-count as an option, the result will be the specific number of hotkeys.

This PR related to PR https://github.com/valkey-io/valkey/pull/1933