### PR TITLE
Bump to the latest patch version: 8.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Version info
-VERSION ?= 8.1.0
-DATE ?= 2025-03-31
+VERSION ?= 8.1.2
+DATE ?= 2025-06-11
 
 # Path to the code repo.
 VALKEY_ROOT ?= ../valkey


### PR DESCRIPTION
Seems like we added at this step at a later point to the release document https://github.com/valkey-io/valkey/wiki/Releasing-a-new-Valkey-version#new-patch-release or missed it for 8.1.1