### PR TITLE
Add 'schema' to Releases and versioning title

### DIFF
--- a/topics/releases.md
+++ b/topics/releases.md
@@ -1,5 +1,5 @@
 ---
-title: "Releases and versioning"
+title: "Releases and versioning schema"
 description: How new versions of Valkey are released and supported
 ---
 


### PR DESCRIPTION
This fixes issue #306 by adding schema to the `Documentation: Releases and versioning` page