### PR TITLE
Update the query commands in SELECT logical databases

### DIFF
--- a/commands/select.md
+++ b/commands/select.md
@@ -7,4 +7,6 @@ In practical terms, Valkey databases should be used to separate different keys b
 
 Valkey 9.0 and later supports multiple databases in cluster mode. You can use `SELECT <dbid>`  to switch between them.
 
-Since the currently selected database is a property of the connection, clients should track the currently selected database and re-select it on reconnection. While there is no command in order to query the selected database in the current connection, the `CLIENT LIST` output shows, for each client, the currently selected database.
+Since the currently selected database is a property of the connection, clients should track the currently selected database and re-select it on reconnection.
+
+While there is no dedicated command to query the currently selected database for a connection, you can infer it from the output of `CLIENT LIST` or `CLIENT INFO`, where each client entry includes the `db=N` field indicating the selected database.


### PR DESCRIPTION
Fixes #323.

Split the last paragraph into two, and updated the now new last paragraph with `CLIENT LIST` and `CLIENT INFO` which include database querying, clarified that these commands expose it via `db=N`.
