### PR TITLE
Add hyperlinks to bitmap and bloom filter files

### DIFF
--- a/commands/bf.add.md
+++ b/commands/bf.add.md
@@ -1,8 +1,8 @@
 Adds a single item to a bloom filter. If the specified bloom filter does not exist, a bloom filter is created with the provided name with default properties.
 
-To add multiple items to a bloom filter, you can use the `BF.MADD` or `BF.INSERT` commands.
+To add multiple items to a bloom filter, you can use the [BF.MADD](bf.madd.md) or [BF.INSERT](bf.insert.md) commands.
 
-To create a bloom filter with non-default properties, use the `BF.INSERT` or `BF.RESERVE` command.
+To create a bloom filter with non-default properties, use the `BF.INSERT` or [BF.RESERVE](bf.reserve.md) command.
 
 ## Examples
 

--- a/commands/bf.add.md
+++ b/commands/bf.add.md
@@ -1,6 +1,6 @@
 Adds a single item to a bloom filter. If the specified bloom filter does not exist, a bloom filter is created with the provided name with default properties.
 
-To add multiple items to a bloom filter, you can use the [BF.MADD](bf.madd.md) or [BF.INSERT](bf.insert.md) commands.
+To add multiple items to a bloom filter, you can use the [`BF.MADD`](bf.madd.md) or [`BF.INSERT`](bf.insert.md) commands.
 
 To create a bloom filter with non-default properties, use the `BF.INSERT` or [BF.RESERVE](bf.reserve.md) command.
 

--- a/commands/bf.add.md
+++ b/commands/bf.add.md
@@ -2,7 +2,7 @@ Adds a single item to a bloom filter. If the specified bloom filter does not exi
 
 To add multiple items to a bloom filter, you can use the [`BF.MADD`](bf.madd.md) or [`BF.INSERT`](bf.insert.md) commands.
 
-To create a bloom filter with non-default properties, use the `BF.INSERT` or [BF.RESERVE](bf.reserve.md) command.
+To create a bloom filter with non-default properties, use the `BF.INSERT` or [`BF.RESERVE`](bf.reserve.md) command.
 
 ## Examples
 

--- a/commands/bf.madd.md
+++ b/commands/bf.madd.md
@@ -1,6 +1,6 @@
 Adds one or more items to a bloom filter. If the specified bloom filter does not exist, a bloom filter is created with the provided name with default properties.
 
-If you want to create a bloom filter with non-default properties, use the `BF.INSERT` or `BF.RESERVE` command.
+If you want to create a bloom filter with non-default properties, use the [BF.INSERT](bf.insert.md) or [BF.RESERVE](bf.reserve.md) command.
 
 ## Examples
 

--- a/commands/bf.madd.md
+++ b/commands/bf.madd.md
@@ -1,6 +1,6 @@
 Adds one or more items to a bloom filter. If the specified bloom filter does not exist, a bloom filter is created with the provided name with default properties.
 
-If you want to create a bloom filter with non-default properties, use the [BF.INSERT](bf.insert.md) or [BF.RESERVE](bf.reserve.md) command.
+If you want to create a bloom filter with non-default properties, use the [`BF.INSERT`](bf.insert.md) or [`BF.RESERVE`](bf.reserve.md) command.
 
 ## Examples
 

--- a/commands/bitcount.md
+++ b/commands/bitcount.md
@@ -4,7 +4,7 @@ By default all the bytes contained in the string are examined.
 It is possible to specify the counting operation only in an interval passing the
 additional arguments _start_ and _end_.
 
-Like for the [GETRANGE](getrange.md) command, start and end can contain negative values in
+Similar to the [GETRANGE](getrange.md) command, `start` and `end` can contain negative values in
 order to index bytes starting from the end of the string, where -1 is the last
 byte, -2 is the penultimate, and so forth.
 

--- a/commands/bitcount.md
+++ b/commands/bitcount.md
@@ -4,7 +4,7 @@ By default all the bytes contained in the string are examined.
 It is possible to specify the counting operation only in an interval passing the
 additional arguments _start_ and _end_.
 
-Like for the `GETRANGE` command start and end can contain negative values in
+Like for the [GETRANGE](getrange.md) command, start and end can contain negative values in
 order to index bytes starting from the end of the string, where -1 is the last
 byte, -2 is the penultimate, and so forth.
 
@@ -40,7 +40,7 @@ One example is a Web application that needs the history of user visits, so that
 for instance it is possible to determine what users are good targets of beta
 features.
 
-Using the `SETBIT` command this is trivial to accomplish, identifying every day
+Using the [SETBIT](setbit.md) command this is trivial to accomplish, identifying every day
 with a small progressive integer.
 For instance day 0 is the first day the application was put online, day 1 the
 next day, and so forth.

--- a/commands/bitcount.md
+++ b/commands/bitcount.md
@@ -40,7 +40,7 @@ One example is a Web application that needs the history of user visits, so that
 for instance it is possible to determine what users are good targets of beta
 features.
 
-Using the [SETBIT](setbit.md) command this is trivial to accomplish, identifying every day
+Using the [SETBIT](setbit.md) command, this is trivial to accomplish, identifying every day
 with a small progressive integer.
 For instance day 0 is the first day the application was put online, day 1 the
 next day, and so forth.

--- a/commands/bitcount.md
+++ b/commands/bitcount.md
@@ -4,13 +4,13 @@ By default all the bytes contained in the string are examined.
 It is possible to specify the counting operation only in an interval passing the
 additional arguments _start_ and _end_.
 
-Similar to the [GETRANGE](getrange.md) command, `start` and `end` can contain negative values in
+Similar to the [`GETRANGE`](getrange.md) command, `start` and `end` can contain negative values in
 order to index bytes starting from the end of the string, where -1 is the last
 byte, -2 is the penultimate, and so forth.
 
 Non-existent keys are treated as empty strings, so the command will return zero.
 
-By default, the additional arguments _start_ and _end_ specify a byte index.
+By default, the additional arguments `start` and `end` specify a byte index.
 We can use an additional argument `BIT` to specify a bit index.
 So 0 is the first bit, 1 is the second bit, and so forth.
 For negative values, -1 is the last bit, -2 is the penultimate, and so forth.
@@ -40,7 +40,7 @@ One example is a Web application that needs the history of user visits, so that
 for instance it is possible to determine what users are good targets of beta
 features.
 
-Using the [SETBIT](setbit.md) command, this is trivial to accomplish, identifying every day
+Using the [`SETBIT`](setbit.md) command, this is trivial to accomplish, identifying every day
 with a small progressive integer.
 For instance day 0 is the first day the application was put online, day 1 the
 next day, and so forth.
@@ -63,12 +63,12 @@ In the above example of counting days, even after 10 years the application is
 online we still have just `365*10` bits of data per user, that is just 456 bytes
 per user.
 With this amount of data `BITCOUNT` is still as fast as any other O(1) Valkey
-command like `GET` or `INCR`.
+command like [`GET`](get.md) or [`INCR`](incr.md).
 
 When the bitmap is big, there are two alternatives:
 
 * Taking a separated key that is incremented every time the bitmap is modified.
   This can be very efficient and atomic using a small Lua script.
-* Running the bitmap incrementally using the `BITCOUNT` _start_ and _end_
+* Running the bitmap incrementally using the `BITCOUNT` `start` and `end`
   optional parameters, accumulating the results client-side, and optionally
   caching the result into a key.

--- a/commands/bitfield_ro.md
+++ b/commands/bitfield_ro.md
@@ -1,8 +1,8 @@
-Read-only variant of the `BITFIELD` command.
-It is like the original `BITFIELD` but only accepts `!GET` subcommand and can safely be used in read-only replicas.
+Read-only variant of the [BITFIELD](bitfield.md) command.
+It is like the original `BITFIELD` but only accepts `GET` subcommand and can safely be used in read-only replicas.
 
-Since the original `BITFIELD` has `!SET` and `!INCRBY` options it is technically flagged as a writing command in the Valkey command table.
-For this reason read-only replicas in a Valkey Cluster will redirect it to the master instance even if the connection is in read-only mode (see the `READONLY` command of Valkey Cluster).
+Since the original `BITFIELD` has `SET` and `INCRBY` options it is technically flagged as a writing command in the Valkey command table.
+For this reason read-only replicas in a Valkey Cluster will redirect it to the master instance even if the connection is in read-only mode (see the [READONLY](readonly.md) command of Valkey Cluster).
 
 See original `BITFIELD` for more details.
 

--- a/commands/bitfield_ro.md
+++ b/commands/bitfield_ro.md
@@ -1,8 +1,8 @@
 Read-only variant of the [`BITFIELD`](bitfield.md) command.
 It is similar to the original `BITFIELD` but only accepts `GET` subcommand and can safely be used in read-only replicas.
 
-Since the original `BITFIELD` has `SET` and `INCRBY` options it is technically flagged as a writing command in the Valkey command table.
-For this reason read-only replicas in a Valkey Cluster will redirect it to the master instance even if the connection is in read-only mode (see the [`READONLY`](readonly.md) command of Valkey Cluster).
+Since the original `BITFIELD` has `SET` and `INCRBY` options, it is technically flagged as a writing command in the Valkey command table.
+For this reason, read-only replicas in a Valkey Cluster will redirect it to the master instance even if the connection is in read-only mode (see the [`READONLY`](readonly.md) command of Valkey Cluster).
 
 See original `BITFIELD` for more details.
 

--- a/commands/bitfield_ro.md
+++ b/commands/bitfield_ro.md
@@ -1,8 +1,8 @@
-Read-only variant of the [BITFIELD](bitfield.md) command.
+Read-only variant of the [`BITFIELD`](bitfield.md) command.
 It is similar to the original `BITFIELD` but only accepts `GET` subcommand and can safely be used in read-only replicas.
 
 Since the original `BITFIELD` has `SET` and `INCRBY` options it is technically flagged as a writing command in the Valkey command table.
-For this reason read-only replicas in a Valkey Cluster will redirect it to the master instance even if the connection is in read-only mode (see the [READONLY](readonly.md) command of Valkey Cluster).
+For this reason read-only replicas in a Valkey Cluster will redirect it to the master instance even if the connection is in read-only mode (see the [`READONLY`](readonly.md) command of Valkey Cluster).
 
 See original `BITFIELD` for more details.
 

--- a/commands/bitfield_ro.md
+++ b/commands/bitfield_ro.md
@@ -1,5 +1,5 @@
 Read-only variant of the [BITFIELD](bitfield.md) command.
-It is like the original `BITFIELD` but only accepts `GET` subcommand and can safely be used in read-only replicas.
+It is similar to the original `BITFIELD` but only accepts `GET` subcommand and can safely be used in read-only replicas.
 
 Since the original `BITFIELD` has `SET` and `INCRBY` options it is technically flagged as a writing command in the Valkey command table.
 For this reason read-only replicas in a Valkey Cluster will redirect it to the master instance even if the connection is in read-only mode (see the [READONLY](readonly.md) command of Valkey Cluster).

--- a/commands/bitop.md
+++ b/commands/bitop.md
@@ -39,7 +39,7 @@ OK
 
 ## Pattern: real time metrics using bitmaps
 
-`BITOP` is a good complement to the pattern documented in the `BITCOUNT` command
+`BITOP` is a good complement to the pattern documented in the [BITCOUNT](bitcount.md) command
 documentation.
 Different bitmaps can be combined in order to obtain a target bitmap where
 the population counting operation is performed.

--- a/commands/bitop.md
+++ b/commands/bitop.md
@@ -39,7 +39,7 @@ OK
 
 ## Pattern: real time metrics using bitmaps
 
-`BITOP` is a good complement to the pattern documented in the [BITCOUNT](bitcount.md) command
+`BITOP` is a good complement to the pattern documented in the [`BITCOUNT`](bitcount.md) command
 documentation.
 Different bitmaps can be combined in order to obtain a target bitmap where
 the population counting operation is performed.

--- a/commands/bitpos.md
+++ b/commands/bitpos.md
@@ -4,7 +4,7 @@ The position is returned, thinking of the string as an array of bits from left t
 right, where the first byte's most significant bit is at position 0, the second
 byte's most significant bit is at position 8, and so forth.
 
-The same bit position convention is followed by [GETBIT](getbit.md) and [SETBIT](setbit.md).
+The same bit position convention is followed by [`GETBIT`](getbit.md) and [`SETBIT`](setbit.md).
 
 By default, all the bytes contained in the string are examined.
 It is possible to look for bits only in a specified interval by passing the additional arguments `start` and `end`. You can also just pass `start`, the operation will assume that the end is the last byte of the string. However there are semantic differences as explained later.
@@ -15,7 +15,7 @@ So `start=0` and `end=2` means to look at the first three bits.
 
 Note that bit positions are returned always as absolute values starting from bit zero even when _start_ and _end_ are used to specify a range.
 
-Similar to the [GETRANGE](getrange.md) command, start and end can contain negative values in
+Similar to the [`GETRANGE`](getrange.md) command, `start` and `end` can contain negative values in
 order to index bytes starting from the end of the string, where -1 is the last
 byte, -2 is the penultimate, and so forth. When `BIT` is specified, -1 is the last
 bit, -2 is the penultimate, and so forth.

--- a/commands/bitpos.md
+++ b/commands/bitpos.md
@@ -7,7 +7,7 @@ byte's most significant bit is at position 8, and so forth.
 The same bit position convention is followed by [GETBIT](getbit.md) and [SETBIT](setbit.md).
 
 By default, all the bytes contained in the string are examined.
-It is possible to look for bits only in a specified interval passing the additional arguments _start_ and _end_ (it is possible to just pass _start_, the operation will assume that the end is the last byte of the string. However there are semantic differences as explained later).
+It is possible to look for bits only in a specified interval by passing the additional arguments `start` and `end`. You can also just pass `start`, the operation will assume that the end is the last byte of the string. However there are semantic differences as explained later.
 By default, the range is interpreted as a range of bytes and not a range of bits, so `start=0` and `end=2` means to look at the first three bytes.
 
 You can use the optional `BIT` modifier to specify that the range should be interpreted as a range of bits.

--- a/commands/bitpos.md
+++ b/commands/bitpos.md
@@ -4,7 +4,7 @@ The position is returned, thinking of the string as an array of bits from left t
 right, where the first byte's most significant bit is at position 0, the second
 byte's most significant bit is at position 8, and so forth.
 
-The same bit position convention is followed by `GETBIT` and `SETBIT`.
+The same bit position convention is followed by [GETBIT](getbit.md) and [SETBIT](setbit.md).
 
 By default, all the bytes contained in the string are examined.
 It is possible to look for bits only in a specified interval passing the additional arguments _start_ and _end_ (it is possible to just pass _start_, the operation will assume that the end is the last byte of the string. However there are semantic differences as explained later).
@@ -15,7 +15,7 @@ So `start=0` and `end=2` means to look at the first three bits.
 
 Note that bit positions are returned always as absolute values starting from bit zero even when _start_ and _end_ are used to specify a range.
 
-Like for the `GETRANGE` command start and end can contain negative values in
+Similar to the [GETRANGE](getrange.md) command, start and end can contain negative values in
 order to index bytes starting from the end of the string, where -1 is the last
 byte, -2 is the penultimate, and so forth. When `BIT` is specified, -1 is the last
 bit, -2 is the penultimate, and so forth.

--- a/commands/bitpos.md
+++ b/commands/bitpos.md
@@ -13,7 +13,7 @@ By default, the range is interpreted as a range of bytes and not a range of bits
 You can use the optional `BIT` modifier to specify that the range should be interpreted as a range of bits.
 So `start=0` and `end=2` means to look at the first three bits.
 
-Note that bit positions are returned always as absolute values starting from bit zero even when _start_ and _end_ are used to specify a range.
+Note that bit positions are returned always as absolute values starting from bit zero even when `start` and `end` are used to specify a range.
 
 Similar to the [`GETRANGE`](getrange.md) command, `start` and `end` can contain negative values in
 order to index bytes starting from the end of the string, where -1 is the last

--- a/commands/setbit.md
+++ b/commands/setbit.md
@@ -36,14 +36,14 @@ the same _key_ will not have the allocation overhead.
 There are cases when you need to set all the bits of single bitmap at once, for
 example when initializing it to a default non-zero value. It is possible to do
 this with multiple calls to the `SETBIT` command, one for each bit that needs to
-be set. However, so as an optimization you can use a single [SET](set.md) command to set
+be set. However, so as an optimization you can use a single [`SET`](set.md) command to set
 the entire bitmap.
 
 Bitmaps are not an actual data type, but a set of bit-oriented operations
 defined on the String type (for more information refer to the
 [Bitmaps section of the Data Types Introduction page][ti]). This means that
-bitmaps can be used with string commands, and most importantly with `SET` and
-[GET](get.md).
+bitmaps can be used with string commands, and most importantly with [`SET`](set.md) and
+[`GET`](get.md).
 
 Because Valkey' strings are binary-safe, a bitmap is trivially encoded as a bytes
 stream. The first byte of the string corresponds to offsets 0..7 of
@@ -75,7 +75,7 @@ with the resultant string.
 
 `SETBIT` excels at setting single bits, and can be called several times when
 multiple bits need to be set. To optimize this operation you can replace
-multiple `SETBIT` calls with a single call to the variadic [BITFIELD](bitfield.md) command
+multiple `SETBIT` calls with a single call to the variadic [`BITFIELD`](bitfield.md) command
 and the use of fields of type `u1`.
 
 For example, the example above could be replaced by:
@@ -86,9 +86,9 @@ For example, the example above could be replaced by:
 
 ## Advanced Pattern: accessing bitmap ranges
 
-It is also possible to use the [GETRANGE](getrange.md) and [SETRANGE](setrange.md) string commands to
+It is also possible to use the [`GETRANGE`](getrange.md) and [`SETRANGE`](setrange.md) string commands to
 efficiently access a range of bit offsets in a bitmap. Below is a sample
-implementation in idiomatic Valkey Lua scripting that can be run with the `EVAL`
+implementation in idiomatic Valkey Lua scripting that can be run with the [`EVAL`](eval.md)
 command:
 
 ```

--- a/commands/setbit.md
+++ b/commands/setbit.md
@@ -36,14 +36,14 @@ the same _key_ will not have the allocation overhead.
 There are cases when you need to set all the bits of single bitmap at once, for
 example when initializing it to a default non-zero value. It is possible to do
 this with multiple calls to the `SETBIT` command, one for each bit that needs to
-be set. However, so as an optimization you can use a single `SET` command to set
+be set. However, so as an optimization you can use a single [SET](set.md) command to set
 the entire bitmap.
 
 Bitmaps are not an actual data type, but a set of bit-oriented operations
 defined on the String type (for more information refer to the
 [Bitmaps section of the Data Types Introduction page][ti]). This means that
 bitmaps can be used with string commands, and most importantly with `SET` and
-`GET`.
+[GET](get.md).
 
 Because Valkey' strings are binary-safe, a bitmap is trivially encoded as a bytes
 stream. The first byte of the string corresponds to offsets 0..7 of
@@ -75,7 +75,7 @@ with the resultant string.
 
 `SETBIT` excels at setting single bits, and can be called several times when
 multiple bits need to be set. To optimize this operation you can replace
-multiple `SETBIT` calls with a single call to the variadic `BITFIELD` command
+multiple `SETBIT` calls with a single call to the variadic [BITFIELD](bitfield.md) command
 and the use of fields of type `u1`.
 
 For example, the example above could be replaced by:
@@ -86,7 +86,7 @@ For example, the example above could be replaced by:
 
 ## Advanced Pattern: accessing bitmap ranges
 
-It is also possible to use the `GETRANGE` and `SETRANGE` string commands to
+It is also possible to use the [GETRANGE](getrange.md) and [SETRANGE](setrange.md) string commands to
 efficiently access a range of bit offsets in a bitmap. Below is a sample
 implementation in idiomatic Valkey Lua scripting that can be run with the `EVAL`
 command:


### PR DESCRIPTION
Added hyperlinks to referenced commands in the following files:

bitcount.md
bitfield_ro.md
bitop.md
bitpos.md
setbit.md
bf.add.md
bf.madd.md

Part of #294
