### PR TITLE
Add hyperlinks in Valkey server-side scripting and function command files

### DIFF
--- a/commands/eval.md
+++ b/commands/eval.md
@@ -15,8 +15,8 @@ Scripts **should never** access keys with programmatically-generated names or ba
 **Note:**
 in some cases, users will abuse Lua EVAL by embedding values in the script instead of providing them as argument, and thus generating a different script on each call to EVAL.
 These are added to the Lua interpreter and cached to valkey-server, consuming a large amount of memory over time.
-Starting from Valkey 8.0, scripts loaded with `EVAL` or `EVAL_RO` will be deleted from Valkey after a certain number (least recently used order).
-The number of evicted scripts can be viewed through `INFO`'s `evicted_scripts`.
+Starting from Valkey 8.0, scripts loaded with `EVAL` or [EVAL_RO](eval_ro.md) will be deleted from Valkey after a certain number (least recently used order).
+The number of evicted scripts can be viewed through the `evicted_scripts` parameter in the `stats` section of the [INFO](info.md) command.
 
 Please refer to the [Valkey Programmability](../topics/programmability.md) and [Introduction to Eval Scripts](../topics/eval-intro.md) for more information about Lua scripts.
 

--- a/commands/eval.md
+++ b/commands/eval.md
@@ -15,8 +15,8 @@ Scripts **should never** access keys with programmatically-generated names or ba
 **Note:**
 in some cases, users will abuse Lua EVAL by embedding values in the script instead of providing them as argument, and thus generating a different script on each call to EVAL.
 These are added to the Lua interpreter and cached to valkey-server, consuming a large amount of memory over time.
-Starting from Valkey 8.0, scripts loaded with `EVAL` or [EVAL_RO](eval_ro.md) will be deleted from Valkey after a certain number (least recently used order).
-The number of evicted scripts can be viewed through the `evicted_scripts` parameter in the `stats` section of the [INFO](info.md) command.
+Starting from Valkey 8.0, scripts loaded with `EVAL` or [`EVAL_RO`](eval_ro.md) will be deleted from Valkey after a certain number (least recently used order).
+The number of evicted scripts can be viewed through the `evicted_scripts` parameter in the `stats` section of the [`INFO`](info.md) command.
 
 Please refer to the [Valkey Programmability](../topics/programmability.md) and [Introduction to Eval Scripts](../topics/eval-intro.md) for more information about Lua scripts.
 

--- a/commands/eval.md
+++ b/commands/eval.md
@@ -16,7 +16,7 @@ Scripts **should never** access keys with programmatically-generated names or ba
 in some cases, users will abuse Lua EVAL by embedding values in the script instead of providing them as argument, and thus generating a different script on each call to EVAL.
 These are added to the Lua interpreter and cached to valkey-server, consuming a large amount of memory over time.
 Starting from Valkey 8.0, scripts loaded with `EVAL` or [`EVAL_RO`](eval_ro.md) will be deleted from Valkey after a certain number (least recently used order).
-The number of evicted scripts can be viewed through the `evicted_scripts` parameter in the `stats` section of the [`INFO`](info.md) command.
+The number of evicted scripts can be viewed through the `evicted_scripts` field in the `stats` section of the [`INFO`](info.md) command.
 
 Please refer to the [Valkey Programmability](../topics/programmability.md) and [Introduction to Eval Scripts](../topics/eval-intro.md) for more information about Lua scripts.
 

--- a/commands/eval_ro.md
+++ b/commands/eval_ro.md
@@ -1,4 +1,4 @@
-This is a read-only variant of the `EVAL` command that cannot execute commands that modify data.
+This is a read-only variant of the [EVAL](eval.md) command that cannot execute commands that modify data.
 
 For more information about when to use this command vs `EVAL`, please refer to [Read-only scripts](../topics/programmability.md#read-only-scripts).
 

--- a/commands/eval_ro.md
+++ b/commands/eval_ro.md
@@ -1,4 +1,4 @@
-This is a read-only variant of the [EVAL](eval.md) command that cannot execute commands that modify data.
+This is a read-only variant of the [`EVAL`](eval.md) command that cannot execute commands that modify data.
 
 For more information about when to use this command vs `EVAL`, please refer to [Read-only scripts](../topics/programmability.md#read-only-scripts).
 

--- a/commands/evalsha.md
+++ b/commands/evalsha.md
@@ -1,6 +1,6 @@
 Evaluate a script from the server's cache by its SHA1 digest.
 
-The server caches scripts by using the `SCRIPT LOAD` command.
-The command is otherwise identical to `EVAL`.
+The server caches scripts by using the [SCRIPT LOAD](script-load.md) command.
+The command is otherwise identical to [EVAL](eval.md).
 
 Please refer to the [Valkey Programmability](../topics/programmability.md) and [Introduction to Eval Scripts](../topics/eval-intro.md) for more information about Lua scripts.

--- a/commands/evalsha.md
+++ b/commands/evalsha.md
@@ -1,6 +1,6 @@
 Evaluate a script from the server's cache by its SHA1 digest.
 
-The server caches scripts by using the [SCRIPT LOAD](script-load.md) command.
-The command is otherwise identical to [EVAL](eval.md).
+The server caches scripts by using the [`SCRIPT LOAD`](script-load.md) command.
+The command is otherwise identical to [`EVAL`](eval.md).
 
 Please refer to the [Valkey Programmability](../topics/programmability.md) and [Introduction to Eval Scripts](../topics/eval-intro.md) for more information about Lua scripts.

--- a/commands/evalsha_ro.md
+++ b/commands/evalsha_ro.md
@@ -1,4 +1,4 @@
-This is a read-only variant of the `EVALSHA` command that cannot execute commands that modify data.
+This is a read-only variant of the [EVALSHA](evalsha.md) command that cannot execute commands that modify data.
 
 For more information about when to use this command vs `EVALSHA`, please refer to [Read-only scripts](../topics/programmability.md#read-only-scripts).
 

--- a/commands/evalsha_ro.md
+++ b/commands/evalsha_ro.md
@@ -1,5 +1,5 @@
-This is a read-only variant of the [EVALSHA](evalsha.md) command that cannot execute commands that modify data.
+This is a read-only variant of the [`EVALSHA`](evalsha.md) command that cannot execute commands that modify data.
 
 For more information about when to use this command vs `EVALSHA`, please refer to [Read-only scripts](../topics/programmability.md#read-only-scripts).
 
-For more information about `EVALSHA` scripts please refer to [Introduction to Eval Scripts](../topics/eval-intro.md).
+For more information about `EVALSHA` scripts, please refer to [Introduction to Eval Scripts](../topics/eval-intro.md).

--- a/commands/fcall.md
+++ b/commands/fcall.md
@@ -1,6 +1,6 @@
 Invoke a function.
 
-Functions are loaded to the server with the `FUNCTION LOAD` command.
+Functions are loaded to the server with the [FUNCTION LOAD](function-load.md) command.
 The first argument is the name of a loaded function.
 
 The second argument is the number of input key name arguments, followed by all the keys accessed by the function.

--- a/commands/fcall.md
+++ b/commands/fcall.md
@@ -1,6 +1,6 @@
 Invoke a function.
 
-Functions are loaded to the server with the [FUNCTION LOAD](function-load.md) command.
+Functions are loaded to the server with the [`FUNCTION LOAD`](function-load.md) command.
 The first argument is the name of a loaded function.
 
 The second argument is the number of input key name arguments, followed by all the keys accessed by the function.

--- a/commands/fcall_ro.md
+++ b/commands/fcall_ro.md
@@ -1,4 +1,4 @@
-This is a read-only variant of the `FCALL` command that cannot execute commands that modify data.
+This is a read-only variant of the [FCALL](fcall.md) command that cannot execute commands that modify data.
 
 For more information about when to use this command vs `FCALL`, please refer to [Read-only scripts](../topics/programmability.md#read-only_scripts).
 

--- a/commands/fcall_ro.md
+++ b/commands/fcall_ro.md
@@ -1,4 +1,4 @@
-This is a read-only variant of the [FCALL](fcall.md) command that cannot execute commands that modify data.
+This is a read-only variant of the [`FCALL`](fcall.md) command that cannot execute commands that modify data.
 
 For more information about when to use this command vs `FCALL`, please refer to [Read-only scripts](../topics/programmability.md#read-only_scripts).
 

--- a/commands/function-dump.md
+++ b/commands/function-dump.md
@@ -1,11 +1,11 @@
 Return the serialized payload of loaded libraries.
-You can restore the serialized payload later with the `FUNCTION RESTORE` command.
+You can restore the serialized payload later with the [FUNCTION RESTORE](function-restore.md) command.
 
 For more information please refer to [Introduction to Valkey Functions](../topics/functions-intro.md).
 
 ## Examples
 
-The following example shows how to dump loaded libraries using `FUNCTION DUMP` and then it calls `FUNCTION FLUSH` deletes all the libraries.
+The following example shows how to dump loaded libraries using `FUNCTION DUMP` and then it calls [FUNCTION FLUSH](function-flush.md) deletes all the libraries.
 Then, it restores the original libraries from the serialized payload with `FUNCTION RESTORE`.
 
 ```

--- a/commands/function-dump.md
+++ b/commands/function-dump.md
@@ -1,11 +1,11 @@
 Return the serialized payload of loaded libraries.
-You can restore the serialized payload later with the [FUNCTION RESTORE](function-restore.md) command.
+You can restore the serialized payload later with the [`FUNCTION RESTORE`](function-restore.md) command.
 
 For more information please refer to [Introduction to Valkey Functions](../topics/functions-intro.md).
 
 ## Examples
 
-The following example shows how to dump loaded libraries using `FUNCTION DUMP` and then it calls [FUNCTION FLUSH](function-flush.md) deletes all the libraries.
+The following example shows how to dump loaded libraries using `FUNCTION DUMP` and then it calls [`FUNCTION FLUSH`](function-flush.md) deletes all the libraries.
 Then, it restores the original libraries from the serialized payload with `FUNCTION RESTORE`.
 
 ```

--- a/commands/function-load.md
+++ b/commands/function-load.md
@@ -1,11 +1,11 @@
 Load a library to Valkey.
 
-The command's gets a single mandatory parameter which is the source code that implements the library.
+The command receives a single mandatory parameter which is the source code that implements the library.
 The library payload must start with Shebang statement that provides a metadata about the library (like the engine to use and the library name).
 Shebang format: `#!<engine name> name=<library name>`. Currently engine name must be `lua`.
 
 For the Lua engine, the implementation should declare one or more entry points to the library with the [`server.register_function()` API](../topics/lua-api.md#server.register_function).
-Once loaded, you can call the functions in the library with the `FCALL` (or `FCALL_RO` when applicable) command.
+Once loaded, you can call the functions in the library with the [FCALL](fcall.md) (or [FCALL_RO](fcall_ro.md) when applicable) command.
 
 When attempting to load a library with a name that already exists, the Valkey server returns an error.
 The `REPLACE` modifier changes this behavior and overwrites the existing library with the new contents.

--- a/commands/function-load.md
+++ b/commands/function-load.md
@@ -5,7 +5,7 @@ The library payload must start with Shebang statement that provides a metadata a
 Shebang format: `#!<engine name> name=<library name>`. Currently engine name must be `lua`.
 
 For the Lua engine, the implementation should declare one or more entry points to the library with the [`server.register_function()` API](../topics/lua-api.md#server.register_function).
-Once loaded, you can call the functions in the library with the [FCALL](fcall.md) (or [FCALL_RO](fcall_ro.md) when applicable) command.
+Once loaded, you can call the functions in the library with the [`FCALL`](fcall.md) (or [`FCALL_RO`](fcall_ro.md) when applicable) command.
 
 When attempting to load a library with a name that already exists, the Valkey server returns an error.
 The `REPLACE` modifier changes this behavior and overwrites the existing library with the new contents.

--- a/commands/function-stats.md
+++ b/commands/function-stats.md
@@ -12,6 +12,6 @@ The reply is map with two keys:
    Engine map contains statistics about the engine like number of functions and number of libraries.
 
 
-You can use this command to inspect the invocation of a long-running function and decide whether kill it with the `FUNCTION KILL` command.
+You can use this command to inspect the invocation of a long-running function and decide whether kill it with the [FUNCTION KILL](function-kill.md) command.
 
 For more information please refer to [Introduction to Valkey Functions](../topics/functions-intro.md).

--- a/commands/function-stats.md
+++ b/commands/function-stats.md
@@ -12,6 +12,6 @@ The reply is map with two keys:
    Engine map contains statistics about the engine like number of functions and number of libraries.
 
 
-You can use this command to inspect the invocation of a long-running function and decide whether kill it with the [FUNCTION KILL](function-kill.md) command.
+You can use this command to inspect the invocation of a long-running function and decide whether kill it with the [`FUNCTION KILL`](function-kill.md) command.
 
 For more information please refer to [Introduction to Valkey Functions](../topics/functions-intro.md).

--- a/commands/function.md
+++ b/commands/function.md
@@ -1,3 +1,3 @@
 This is a container command for function commands.
 
-To see the list of available commands you can call `FUNCTION HELP`.
+To see the list of available commands you can call [FUNCTION HELP](function-help.md).

--- a/commands/function.md
+++ b/commands/function.md
@@ -1,3 +1,3 @@
 This is a container command for function commands.
 
-To see the list of available commands you can call [FUNCTION HELP](function-help.md).
+To see the list of available commands you can call [`FUNCTION HELP`](function-help.md).

--- a/commands/script-debug.md
+++ b/commands/script-debug.md
@@ -1,7 +1,7 @@
-Set the debug mode for subsequent scripts executed with `EVAL`. Valkey includes a
+Set the debug mode for subsequent scripts executed with [EVAL](eval.md). Valkey includes a
 complete Lua debugger, codename LDB, that can be used to make the task of
 writing complex scripts much simpler. In debug mode Valkey acts as a remote
-debugging server and a client, such as `valkey-cli`, can execute scripts step by
+debugging server and a client, such as [valkey-cli](../topics/cli.md), can execute scripts step by
 step, set breakpoints, inspect variables and more - for additional information
 about LDB refer to the [Valkey Lua debugger](../topics/ldb.md) page.
 
@@ -16,7 +16,7 @@ alternative synchronous debug mode blocks the server while the debugging session
 is active and retains all changes to the data set once it ends.
 
 * `YES`. Enable non-blocking asynchronous debugging of Lua scripts (changes are discarded).
-* `!SYNC`. Enable blocking synchronous debugging of Lua scripts (saves changes to data).
+* `SYNC`. Enable blocking synchronous debugging of Lua scripts (saves changes to data).
 * `NO`. Disables scripts debug mode.
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](../topics/eval-intro.md).

--- a/commands/script-debug.md
+++ b/commands/script-debug.md
@@ -1,7 +1,7 @@
 Set the debug mode for subsequent scripts executed with [`EVAL`](eval.md). Valkey includes a
 complete Lua debugger, codename LDB, that can be used to make the task of
 writing complex scripts much simpler. In debug mode Valkey acts as a remote
-debugging server and a client, such as [valkey-cli](../topics/cli.md), can execute scripts step by
+debugging server and a client, such as [`valkey-cli`](../topics/cli.md), can execute scripts step by
 step, set breakpoints, inspect variables and more - for additional information
 about LDB refer to the [Valkey Lua debugger](../topics/ldb.md) page.
 

--- a/commands/script-debug.md
+++ b/commands/script-debug.md
@@ -1,4 +1,4 @@
-Set the debug mode for subsequent scripts executed with [EVAL](eval.md). Valkey includes a
+Set the debug mode for subsequent scripts executed with [`EVAL`](eval.md). Valkey includes a
 complete Lua debugger, codename LDB, that can be used to make the task of
 writing complex scripts much simpler. In debug mode Valkey acts as a remote
 debugging server and a client, such as [valkey-cli](../topics/cli.md), can execute scripts step by

--- a/commands/script-exists.md
+++ b/commands/script-exists.md
@@ -4,8 +4,8 @@ This command accepts one or more SHA1 digests and returns a list of ones or
 zeros to signal if the scripts are already defined or not inside the script
 cache.
 This can be useful before a pipelining operation to ensure that scripts are
-loaded (and if not, to load them using `SCRIPT LOAD`) so that the pipelining
-operation can be performed solely using `EVALSHA` instead of `EVAL` to save
+loaded (and if not, to load them using [SCRIPT LOAD](script-load.md)) so that the pipelining
+operation can be performed solely using [EVALSHA](evalsha.md) instead of [EVAL](eval.md) to save
 bandwidth.
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](../topics/eval-intro.md).

--- a/commands/script-exists.md
+++ b/commands/script-exists.md
@@ -4,8 +4,8 @@ This command accepts one or more SHA1 digests and returns a list of ones or
 zeros to signal if the scripts are already defined or not inside the script
 cache.
 This can be useful before a pipelining operation to ensure that scripts are
-loaded (and if not, to load them using [SCRIPT LOAD](script-load.md)) so that the pipelining
-operation can be performed solely using [EVALSHA](evalsha.md) instead of [EVAL](eval.md) to save
+loaded (and if not, to load them using [`SCRIPT LOAD`](script-load.md)) so that the pipelining
+operation can be performed solely using [`EVALSHA`](evalsha.md) instead of [`EVAL`](eval.md) to save
 bandwidth.
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](../topics/eval-intro.md).

--- a/commands/script-flush.md
+++ b/commands/script-flush.md
@@ -6,6 +6,6 @@ Setting the **lazyfree-lazy-user-flush** configuration directive to "yes" change
 It is possible to use one of the following modifiers to dictate the flushing mode explicitly:
 
 * `ASYNC`: flushes the cache asynchronously
-* `!SYNC`: flushes the cache synchronously
+* `SYNC`: flushes the cache synchronously
 
 For more information about `EVAL` scripts please refer to [Introduction to Eval Scripts](../topics/eval-intro.md).

--- a/commands/script-kill.md
+++ b/commands/script-kill.md
@@ -1,4 +1,4 @@
-Kills the currently executing `EVAL` script, assuming no write operation was yet
+Kills the currently executing [EVAL](eval.md) script, assuming no write operation was yet
 performed by the script.
 
 This command is mainly useful to kill a script that is running for too much
@@ -8,7 +8,7 @@ the command returning with an error.
 
 If the script has already performed write operations, it can not be killed in this
 way because it would violate Lua's script atomicity contract.
-In such a case, only `SHUTDOWN NOSAVE` can kill the script, killing
+In such a case, only [SHUTDOWN NOSAVE](shutdown.md) can kill the script, killing
 the Valkey process in a hard way and preventing it from persisting with half-written
 information.
 

--- a/commands/script-kill.md
+++ b/commands/script-kill.md
@@ -1,4 +1,4 @@
-Kills the currently executing [EVAL](eval.md) script, assuming no write operation was yet
+Kills the currently executing [`EVAL`](eval.md) script, assuming no write operation was yet
 performed by the script.
 
 This command is mainly useful to kill a script that is running for too much
@@ -8,7 +8,7 @@ the command returning with an error.
 
 If the script has already performed write operations, it can not be killed in this
 way because it would violate Lua's script atomicity contract.
-In such a case, only [SHUTDOWN NOSAVE](shutdown.md) can kill the script, killing
+In such a case, only [`SHUTDOWN NOSAVE`](shutdown.md) can kill the script, killing
 the Valkey process in a hard way and preventing it from persisting with half-written
 information.
 

--- a/commands/script-load.md
+++ b/commands/script-load.md
@@ -1,10 +1,10 @@
 Load a script into the scripts cache, without executing it.
 After the specified command is loaded into the script cache it will be callable
-using `EVALSHA` with the correct SHA1 digest of the script, exactly like after
-the first successful invocation of `EVAL`.
+using [EVALSHA](evalsha.md) with the correct SHA1 digest of the script, exactly like after
+the first successful invocation of [EVAL](eval.md).
 
-The script is guaranteed to stay in the script cache forever (unless `SCRIPT
-FLUSH` is called).
+The script is guaranteed to stay in the script cache forever (unless [SCRIPT
+FLUSH](script-flush.md) is called).
 
 The command works in the same way even if the script was already present in the
 script cache.

--- a/commands/script-load.md
+++ b/commands/script-load.md
@@ -1,10 +1,10 @@
 Load a script into the scripts cache, without executing it.
 After the specified command is loaded into the script cache it will be callable
-using [EVALSHA](evalsha.md) with the correct SHA1 digest of the script, exactly like after
-the first successful invocation of [EVAL](eval.md).
+using [`EVALSHA`](evalsha.md) with the correct SHA1 digest of the script, exactly like after
+the first successful invocation of [`EVAL`](eval.md).
 
-The script is guaranteed to stay in the script cache forever (unless [SCRIPT
-FLUSH](script-flush.md) is called).
+The script is guaranteed to stay in the script cache forever (unless [`SCRIPT
+FLUSH`](script-flush.md) is called).
 
 The command works in the same way even if the script was already present in the
 script cache.

--- a/commands/script.md
+++ b/commands/script.md
@@ -1,3 +1,3 @@
 This is a container command for script management commands.
 
-To see the list of available commands you can call `SCRIPT HELP`.
+To see the list of available commands you can call [SCRIPT HELP](script-help.md).

--- a/commands/script.md
+++ b/commands/script.md
@@ -1,3 +1,3 @@
 This is a container command for script management commands.
 
-To see the list of available commands you can call [SCRIPT HELP](script-help.md).
+To see the list of available commands you can call [`SCRIPT HELP`](script-help.md).


### PR DESCRIPTION
Hyperlinks were added into the following Valkey server-side scripting and function command files:
- eval.md
- evalsha.md
- evalsha_ro.md
- eval_ro.md
- fcall.md
- fcall_ro.md
- function.md
- function-dump.md
- function-load.md
- function-stats.md
- script.md
- script-debug.md
- script-exists.md
- script-flush.md
- script-kill.md
- script-load.md

#294 part 7