### PR TITLE
Milliehartnt123 issue 294  5 add hyperlinks for referenced commands to geospatial index, hash, hyperloglog, JSON, and list command files

### DIFF
--- a/commands/blmove.md
+++ b/commands/blmove.md
@@ -1,11 +1,11 @@
 `BLMOVE` is the blocking variant of [LMOVE](lmove.md).
 When `source` contains elements, this command behaves exactly like `LMOVE`.
-When used inside a `MULTI`/`EXEC` block, this command behaves exactly like `LMOVE`.
+When used inside a [MULTI](multi.md)/[EXEC](exec.md) block, this command behaves exactly like `LMOVE`.
 When `source` is empty, Valkey will block the connection until another client
 pushes to it or until `timeout` (a double value specifying the maximum number of seconds to block) is reached.
 A `timeout` of zero can be used to block indefinitely.
 
-This command comes in place of the now deprecated `BRPOPLPUSH`. Doing
+This command comes in place of the now deprecated [BRPOPLPUSH](brpoplpush.md). Doing
 `BLMOVE RIGHT LEFT` is equivalent.
 
 See [LMOVE](lmove.md) for more information.

--- a/commands/blmove.md
+++ b/commands/blmove.md
@@ -1,4 +1,4 @@
-`BLMOVE` is the blocking variant of `LMOVE`.
+`BLMOVE` is the blocking variant of [LMOVE](lmove.md).
 When `source` contains elements, this command behaves exactly like `LMOVE`.
 When used inside a `MULTI`/`EXEC` block, this command behaves exactly like `LMOVE`.
 When `source` is empty, Valkey will block the connection until another client
@@ -8,7 +8,7 @@ A `timeout` of zero can be used to block indefinitely.
 This command comes in place of the now deprecated `BRPOPLPUSH`. Doing
 `BLMOVE RIGHT LEFT` is equivalent.
 
-See `LMOVE` for more information.
+See [LMOVE](lmove.md) for more information.
 
 ## Pattern: Reliable queue
 

--- a/commands/blmove.md
+++ b/commands/blmove.md
@@ -1,14 +1,14 @@
-`BLMOVE` is the blocking variant of [LMOVE](lmove.md).
+`BLMOVE` is the blocking variant of [`LMOVE`](lmove.md).
 When `source` contains elements, this command behaves exactly like `LMOVE`.
-When used inside a [MULTI](multi.md)/[EXEC](exec.md) block, this command behaves exactly like `LMOVE`.
+When used inside a [`MULTI`](multi.md)/[`EXEC`](exec.md) block, this command behaves exactly like `LMOVE`.
 When `source` is empty, Valkey will block the connection until another client
 pushes to it or until `timeout` (a double value specifying the maximum number of seconds to block) is reached.
 A `timeout` of zero can be used to block indefinitely.
 
-This command comes in place of the now deprecated [BRPOPLPUSH](brpoplpush.md). Doing
+This command comes in place of the now deprecated [`BRPOPLPUSH`](brpoplpush.md). Doing
 `BLMOVE RIGHT LEFT` is equivalent.
 
-See [LMOVE](lmove.md) for more information.
+See [`LMOVE`](lmove.md) for more information.
 
 ## Pattern: Reliable queue
 

--- a/commands/blmpop.md
+++ b/commands/blmpop.md
@@ -1,8 +1,8 @@
-`BLMPOP` is the blocking variant of `LMPOP`.
+`BLMPOP` is the blocking variant of [LMPOP](lmpop.md).
 
 When any of the lists contains elements, this command behaves exactly like `LMPOP`.
-When used inside a `MULTI`/`EXEC` block, this command behaves exactly like `LMPOP`.
+When used inside a [MULTI](multi.md)/[EXEC](exec.md) block, this command behaves exactly like `LMPOP`.
 When all lists are empty, Valkey will block the connection until another client pushes to it or until the `timeout` (a double value specifying the maximum number of seconds to block) elapses.
 A `timeout` of zero can be used to block indefinitely.
 
-See `LMPOP` for more information.
+See [LMPOP](lmpop.md) for more information.

--- a/commands/blmpop.md
+++ b/commands/blmpop.md
@@ -1,8 +1,8 @@
-`BLMPOP` is the blocking variant of [LMPOP](lmpop.md).
+`BLMPOP` is the blocking variant of [`LMPOP`](lmpop.md).
 
 When any of the lists contains elements, this command behaves exactly like `LMPOP`.
-When used inside a [MULTI](multi.md)/[EXEC](exec.md) block, this command behaves exactly like `LMPOP`.
+When used inside a [`MULTI`](multi.md)/[`EXEC`](exec.md) block, this command behaves exactly like `LMPOP`.
 When all lists are empty, Valkey will block the connection until another client pushes to it or until the `timeout` (a double value specifying the maximum number of seconds to block) elapses.
 A `timeout` of zero can be used to block indefinitely.
 
-See [LMPOP](lmpop.md) for more information.
+See [`LMPOP`](lmpop.md) for more information.

--- a/commands/blpop.md
+++ b/commands/blpop.md
@@ -1,5 +1,5 @@
 `BLPOP` is a blocking list pop primitive.
-It is the blocking version of `LPOP` because it blocks the connection when there
+It is the blocking version of [LPOP](lpop.md) because it blocks the connection when there
 are no elements to pop from any of the given lists.
 An element is popped from the head of the first list that is non-empty, with the
 given keys being checked in the order that they are given.
@@ -26,7 +26,7 @@ that order).
 ## Blocking behavior
 
 If none of the specified keys exist, `BLPOP` blocks the connection until another
-client performs an `LPUSH` or `RPUSH` operation against one of the keys.
+client performs an [LPUSH](lpush.md) or [RPUSH](rpush.md) operation against one of the keys.
 
 Once new data is present on one of the lists, the client returns with the name
 of the key unblocking it and the popped value.
@@ -44,12 +44,12 @@ specified keys.
 * If multiple clients are blocked for the same key, the first client to be served is the one that was waiting for more time (the first that blocked for the key). Once a client is unblocked it does not retain any priority, when it blocks again with the next call to `BLPOP` it will be served accordingly to the number of clients already blocked for the same key, that will all be served before it (from the first to the last that blocked).
 * When a client is blocking for multiple keys at the same time, and elements are available at the same time in multiple keys (because of a transaction or a Lua script added elements to multiple lists), the client will be unblocked using the first key that received a push operation (assuming it has enough elements to serve our client, as there may be other clients as well waiting for this key). Basically after the execution of every command Valkey will run a list of all the keys that received data AND that have at least a client blocked. The list is ordered by new element arrival time, from the first key that received data to the last. For every key processed, Valkey will serve all the clients waiting for that key in a FIFO fashion, as long as there are elements in this key. When the key is empty or there are no longer clients waiting for this key, the next key that received new data in the previous command / transaction / script is processed, and so forth.
 
-## Behavior of `!BLPOP` when multiple elements are pushed inside a list.
+## Behavior of `BLPOP` when multiple elements are pushed inside a list.
 
 There are times when a list can receive multiple elements in the context of the same conceptual command:
 
 * Variadic push operations such as `LPUSH mylist a b c`.
-* After an `EXEC` of a `MULTI` block with multiple push operations against the same list.
+* After an [EXEC](exec.md) of a [MULTI](multi.md) block with multiple push operations against the same list.
 * Executing a Lua Script.
 
 What happens is that the command performing multiple pushes is executed, and *only after* the execution of the command the blocked clients are served. Consider this sequence of commands.
@@ -61,13 +61,13 @@ If the above condition happens using a Redis OSS 2.6 server or greater, Client *
 
 Note that for the same reason a Lua script or a `MULTI/EXEC` block may push elements into a list and afterward **delete the list**. In this case the blocked clients will not be served at all and will continue to be blocked as long as no data is present on the list after the execution of a single command, transaction, or script.
 
-## `!BLPOP` inside a `!MULTI` / `!EXEC` transaction
+## `BLPOP` inside a `MULTI` / `EXEC` transaction
 
 `BLPOP` can be used with pipelining (sending multiple commands and
 reading the replies in batch), however this setup makes sense almost solely
 when it is the last command of the pipeline.
 
-Using `BLPOP` inside a `MULTI` / `EXEC` block does not make a lot of sense
+Using `BLPOP` inside a [MULTI](multi.md) / [EXEC](exec.md) block does not make a lot of sense
 as it would require blocking the entire server in order to execute the block
 atomically, which in turn does not allow other clients to perform a push
 operation. For this reason the behavior of `BLPOP` inside `MULTI` / `EXEC` when the list is empty is to return a `nil` multi-bulk reply, which is the same
@@ -92,7 +92,7 @@ If you like science fiction, think of time flowing at infinite speed inside a
 
 When `BLPOP` returns an element to the client, it also removes the element from the list. This means that the element only exists in the context of the client: if the client crashes while processing the returned element, it is lost forever.
 
-This can be a problem with some application where we want a more reliable messaging system. When this is the case, please check the `BRPOPLPUSH` command, that is a variant of `BLPOP` that adds the returned element to a target list before returning it to the client.
+This can be a problem with some application where we want a more reliable messaging system. When this is the case, please check the [BRPOPLPUSH](brpoplpush.md) command, that is a variant of `BLPOP` that adds the returned element to a target list before returning it to the client.
 
 ## Pattern: Event notification
 
@@ -101,7 +101,7 @@ primitives.
 For instance for some application you may need to block waiting for elements
 into a Set, so that as far as a new element is added to the Set, it is
 possible to retrieve it without resort to polling.
-This would require a blocking version of `SPOP` that is not available, but using
+This would require a blocking version of [SPOP](spop.md) that is not available, but using
 blocking list operations we can easily accomplish this task.
 
 The consumer will do:

--- a/commands/blpop.md
+++ b/commands/blpop.md
@@ -1,5 +1,5 @@
 `BLPOP` is a blocking list pop primitive.
-It is the blocking version of [LPOP](lpop.md) because it blocks the connection when there
+It is the blocking version of [`LPOP`](lpop.md) because it blocks the connection when there
 are no elements to pop from any of the given lists.
 An element is popped from the head of the first list that is non-empty, with the
 given keys being checked in the order that they are given.
@@ -26,7 +26,7 @@ that order).
 ## Blocking behavior
 
 If none of the specified keys exist, `BLPOP` blocks the connection until another
-client performs an [LPUSH](lpush.md) or [RPUSH](rpush.md) operation against one of the keys.
+client performs an [`LPUSH`](lpush.md) or [`RPUSH`](rpush.md) operation against one of the keys.
 
 Once new data is present on one of the lists, the client returns with the name
 of the key unblocking it and the popped value.
@@ -49,7 +49,7 @@ specified keys.
 There are times when a list can receive multiple elements in the context of the same conceptual command:
 
 * Variadic push operations such as `LPUSH mylist a b c`.
-* After an [EXEC](exec.md) of a [MULTI](multi.md) block with multiple push operations against the same list.
+* After an [`EXEC`](exec.md) of a [`MULTI`](multi.md) block with multiple push operations against the same list.
 * Executing a Lua Script.
 
 What happens is that the command performing multiple pushes is executed, and *only after* the execution of the command the blocked clients are served. Consider this sequence of commands.
@@ -67,7 +67,7 @@ Note that for the same reason a Lua script or a `MULTI/EXEC` block may push elem
 reading the replies in batch), however this setup makes sense almost solely
 when it is the last command of the pipeline.
 
-Using `BLPOP` inside a [MULTI](multi.md) / [EXEC](exec.md) block does not make a lot of sense
+Using `BLPOP` inside a [`MULTI`](multi.md) / [`EXEC`](exec.md) block does not make a lot of sense
 as it would require blocking the entire server in order to execute the block
 atomically, which in turn does not allow other clients to perform a push
 operation. For this reason the behavior of `BLPOP` inside `MULTI` / `EXEC` when the list is empty is to return a `nil` multi-bulk reply, which is the same
@@ -92,7 +92,7 @@ If you like science fiction, think of time flowing at infinite speed inside a
 
 When `BLPOP` returns an element to the client, it also removes the element from the list. This means that the element only exists in the context of the client: if the client crashes while processing the returned element, it is lost forever.
 
-This can be a problem with some application where we want a more reliable messaging system. When this is the case, please check the [BRPOPLPUSH](brpoplpush.md) command, that is a variant of `BLPOP` that adds the returned element to a target list before returning it to the client.
+This can be a problem with some application where we want a more reliable messaging system. When this is the case, please check the [`BRPOPLPUSH`](brpoplpush.md) command, that is a variant of `BLPOP` that adds the returned element to a target list before returning it to the client.
 
 ## Pattern: Event notification
 
@@ -101,7 +101,7 @@ primitives.
 For instance for some application you may need to block waiting for elements
 into a Set, so that as far as a new element is added to the Set, it is
 possible to retrieve it without resort to polling.
-This would require a blocking version of [SPOP](spop.md) that is not available, but using
+This would require a blocking version of [`SPOP`](spop.md) that is not available, but using
 blocking list operations we can easily accomplish this task.
 
 The consumer will do:

--- a/commands/blpop.md
+++ b/commands/blpop.md
@@ -67,7 +67,7 @@ Note that for the same reason a Lua script or a `MULTI/EXEC` block may push elem
 reading the replies in batch), however this setup makes sense almost solely
 when it is the last command of the pipeline.
 
-Using `BLPOP` inside a [`MULTI`](multi.md) / [`EXEC`](exec.md) block does not make a lot of sense
+Using `BLPOP` inside a `MULTI`/`EXEC` block does not make a lot of sense
 as it would require blocking the entire server in order to execute the block
 atomically, which in turn does not allow other clients to perform a push
 operation. For this reason the behavior of `BLPOP` inside `MULTI` / `EXEC` when the list is empty is to return a `nil` multi-bulk reply, which is the same

--- a/commands/brpop.md
+++ b/commands/brpop.md
@@ -1,5 +1,5 @@
 `BRPOP` is a blocking list pop primitive.
-It is the blocking version of `RPOP` because it blocks the connection when there
+It is the blocking version of [RPOP](rpop.md) because it blocks the connection when there
 are no elements to pop from any of the given lists.
 An element is popped from the tail of the first list that is non-empty, with the
 given keys being checked in the order that they are given.

--- a/commands/brpop.md
+++ b/commands/brpop.md
@@ -1,5 +1,5 @@
 `BRPOP` is a blocking list pop primitive.
-It is the blocking version of [RPOP](rpop.md) because it blocks the connection when there
+It is the blocking version of [`RPOP`](rpop.md) because it blocks the connection when there
 are no elements to pop from any of the given lists.
 An element is popped from the tail of the first list that is non-empty, with the
 given keys being checked in the order that they are given.

--- a/commands/geoadd.md
+++ b/commands/geoadd.md
@@ -1,4 +1,4 @@
-Adds the specified geospatial items (longitude, latitude, name) to the specified key. Data is stored into the key as a sorted set, in a way that makes it possible to query the items with the `GEOSEARCH` command.
+Adds the specified geospatial items (longitude, latitude, name) to the specified key. Data is stored into the key as a sorted set, in a way that makes it possible to query the items with the [GEOSEARCH](geosearch.md) command.
 
 The command takes arguments in the standard format x,y so the longitude must be specified before the latitude. There are limits to the coordinates that can be indexed: areas very near to the poles are not indexable.
 
@@ -9,7 +9,7 @@ The exact limits, as specified by EPSG:900913 / EPSG:3785 / OSGEO:41001 are the 
 
 The command will report an error when the user attempts to index coordinates outside the specified ranges.
 
-**Note:** there is no **GEODEL** command because you can use `ZREM` to remove elements. The Geo index structure is just a sorted set.
+**Note:** there is no **GEODEL** command because you can use [ZREM](zrem.md) to remove elements. The Geo index structure is just a sorted set.
 
 ## GEOADD options
 

--- a/commands/geoadd.md
+++ b/commands/geoadd.md
@@ -1,4 +1,4 @@
-Adds the specified geospatial items (longitude, latitude, name) to the specified key. Data is stored into the key as a sorted set, in a way that makes it possible to query the items with the [GEOSEARCH](geosearch.md) command.
+Adds the specified geospatial items (longitude, latitude, name) to the specified key. Data is stored into the key as a sorted set, in a way that makes it possible to query the items with the [`GEOSEARCH`](geosearch.md) command.
 
 The command takes arguments in the standard format x,y so the longitude must be specified before the latitude. There are limits to the coordinates that can be indexed: areas very near to the poles are not indexable.
 
@@ -9,7 +9,7 @@ The exact limits, as specified by EPSG:900913 / EPSG:3785 / OSGEO:41001 are the 
 
 The command will report an error when the user attempts to index coordinates outside the specified ranges.
 
-**Note:** there is no **GEODEL** command because you can use [ZREM](zrem.md) to remove elements. The Geo index structure is just a sorted set.
+**Note:** there is no **GEODEL** command because you can use [`ZREM`](zrem.md) to remove elements. The Geo index structure is just a sorted set.
 
 ## GEOADD options
 

--- a/commands/geodist.md
+++ b/commands/geodist.md
@@ -1,6 +1,6 @@
 Return the distance between two members in the geospatial index represented by the sorted set.
 
-Given a sorted set representing a geospatial index, populated using the `GEOADD` command, the command returns the distance between the two specified members in the specified unit.
+Given a sorted set representing a geospatial index, populated using the [GEOADD](geoadd.md) command, the command returns the distance between the two specified members in the specified unit.
 
 If one or both the members are missing, the command returns NULL.
 

--- a/commands/geodist.md
+++ b/commands/geodist.md
@@ -1,6 +1,6 @@
 Return the distance between two members in the geospatial index represented by the sorted set.
 
-Given a sorted set representing a geospatial index, populated using the [GEOADD](geoadd.md) command, the command returns the distance between the two specified members in the specified unit.
+Given a sorted set representing a geospatial index, populated using the [`GEOADD`](geoadd.md) command, the command returns the distance between the two specified members in the specified unit.
 
 If one or both the members are missing, the command returns NULL.
 

--- a/commands/geohash.md
+++ b/commands/geohash.md
@@ -1,4 +1,4 @@
-Return valid [Geohash](https://en.wikipedia.org/wiki/Geohash) strings representing the position of one or more elements in a sorted set value representing a geospatial index (where elements were added using `GEOADD`).
+Return valid [Geohash](https://en.wikipedia.org/wiki/Geohash) strings representing the position of one or more elements in a sorted set value representing a geospatial index (where elements were added using [GEOADD](geoadd.md)).
 
 Normally Valkey represents positions of elements using a variation of the Geohash
 technique where positions are encoded using 52 bit integers. The encoding is

--- a/commands/geohash.md
+++ b/commands/geohash.md
@@ -1,4 +1,4 @@
-Return valid [Geohash](https://en.wikipedia.org/wiki/Geohash) strings representing the position of one or more elements in a sorted set value representing a geospatial index (where elements were added using [GEOADD](geoadd.md)).
+Return valid [Geohash](https://en.wikipedia.org/wiki/Geohash) strings representing the position of one or more elements in a sorted set value representing a geospatial index (where elements were added using [`GEOADD`](geoadd.md)).
 
 Normally Valkey represents positions of elements using a variation of the Geohash
 technique where positions are encoded using 52 bit integers. The encoding is

--- a/commands/geopos.md
+++ b/commands/geopos.md
@@ -1,6 +1,6 @@
 Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the sorted set at *key*.
 
-Given a sorted set representing a geospatial index, populated using the `GEOADD` command, it is often useful to obtain back the coordinates of specified members. When the geospatial index is populated via `GEOADD` the coordinates are converted into a 52 bit geohash, so the coordinates returned may not be exactly the ones used in order to add the elements, but small errors may be introduced.
+Given a sorted set representing a geospatial index, populated using the [GEOADD](geoadd.md) command, it is often useful to obtain back the coordinates of specified members. When the geospatial index is populated via `GEOADD` the coordinates are converted into a 52 bit geohash, so the coordinates returned may not be exactly the ones used in order to add the elements, but small errors may be introduced.
 
 The command can accept a variable number of arguments so it always returns an array of positions even when a single element is specified.
 

--- a/commands/geopos.md
+++ b/commands/geopos.md
@@ -1,6 +1,6 @@
 Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the sorted set at *key*.
 
-Given a sorted set representing a geospatial index, populated using the [GEOADD](geoadd.md) command, it is often useful to obtain back the coordinates of specified members. When the geospatial index is populated via `GEOADD` the coordinates are converted into a 52 bit geohash, so the coordinates returned may not be exactly the ones used in order to add the elements, but small errors may be introduced.
+Given a sorted set representing a geospatial index, populated using the [`GEOADD`](geoadd.md) command, it is often useful to obtain back the coordinates of specified members. When the geospatial index is populated via `GEOADD` the coordinates are converted into a 52 bit geohash, so the coordinates returned may not be exactly the ones used in order to add the elements, but small errors may be introduced.
 
 The command can accept a variable number of arguments so it always returns an array of positions even when a single element is specified.
 

--- a/commands/geosearch.md
+++ b/commands/geosearch.md
@@ -1,6 +1,6 @@
-Return the members of a sorted set populated with geospatial information using `GEOADD`, which are within the borders of the area specified by a given shape. This command extends the `GEORADIUS` command, so in addition to searching within circular areas, it supports searching within rectangular areas and polygon shaped areas.
+Return the members of a sorted set populated with geospatial information using [GEOADD](geoadd.md), which are within the borders of the area specified by a given shape. This command extends the [GEORADIUS](georadius.md) command, so in addition to searching within circular areas, it supports searching within rectangular areas and polygon shaped areas.
 
-This command should be used in place of the deprecated `GEORADIUS` and `GEORADIUSBYMEMBER` commands.
+This command should be used in place of the deprecated `GEORADIUS` and [GEORADIUSBYMEMBER](georadiusbymember.md) commands.
 
 The query's shape is provided by one of these mandatory options:
 

--- a/commands/geosearch.md
+++ b/commands/geosearch.md
@@ -1,6 +1,6 @@
-Return the members of a sorted set populated with geospatial information using [GEOADD](geoadd.md), which are within the borders of the area specified by a given shape. This command extends the [GEORADIUS](georadius.md) command, so in addition to searching within circular areas, it supports searching within rectangular areas and polygon shaped areas.
+Return the members of a sorted set populated with geospatial information using [`GEOADD`](geoadd.md), which are within the borders of the area specified by a given shape. This command extends the [`GEORADIUS`](georadius.md) command, so in addition to searching within circular areas, it supports searching within rectangular areas and polygon shaped areas.
 
-This command should be used in place of the deprecated `GEORADIUS` and [GEORADIUSBYMEMBER](georadiusbymember.md) commands.
+This command should be used in place of the deprecated `GEORADIUS` and [`GEORADIUSBYMEMBER`](georadiusbymember.md) commands.
 
 The query's shape is provided by one of these mandatory options:
 

--- a/commands/geosearchstore.md
+++ b/commands/geosearchstore.md
@@ -1,6 +1,6 @@
-This command is like `GEOSEARCH`, but stores the result in destination key.
+This command is like [GEOSEARCH](geosearch.md), but stores the result in destination key.
 
-This command replaces the now deprecated `GEORADIUS` and `GEORADIUSBYMEMBER`.
+This command replaces the now deprecated [GEORADIUS](georadius.md) and [GEORADIUSBYMEMBER](georadiusbymember.md).
 
 By default, it stores the results in the `destination` sorted set with their geospatial information.
 

--- a/commands/geosearchstore.md
+++ b/commands/geosearchstore.md
@@ -1,6 +1,6 @@
-This command is like [GEOSEARCH](geosearch.md), but stores the result in destination key.
+This command is like [`GEOSEARCH`](geosearch.md), but stores the result in destination key.
 
-This command replaces the now deprecated [GEORADIUS](georadius.md) and [GEORADIUSBYMEMBER](georadiusbymember.md).
+This command replaces the now deprecated [`GEORADIUS`](georadius.md) and [`GEORADIUSBYMEMBER`](georadiusbymember.md).
 
 By default, it stores the results in the `destination` sorted set with their geospatial information.
 

--- a/commands/hincrbyfloat.md
+++ b/commands/hincrbyfloat.md
@@ -9,7 +9,7 @@ An error is returned if one of the following conditions occur:
   double precision floating point number.
 
 The exact behavior of this command is identical to the one of the `INCRBYFLOAT`
-command, please refer to the documentation of `INCRBYFLOAT` for further
+command, please refer to the documentation of [INCRBYFLOAT](incrbyfloat.md) for further
 information.
 
 ## Examples
@@ -30,5 +30,5 @@ information.
 ## Implementation details
 
 The command is always propagated in the replication link and the Append Only
-File as a `HSET` operation, so that differences in the underlying floating point
+File as a [HSET](hset.md) operation, so that differences in the underlying floating point
 math implementation will not be sources of inconsistency.

--- a/commands/hincrbyfloat.md
+++ b/commands/hincrbyfloat.md
@@ -30,5 +30,5 @@ information.
 ## Implementation details
 
 The command is always propagated in the replication link and the Append Only
-File as a [HSET](hset.md) operation, so that differences in the underlying floating point
+File as a [`HSET`](hset.md) operation, so that differences in the underlying floating point
 math implementation will not be sources of inconsistency.

--- a/commands/hincrbyfloat.md
+++ b/commands/hincrbyfloat.md
@@ -9,7 +9,7 @@ An error is returned if one of the following conditions occur:
   double precision floating point number.
 
 The exact behavior of this command is identical to the one of the `INCRBYFLOAT`
-command, please refer to the documentation of [INCRBYFLOAT](incrbyfloat.md) for further
+command, please refer to the documentation of [`INCRBYFLOAT`](incrbyfloat.md) for further
 information.
 
 ## Examples

--- a/commands/hrandfield.md
+++ b/commands/hrandfield.md
@@ -1,7 +1,7 @@
 When called with just the `key` argument, return a random field from the hash value stored at `key`.
 
 If the provided `count` argument is positive, return an array of **distinct fields**.
-The array's length is either `count` or the hash's number of fields (`HLEN`), whichever is lower.
+The array's length is either `count` or the hash's number of fields ([HLEN](hlen.md)), whichever is lower.
 
 If called with a negative `count`, the behavior changes and the command is allowed to return the **same field multiple times**.
 In this case, the number of returned fields is the absolute value of the specified `count`.

--- a/commands/hrandfield.md
+++ b/commands/hrandfield.md
@@ -1,7 +1,7 @@
 When called with just the `key` argument, return a random field from the hash value stored at `key`.
 
 If the provided `count` argument is positive, return an array of **distinct fields**.
-The array's length is either `count` or the hash's number of fields ([HLEN](hlen.md)), whichever is lower.
+The array's length is either `count` or the hash's number of fields ([`HLEN`](hlen.md)), whichever is lower.
 
 If called with a negative `count`, the behavior changes and the command is allowed to return the **same field multiple times**.
 In this case, the number of returned fields is the absolute value of the specified `count`.

--- a/commands/hscan.md
+++ b/commands/hscan.md
@@ -1,1 +1,1 @@
-See `SCAN` for `HSCAN` documentation.
+See [SCAN](scan.md) for `HSCAN` documentation.

--- a/commands/hscan.md
+++ b/commands/hscan.md
@@ -1,1 +1,1 @@
-See [SCAN](scan.md) for `HSCAN` documentation.
+See [`SCAN`](scan.md) for `HSCAN` documentation.

--- a/commands/json.forget.md
+++ b/commands/json.forget.md
@@ -1,1 +1,1 @@
-An alias of JSON.DEL
+An alias of [JSON.DEL](json.del.md)

--- a/commands/json.forget.md
+++ b/commands/json.forget.md
@@ -1,1 +1,1 @@
-An alias of [JSON.DEL](json.del.md)
+An alias of [`JSON.DEL`](json.del.md)

--- a/commands/lmove.md
+++ b/commands/lmove.md
@@ -15,7 +15,7 @@ removing the first/last element from the list and pushing it as first/last
 element of the list, so it can be considered as a list rotation command (or a
 no-op if `wherefrom` is the same as `whereto`).
 
-This command comes in place of the now deprecated `RPOPLPUSH`. Doing
+This command comes in place of the now deprecated [RPOPLPUSH](rpoplpush.md). Doing
 `LMOVE RIGHT LEFT` is equivalent.
 
 ## Examples
@@ -43,18 +43,18 @@ This command comes in place of the now deprecated `RPOPLPUSH`. Doing
 Valkey is often used as a messaging server to implement processing of background
 jobs or other kinds of messaging tasks.
 A simple form of queue is often obtained pushing values into a list in the
-producer side, and waiting for this values in the consumer side using `RPOP`
-(using polling), or `BRPOP` if the client is better served by a blocking
+producer side, and waiting for this values in the consumer side using [RPOP](rpop.md)
+(using polling), or [BRPOP](brpop.md) if the client is better served by a blocking
 operation.
 
 However in this context the obtained queue is not _reliable_ as messages can
 be lost, for example in the case there is a network problem or if the consumer
 crashes just after the message is received but it is still to process.
 
-`LMOVE` (or `BLMOVE` for the blocking variant) offers a way to avoid
+`LMOVE` (or [BLMOVE](blmove.md) for the blocking variant) offers a way to avoid
 this problem: the consumer fetches the message and at the same time pushes it
 into a _processing_ list.
-It will use the `LREM` command in order to remove the message from the
+It will use the [LREM](lrem.md) command in order to remove the message from the
 _processing_ list once the message has been processed.
 
 An additional client may monitor the _processing_ list for items that remain
@@ -65,7 +65,7 @@ again if needed.
 
 Using `LMOVE` with the same source and destination key, a client can visit
 all the elements of an N-elements list, one after the other, in O(N) without
-transferring the full list from the server to the client using a single `LRANGE`
+transferring the full list from the server to the client using a single [LRANGE](lrange.md)
 operation.
 
 The above pattern works even in the following conditions:

--- a/commands/lmove.md
+++ b/commands/lmove.md
@@ -15,7 +15,7 @@ removing the first/last element from the list and pushing it as first/last
 element of the list, so it can be considered as a list rotation command (or a
 no-op if `wherefrom` is the same as `whereto`).
 
-This command comes in place of the now deprecated [RPOPLPUSH](rpoplpush.md). Doing
+This command comes in place of the now deprecated [`RPOPLPUSH`](rpoplpush.md). Doing
 `LMOVE RIGHT LEFT` is equivalent.
 
 ## Examples
@@ -43,18 +43,18 @@ This command comes in place of the now deprecated [RPOPLPUSH](rpoplpush.md). Doi
 Valkey is often used as a messaging server to implement processing of background
 jobs or other kinds of messaging tasks.
 A simple form of queue is often obtained pushing values into a list in the
-producer side, and waiting for this values in the consumer side using [RPOP](rpop.md)
-(using polling), or [BRPOP](brpop.md) if the client is better served by a blocking
+producer side, and waiting for this values in the consumer side using [`RPOP`](rpop.md)
+(using polling), or [`BRPOP`](brpop.md) if the client is better served by a blocking
 operation.
 
 However in this context the obtained queue is not _reliable_ as messages can
 be lost, for example in the case there is a network problem or if the consumer
 crashes just after the message is received but it is still to process.
 
-`LMOVE` (or [BLMOVE](blmove.md) for the blocking variant) offers a way to avoid
+`LMOVE` (or [`BLMOVE`](blmove.md) for the blocking variant) offers a way to avoid
 this problem: the consumer fetches the message and at the same time pushes it
 into a _processing_ list.
-It will use the [LREM](lrem.md) command in order to remove the message from the
+It will use the [`LREM`](lrem.md) command in order to remove the message from the
 _processing_ list once the message has been processed.
 
 An additional client may monitor the _processing_ list for items that remain
@@ -65,7 +65,7 @@ again if needed.
 
 Using `LMOVE` with the same source and destination key, a client can visit
 all the elements of an N-elements list, one after the other, in O(N) without
-transferring the full list from the server to the client using a single [LRANGE](lrange.md)
+transferring the full list from the server to the client using a single [`LRANGE`](lrange.md)
 operation.
 
 The above pattern works even in the following conditions:

--- a/commands/lmpop.md
+++ b/commands/lmpop.md
@@ -1,11 +1,11 @@
 Pops one or more elements from the first non-empty list key from the list of provided key names.
 
-`LMPOP` and `BLMPOP` are similar to the following, more limited, commands:
+`LMPOP` and [BLMPOP](blmpop.md) are similar to the following, more limited, commands:
 
-- `LPOP` or `RPOP` which take only one key, and can return multiple elements.
-- `BLPOP` or `BRPOP` which take multiple keys, but return only one element from just one key.
+- [LPOP](lpop.md) or [RPOP](rpop.md) which take only one key, and can return multiple elements.
+- [BLPOP](blpop.md) or [BRPOP](brpop.md) which take multiple keys, but return only one element from just one key.
 
-See `BLMPOP` for the blocking variant of this command.
+See [BLMPOP](blmpop.md) for the blocking variant of this command.
 
 Elements are popped from either the left or right of the first non-empty list based on the passed argument.
 The number of returned elements is limited to the lower between the non-empty list's length, and the count argument (which defaults to 1).

--- a/commands/lmpop.md
+++ b/commands/lmpop.md
@@ -1,11 +1,11 @@
 Pops one or more elements from the first non-empty list key from the list of provided key names.
 
-`LMPOP` and [BLMPOP](blmpop.md) are similar to the following, more limited, commands:
+`LMPOP` and [`BLMPOP`](blmpop.md) are similar to the following, more limited, commands:
 
-- [LPOP](lpop.md) or [RPOP](rpop.md) which take only one key, and can return multiple elements.
-- [BLPOP](blpop.md) or [BRPOP](brpop.md) which take multiple keys, but return only one element from just one key.
+- [`LPOP`](lpop.md) or [`RPOP`](rpop.md) which take only one key, and can return multiple elements.
+- [`BLPOP`](blpop.md) or [`BRPOP`](brpop.md) which take multiple keys, but return only one element from just one key.
 
-See [BLMPOP](blmpop.md) for the blocking variant of this command.
+See [`BLMPOP`](blmpop.md) for the blocking variant of this command.
 
 Elements are popped from either the left or right of the first non-empty list based on the passed argument.
 The number of returned elements is limited to the lower between the non-empty list's length, and the count argument (which defaults to 1).

--- a/commands/lpushx.md
+++ b/commands/lpushx.md
@@ -1,6 +1,6 @@
 Inserts specified values at the head of the list stored at `key`, only if `key`
 already exists and holds a list.
-In contrary to `LPUSH`, no operation will be performed when `key` does not yet
+In contrary to [LPUSH](lpush.md), no operation will be performed when `key` does not yet
 exist.
 
 ## Examples

--- a/commands/lpushx.md
+++ b/commands/lpushx.md
@@ -1,6 +1,6 @@
 Inserts specified values at the head of the list stored at `key`, only if `key`
 already exists and holds a list.
-In contrary to [LPUSH](lpush.md), no operation will be performed when `key` does not yet
+In contrary to [`LPUSH`](lpush.md), no operation will be performed when `key` does not yet
 exist.
 
 ## Examples

--- a/commands/lset.md
+++ b/commands/lset.md
@@ -1,5 +1,5 @@
 Sets the list element at `index` to `element`.
-For more information on the `index` argument, see `LINDEX`.
+For more information on the `index` argument, see [LINDEX](lindex.md).
 
 An error is returned for out of range indexes.
 

--- a/commands/lset.md
+++ b/commands/lset.md
@@ -1,5 +1,5 @@
 Sets the list element at `index` to `element`.
-For more information on the `index` argument, see [LINDEX](lindex.md).
+For more information on the `index` argument, see [`LINDEX`](lindex.md).
 
 An error is returned for out of range indexes.
 

--- a/commands/ltrim.md
+++ b/commands/ltrim.md
@@ -16,7 +16,7 @@ causes `key` to be removed).
 If `end` is larger than the end of the list, Valkey will treat it like the last
 element of the list.
 
-A common use of `LTRIM` is together with `LPUSH` / `RPUSH`.
+A common use of `LTRIM` is together with [LPUSH](lpush.md) / [RPUSH](rpush.md).
 For example:
 
 ```

--- a/commands/ltrim.md
+++ b/commands/ltrim.md
@@ -16,7 +16,7 @@ causes `key` to be removed).
 If `end` is larger than the end of the list, Valkey will treat it like the last
 element of the list.
 
-A common use of `LTRIM` is together with [LPUSH](lpush.md) / [RPUSH](rpush.md).
+A common use of `LTRIM` is together with [`LPUSH`](lpush.md) / [`RPUSH`](rpush.md).
 For example:
 
 ```

--- a/commands/pfadd.md
+++ b/commands/pfadd.md
@@ -6,7 +6,7 @@ If the approximated cardinality estimated by the HyperLogLog changed after execu
 
 To call the command without elements but just the variable name is valid, this will result into no operation performed if the variable already exists, or just the creation of the data structure if the key does not exist (in the latter case 1 is returned).
 
-For an introduction to HyperLogLog data structure check the `PFCOUNT` command page.
+For an introduction to HyperLogLog data structure check the [PFCOUNT](pfcount.md) command page.
 
 ## Examples
 

--- a/commands/pfadd.md
+++ b/commands/pfadd.md
@@ -6,7 +6,7 @@ If the approximated cardinality estimated by the HyperLogLog changed after execu
 
 To call the command without elements but just the variable name is valid, this will result into no operation performed if the variable already exists, or just the creation of the data structure if the key does not exist (in the latter case 1 is returned).
 
-For an introduction to HyperLogLog data structure check the [PFCOUNT](pfcount.md) command page.
+For an introduction to HyperLogLog data structure check the [`PFCOUNT`](pfcount.md) command page.
 
 ## Examples
 

--- a/commands/pfcount.md
+++ b/commands/pfcount.md
@@ -6,7 +6,7 @@ The HyperLogLog data structure can be used in order to count **unique** elements
 
 The returned cardinality of the observed set is not exact, but approximated with a standard error of 0.81%.
 
-For example in order to take the count of all the unique search queries performed in a day, a program needs to call `PFADD` every time a query is processed. The estimated number of unique queries can be retrieved with `PFCOUNT` at any time.
+For example in order to take the count of all the unique search queries performed in a day, a program needs to call [PFADD](pfadd.md) every time a query is processed. The estimated number of unique queries can be retrieved with `PFCOUNT` at any time.
 
 Note: as a side effect of calling this function, it is possible that the HyperLogLog is modified, since the last 8 bytes encode the latest computed cardinality
 for caching purposes. So `PFCOUNT` is technically a write command.
@@ -54,7 +54,7 @@ The sparse representation uses a run-length encoding optimized to store efficien
 
 Both representations are prefixed with a 16 bytes header, that includes a magic, an encoding / version field, and the cached cardinality estimation computed, stored in little endian format (the most significant bit is 1 if the estimation is invalid since the HyperLogLog was updated since the cardinality was computed).
 
-The HyperLogLog, being a String, can be retrieved with `GET` and restored with `SET`. Calling `PFADD`, `PFCOUNT` or `PFMERGE` commands with a corrupted HyperLogLog is never a problem, it may return random values but does not affect the stability of the server. Most of the times when corrupting a sparse representation, the server recognizes the corruption and returns an error.
+The HyperLogLog, being a String, can be retrieved with [GET](get.md) and restored with [SET](set.md). Calling [PFADD](pfadd.md), `PFCOUNT` or [PFMERGE](pfmerge.md) commands with a corrupted HyperLogLog is never a problem, it may return random values but does not affect the stability of the server. Most of the times when corrupting a sparse representation, the server recognizes the corruption and returns an error.
 
 The representation is neutral from the point of view of the processor word size and endianness, so the same representation is used by 32 bit and 64 bit processor, big endian or little endian.
 

--- a/commands/pfcount.md
+++ b/commands/pfcount.md
@@ -6,7 +6,7 @@ The HyperLogLog data structure can be used in order to count **unique** elements
 
 The returned cardinality of the observed set is not exact, but approximated with a standard error of 0.81%.
 
-For example in order to take the count of all the unique search queries performed in a day, a program needs to call [PFADD](pfadd.md) every time a query is processed. The estimated number of unique queries can be retrieved with `PFCOUNT` at any time.
+For example, in order to take the count of all the unique search queries performed in a day, a program needs to call [`PFADD`](pfadd.md) every time a query is processed. The estimated number of unique queries can be retrieved with `PFCOUNT` at any time.
 
 Note: as a side effect of calling this function, it is possible that the HyperLogLog is modified, since the last 8 bytes encode the latest computed cardinality
 for caching purposes. So `PFCOUNT` is technically a write command.
@@ -54,7 +54,7 @@ The sparse representation uses a run-length encoding optimized to store efficien
 
 Both representations are prefixed with a 16 bytes header, that includes a magic, an encoding / version field, and the cached cardinality estimation computed, stored in little endian format (the most significant bit is 1 if the estimation is invalid since the HyperLogLog was updated since the cardinality was computed).
 
-The HyperLogLog, being a String, can be retrieved with [GET](get.md) and restored with [SET](set.md). Calling [PFADD](pfadd.md), `PFCOUNT` or [PFMERGE](pfmerge.md) commands with a corrupted HyperLogLog is never a problem, it may return random values but does not affect the stability of the server. Most of the times when corrupting a sparse representation, the server recognizes the corruption and returns an error.
+The HyperLogLog, being a String, can be retrieved with [`GET`](get.md) and restored with [`SET`](set.md). Calling [`PFADD`](pfadd.md), `PFCOUNT` or [`PFMERGE`](pfmerge.md) commands with a corrupted HyperLogLog is never a problem, it may return random values but does not affect the stability of the server. Most of the times when corrupting a sparse representation, the server recognizes the corruption and returns an error.
 
 The representation is neutral from the point of view of the processor word size and endianness, so the same representation is used by 32 bit and 64 bit processor, big endian or little endian.
 

--- a/commands/rpushx.md
+++ b/commands/rpushx.md
@@ -1,6 +1,6 @@
 Inserts specified values at the tail of the list stored at `key`, only if `key`
 already exists and holds a list.
-In contrary to `RPUSH`, no operation will be performed when `key` does not yet
+In contrary to [RPUSH](rpush.md), no operation will be performed when `key` does not yet
 exist.
 
 ## Examples

--- a/commands/rpushx.md
+++ b/commands/rpushx.md
@@ -1,6 +1,6 @@
 Inserts specified values at the tail of the list stored at `key`, only if `key`
 already exists and holds a list.
-In contrary to [RPUSH](rpush.md), no operation will be performed when `key` does not yet
+In contrary to [`RPUSH`](rpush.md), no operation will be performed when `key` does not yet
 exist.
 
 ## Examples


### PR DESCRIPTION
Added hyperlinks to the following command pages.

The following Geospatial Index data type files were updated:
   - geoadd.md
   - geodist.md
   - geohash.md
   - geopos.md
   - geosearch.md
   - geosearchstore.md

The following Hash data type files were updated:
   - hincrbyfloat.md
   - hrandfield.md
   - hscan.md

The following HyperLogLog data type files were updated:
   - pfadd.md
   - pfcount.md

The following JSON data type files were updated:
   - json.forget.md

The following List data type files were updated:
   - blmove.md
   - blmpop.md
   - blpop.md
   - brpop.md
   - lmove.md
   - lmpop.md
   - lpushx.md
   - lset.md
   - ltrim.md
   - rpushx.md