### PR TITLE
Fix valkey-compat package name and info

### DIFF
--- a/topics/installation.md
+++ b/topics/installation.md
@@ -78,7 +78,7 @@ sudo apk add valkey-compat
 ```bash
 sudo yum install valkey
 # For symlinked binaries to redis-cli and redis-server
-sudo yum install valkey-compat
+sudo yum install valkey-compat-redis
 # For valkey-doc (can be used with man, e.g. `man hgetall`, `man valkey.conf`, etc.)
 sudo yum install valkey-doc
 ```
@@ -91,7 +91,7 @@ You can use the EPEL repository - https://fedoraproject.org/wiki/EPEL to install
 ```bash
 sudo dnf install valkey
 # For symlinked binaries to redis-cli and redis-server
-sudo dnf install valkey-compat
+sudo dnf install valkey-compat-redis
 # For valkey-doc (can be used with man, e.g. `man hgetall`, `man valkey.conf`, etc.)
 sudo dnf install valkey-doc
 ```


### PR DESCRIPTION
The name of the package for symlinked binaries with redis is wrong in a couple of spots. This PR fixes the wrong names and modify a comment a little for improved clarity.

**Debian/Ubuntu**:
1. The name of the package on Ubuntu is `valkey-redis-compat`, not `valkey-compat`
2. It is only available on Ubuntu and not on Debian (v13/trixie doesn't have it)
3. It doesn't symlink `redis-server` but only `redis-cli`, `redis-benchmark`, `redis-check-aof`, `redis-check-rdb`

**RHEL/Fedora**:
1. The name of the package on Fedora is `valkey-compat-redis`, not `valkey-compat`
2. Not sure if it still makes sense to mention CentOS, but I didn't change anything

**Alpine**: All correct ✅ 

## Demonstration

#### Ubuntu 25.10

```
root@6594d840c00d:/# grep -E '^ID=|^VERSION=' /etc/os-release
VERSION="25.10 (Questing Quokka)"
ID=ubuntu

root@6594d840c00d:/# apt-cache search valkey
php-predis - A flexible and feature-complete Redis/Valkey client for PHP
prometheus-redis-exporter - Prometheus exporter for Valkey metrics (Redis-compatible)
valkey-redis-compat - Conversion script and compatibility symlinks for Redis          # <---
valkey-sentinel - Persistent key-value database with network interface (monitoring)
valkey-server - Persistent key-value database with network interface
valkey-tools - Persistent key-value database with network interface (client)

root@6594d840c00d:/# apt-file list valkey-redis-compat
valkey-redis-compat: /usr/bin/redis-benchmark
valkey-redis-compat: /usr/bin/redis-check-aof
valkey-redis-compat: /usr/bin/redis-check-rdb
valkey-redis-compat: /usr/bin/redis-cli
valkey-redis-compat: /usr/share/doc/valkey-redis-compat/00-RELEASENOTES.gz
valkey-redis-compat: /usr/share/doc/valkey-redis-compat/NEWS.Debian.gz
valkey-redis-compat: /usr/share/doc/valkey-redis-compat/README.Debian
valkey-redis-compat: /usr/share/doc/valkey-redis-compat/changelog.Debian.gz
valkey-redis-compat: /usr/share/doc/valkey-redis-compat/copyright
```

#### Ubuntu 24.04 LTS

```
root@40fab4b9dae7:/# grep -E '^ID=|^VERSION=' /etc/os-release
VERSION="24.04.2 LTS (Noble Numbat)"
ID=ubuntu

root@40fab4b9dae7:/# apt-cache search valkey
valkey-redis-compat - Conversion script and compatibility symlinks for Redis          # <---
valkey-sentinel - Persistent key-value database with network interface (monitoring)
valkey-server - Persistent key-value database with network interface
valkey-tools - Persistent key-value database with network interface (client)
```

#### Debian 13

```
root@1842d16582e1:/# grep -E '^ID=|^VERSION=' /etc/os-release
VERSION="13 (trixie)"
ID=debian

root@1842d16582e1:/# apt-cache search valkey
php-predis - A flexible and feature-complete Redis/Valkey client for PHP
prometheus-redis-exporter - Prometheus exporter for Valkey metrics (Redis-compatible)
valkey-sentinel - Persistent key-value database with network interface (monitoring)
valkey-server - Persistent key-value database with network interface
valkey-tools - Persistent key-value database with network interface (client)
```

---

#### Fedora 42

```
[root@2ff9151a0613 /]# grep -E '^ID=|^VERSION=' /etc/os-release
VERSION="42 (Container Image)"
ID=fedora

[root@2ff9151a0613 /]# dnf search valkey
Updating and loading repositories:
Repositories loaded.
Matched fields: name (exact)
 valkey.aarch64	A persistent key-value database
Matched fields: name, summary
 python3-valkey.noarch	The Python interface to the Valkey key-value store
 valkey-compat-redis-devel.noarch	Compatibility development header for Redis API Valkey modules
 valkey-devel.aarch64	Development header for Valkey module development
 valkey-doc.noarch	Documentation and extra man pages for valkey
Matched fields: name
 valkey-compat-redis.noarch	Conversion script and compatibility symlinks for Redis    # <---

[root@2ff9151a0613 /]# dnf repoquery --list valkey-compat-redis
Updating and loading repositories:
Repositories loaded.
/usr/bin/redis-benchmark
/usr/bin/redis-check-aof
/usr/bin/redis-check-rdb
/usr/bin/redis-cli
/usr/bin/redis-sentinel
/usr/bin/redis-server
/usr/lib/systemd/system/redis-sentinel.service
/usr/lib/systemd/system/redis.service
/usr/libexec/migrate_redis_to_valkey.sh
```

---

#### Alpine

```
/ # grep -E '^ID=|^VERSION_ID=' /etc/os-release
ID=alpine
VERSION_ID=3.22.1

/ # apk search valkey
valkey-8.1.1-r2
valkey-benchmark-8.1.1-r2
valkey-cli-8.1.1-r2
valkey-compat-8.1.1-r2
valkey-openrc-8.1.1-r2

/ # apk fetch valkey-compat && tar -tf valkey-compat-8.1.1-r2.apk
Downloading valkey-compat-8.1.1-r2
.SIGN.RSA.alpine-devel@lists.alpinelinux.org-616ae350.rsa.pub
.PKGINFO
.pre-install
usr/
usr/bin/
usr/bin/redis-check-aof
usr/bin/redis-check-rdb
usr/bin/redis-cli
usr/bin/redis-sentinel
usr/bin/redis-server
```