### PR TITLE
Add hyperlinks for pub/sub commands

### DIFF
--- a/commands/psubscribe.md
+++ b/commands/psubscribe.md
@@ -8,10 +8,10 @@ Supported glob-style patterns:
 
 Use `\` to escape special characters if you want to match them verbatim.
 
-Once the client enters the subscribed state it is not supposed to issue any other commands, except for additional `SUBSCRIBE`, `SSUBSCRIBE`, `PSUBSCRIBE`, `UNSUBSCRIBE`, `SUNSUBSCRIBE`, `PUNSUBSCRIBE`, `PING`, `RESET` and `QUIT` commands.
-However, if RESP3 is used (see `HELLO`) it is possible for a client to issue any commands while in subscribed state.
+Once the client enters the subscribed state it is not supposed to issue any other commands, except for additional [SUBSCRIBE](subscribe.md), [SSUBSCRIBE](ssubscribe.md), `PSUBSCRIBE`, [UNSUBSCRIBE](unsubscribe.md), [SUNSUBSCRIBE](sunsubscribe.md), [PUNSUBSCRIBE](punsubscribe.md), [PING](ping.md), [RESET](reset.md) and [QUIT](quit.md) commands.
+However, if RESP3 is used (see [HELLO](hello.md)) it is possible for a client to issue any commands while in subscribed state.
 
-Note that `RESET` can be called to exit subscribed state.
+Note that [RESET](reset.md) can be called to exit subscribed state.
 
 For more information, see [Pub/sub](../topics/pubsub.md).
 

--- a/commands/psubscribe.md
+++ b/commands/psubscribe.md
@@ -8,10 +8,10 @@ Supported glob-style patterns:
 
 Use `\` to escape special characters if you want to match them verbatim.
 
-Once the client enters the subscribed state it is not supposed to issue any other commands, except for additional [SUBSCRIBE](subscribe.md), [SSUBSCRIBE](ssubscribe.md), `PSUBSCRIBE`, [UNSUBSCRIBE](unsubscribe.md), [SUNSUBSCRIBE](sunsubscribe.md), [PUNSUBSCRIBE](punsubscribe.md), [PING](ping.md), [RESET](reset.md) and [QUIT](quit.md) commands.
-However, if RESP3 is used (see [HELLO](hello.md)) it is possible for a client to issue any commands while in subscribed state.
+Once the client enters the subscribed state it is not supposed to issue any other commands, except for additional [`SUBSCRIBE`](subscribe.md), [`SSUBSCRIBE`](ssubscribe.md), `PSUBSCRIBE`, [`UNSUBSCRIBE`](unsubscribe.md), [`SUNSUBSCRIBE`](sunsubscribe.md), [`PUNSUBSCRIBE`](punsubscribe.md), [`PING`](ping.md), [`RESET`](reset.md) and [`QUIT`](quit.md) commands.
+However, if RESP3 is used (see [`HELLO`](hello.md)) it is possible for a client to issue any commands while in subscribed state.
 
-Note that [RESET](reset.md) can be called to exit subscribed state.
+Note that [`RESET`](reset.md) can be called to exit subscribed state.
 
 For more information, see [Pub/sub](../topics/pubsub.md).
 

--- a/commands/pubsub-channels.md
+++ b/commands/pubsub-channels.md
@@ -4,4 +4,4 @@ An active channel is a Pub/Sub channel with one or more subscribers (excluding c
 
 If no `pattern` is specified, all the channels are listed, otherwise if pattern is specified only channels matching the specified glob-style pattern are listed.
 
-Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, [PUBSUB](pubsub.md)'s replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, the replies from [PUBSUB](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.

--- a/commands/pubsub-channels.md
+++ b/commands/pubsub-channels.md
@@ -4,4 +4,4 @@ An active channel is a Pub/Sub channel with one or more subscribers (excluding c
 
 If no `pattern` is specified, all the channels are listed, otherwise if pattern is specified only channels matching the specified glob-style pattern are listed.
 
-Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, `PUBSUB`'s replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, [PUBSUB](pubsub.md)'s replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.

--- a/commands/pubsub-channels.md
+++ b/commands/pubsub-channels.md
@@ -4,4 +4,4 @@ An active channel is a Pub/Sub channel with one or more subscribers (excluding c
 
 If no `pattern` is specified, all the channels are listed, otherwise if pattern is specified only channels matching the specified glob-style pattern are listed.
 
-Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, the replies from [PUBSUB](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, the replies from [`PUBSUB`](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.

--- a/commands/pubsub-numpat.md
+++ b/commands/pubsub-numpat.md
@@ -1,5 +1,5 @@
-Returns the number of unique patterns that are subscribed to by clients (that are performed using the `PSUBSCRIBE` command).
+Returns the number of unique patterns that are subscribed to by clients (that are performed using the [PSUBSCRIBE](psubscribe.md) command).
 
 Note that this isn't the count of clients subscribed to patterns, but the total number of unique patterns all the clients are subscribed to.
 
-Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, `PUBSUB`'s replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, [PUBSUB's](pubsub.md) replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.

--- a/commands/pubsub-numpat.md
+++ b/commands/pubsub-numpat.md
@@ -2,4 +2,4 @@ Returns the number of unique patterns that are subscribed to by clients (that ar
 
 Note that this isn't the count of clients subscribed to patterns, but the total number of unique patterns all the clients are subscribed to.
 
-Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, [PUBSUB's](pubsub.md) replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, the replies from [PUBSUB](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.

--- a/commands/pubsub-numpat.md
+++ b/commands/pubsub-numpat.md
@@ -1,5 +1,5 @@
-Returns the number of unique patterns that are subscribed to by clients (that are performed using the [PSUBSCRIBE](psubscribe.md) command).
+Returns the number of unique patterns that are subscribed to by clients (that are performed using the [`PSUBSCRIBE`](psubscribe.md) command).
 
 Note that this isn't the count of clients subscribed to patterns, but the total number of unique patterns all the clients are subscribed to.
 
-Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, the replies from [PUBSUB](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, the replies from [`PUBSUB`](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.

--- a/commands/pubsub-numsub.md
+++ b/commands/pubsub-numsub.md
@@ -2,4 +2,4 @@ Returns the number of subscribers (exclusive of clients subscribed to patterns) 
 
 Note that it is valid to call this command without channels. In this case it will just return an empty list.
 
-Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, [PUBSUB's](pubsub.md) replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, the replies from [PUBSUB](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.

--- a/commands/pubsub-numsub.md
+++ b/commands/pubsub-numsub.md
@@ -2,4 +2,4 @@ Returns the number of subscribers (exclusive of clients subscribed to patterns) 
 
 Note that it is valid to call this command without channels. In this case it will just return an empty list.
 
-Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, `PUBSUB`'s replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, [PUBSUB's](pubsub.md) replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.

--- a/commands/pubsub-numsub.md
+++ b/commands/pubsub-numsub.md
@@ -2,4 +2,4 @@ Returns the number of subscribers (exclusive of clients subscribed to patterns) 
 
 Note that it is valid to call this command without channels. In this case it will just return an empty list.
 
-Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, the replies from [PUBSUB](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster clients can subscribe to every node, and can also publish to every other node. The cluster will make sure that published messages are forwarded as needed. That said, the replies from [`PUBSUB`](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.

--- a/commands/pubsub-shardnumsub.md
+++ b/commands/pubsub-shardnumsub.md
@@ -2,7 +2,7 @@ Returns the number of subscribers for the specified shard channels.
 
 Note that it is valid to call this command without channels, in this case it will just return an empty list.
 
-Cluster note: in a Valkey Cluster, `PUBSUB`'s replies in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster, the replies from [PUBSUB](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
 
 ## Examples
 

--- a/commands/pubsub-shardnumsub.md
+++ b/commands/pubsub-shardnumsub.md
@@ -2,7 +2,7 @@ Returns the number of subscribers for the specified shard channels.
 
 Note that it is valid to call this command without channels, in this case it will just return an empty list.
 
-Cluster note: in a Valkey Cluster, the replies from [PUBSUB](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
+Cluster note: in a Valkey Cluster, the replies from [`PUBSUB`](pubsub.md) in a cluster only report information from the node's Pub/Sub context, rather than the entire cluster.
 
 ## Examples
 

--- a/commands/pubsub.md
+++ b/commands/pubsub.md
@@ -1,3 +1,3 @@
 This is a container command for Pub/Sub introspection commands.
 
-To see the list of available commands you can call `PUBSUB HELP`.
+To see the list of available commands you can call [PUBSUB HELP](pubsub-help.md).

--- a/commands/pubsub.md
+++ b/commands/pubsub.md
@@ -1,3 +1,3 @@
 This is a container command for Pub/Sub introspection commands.
 
-To see the list of available commands you can call [PUBSUB HELP](pubsub-help.md).
+To see the list of available commands you can call [`PUBSUB HELP`](pubsub-help.md).

--- a/commands/subscribe.md
+++ b/commands/subscribe.md
@@ -1,11 +1,11 @@
 Subscribes the client to the specified channels.
 
 Once the client enters the subscribed state it is not supposed to issue any
-other commands, except for additional `SUBSCRIBE`, `SSUBSCRIBE`, `PSUBSCRIBE`, `UNSUBSCRIBE`, `SUNSUBSCRIBE`, 
-`PUNSUBSCRIBE`, `PING`, `RESET` and `QUIT` commands.
-However, if RESP3 is used (see `HELLO`) it is possible for a client to issue any commands while in subscribed state.
+other commands, except for additional `SUBSCRIBE`, [SSUBSCRIBE](ssubscribe.md), [PSUBSCRIBE](psubscribe.md), [UNSUBSCRIBE](unsubscribe.md), [SUNSUBSCRIBE](sunsubscribe.md), 
+[PUNSUBSCRIBE](punsubscribe.md), [PING](ping.md), [RESET](reset.md) and [QUIT](quit.md) commands.
+However, if RESP3 is used (see [HELLO](hello.md)) it is possible for a client to issue any commands while in subscribed state.
 
-Note that `RESET` can be called to exit subscribed state.
+Note that [RESET](reset.md) can be called to exit subscribed state.
 
 For more information, see [Pub/sub](../topics/pubsub.md).
 

--- a/commands/subscribe.md
+++ b/commands/subscribe.md
@@ -1,11 +1,11 @@
 Subscribes the client to the specified channels.
 
 Once the client enters the subscribed state it is not supposed to issue any
-other commands, except for additional `SUBSCRIBE`, [SSUBSCRIBE](ssubscribe.md), [PSUBSCRIBE](psubscribe.md), [UNSUBSCRIBE](unsubscribe.md), [SUNSUBSCRIBE](sunsubscribe.md), 
-[PUNSUBSCRIBE](punsubscribe.md), [PING](ping.md), [RESET](reset.md) and [QUIT](quit.md) commands.
-However, if RESP3 is used (see [HELLO](hello.md)) it is possible for a client to issue any commands while in subscribed state.
+other commands, except for additional `SUBSCRIBE`, [`SSUBSCRIBE`](ssubscribe.md), [`PSUBSCRIBE`](psubscribe.md), [`UNSUBSCRIBE`](unsubscribe.md), [`SUNSUBSCRIBE`](sunsubscribe.md), 
+[`PUNSUBSCRIBE`](punsubscribe.md), [`PING`](ping.md), [`RESET`](reset.md) and [`QUIT`](quit.md) commands.
+However, if RESP3 is used (see [`HELLO`](hello.md)) it is possible for a client to issue any commands while in subscribed state.
 
-Note that [RESET](reset.md) can be called to exit subscribed state.
+Note that [`RESET`](reset.md) can be called to exit subscribed state.
 
 For more information, see [Pub/sub](../topics/pubsub.md).
 


### PR DESCRIPTION
Added hyperlinks in the following pub/sub command files:

- psubscribe.md
- pubsub.md
- pubsub-channels.md
- pubsub-numpat.md
- pubsub-numsub.md
- pubsub-shardnumsub.md
- subscribe.md

Slightly reword sentence as spell check did not link PUBSUB's as a link text.

#294 part 6