### PR TITLE
Add max-rand-count info to HRANDFIELD/ZRANDMEMBER/SRANDMEMBER

### DIFF
--- a/commands/hrandfield.md
+++ b/commands/hrandfield.md
@@ -43,3 +43,7 @@ When the `count` is a negative value, the behavior changes as follows:
 * Repeating fields are possible.
 * Exactly `count` fields, or an empty array if the hash is empty (non-existing key), are always returned.
 * The order of fields in the reply is truly random.
+
+## Count limits
+
+The `count` argument is limited by the `max-rand-count` configuration parameter. If the absolute value of `count` exceeds this limit, the command will return an error. The default limit is `LONG_MAX/2` to prevent integer overflow when using the `WITHVALUES` option.

--- a/commands/srandmember.md
+++ b/commands/srandmember.md
@@ -37,3 +37,7 @@ When the `count` is a negative value, the behavior changes as follows:
 * Repeating elements are possible.
 * Exactly `count` elements, or an empty array if the set is empty (non-existing key), are always returned.
 * The order of elements in the reply is truly random.
+
+## Count limits
+
+The `count` argument is limited by the `max-rand-count` configuration parameter. If the absolute value of `count` exceeds this limit, the command will return an error. The default limit is `LONG_MAX/2` to prevent potential memory issues.

--- a/commands/zrandmember.md
+++ b/commands/zrandmember.md
@@ -43,3 +43,7 @@ When the `count` is a negative value, the behavior changes as follows:
 * Repeating elements are possible.
 * Exactly `count` elements, or an empty array if the sorted set is empty (non-existing key), are always returned.
 * The order of elements in the reply is truly random.
+
+## Count limits
+
+The `count` argument is limited by the `max-rand-count` configuration parameter. If the absolute value of `count` exceeds this limit, the command will return an error. The default limit is `LONG_MAX/2` to prevent integer overflow when using the `WITHSCORES` option.


### PR DESCRIPTION
For changes from https://github.com/valkey-io/valkey/pull/2390.

This PR adds documentation about the max-rand-count configuration parameter limit for the random member selection commands (`HRANDFIELD`, `SRANDMEMBER`, and `ZRANDMEMBER`). The limit prevents potential issues with large count values and defaults to `LONG_MAX/2`. This affects commands when using count parameters to prevent integer overflow and memory issues.

Changes made to:

- `hrandfield.md`
- `srandmember.md`
- `zrandmember.md`