### PR TITLE
moves `replaced_by` from command json to markdown

### DIFF
--- a/commands/brpoplpush.md
+++ b/commands/brpoplpush.md
@@ -14,3 +14,7 @@ Please see the pattern description in the `RPOPLPUSH` documentation.
 ## Pattern: Circular list
 
 Please see the pattern description in the `RPOPLPUSH` documentation.
+
+## Alternative
+
+`BLMOVE` with the `RIGHT` and `LEFT` arguments.

--- a/commands/georadius.md
+++ b/commands/georadius.md
@@ -39,6 +39,10 @@ Since `GEORADIUS` and `GEORADIUSBYMEMBER` have a `STORE` and `STOREDIST` option 
 
 Two read-only variants of the commands were added. They are exactly like the original commands but refuse the `STORE` and `STOREDIST` options. The two variants are called `GEORADIUS_RO` and `GEORADIUSBYMEMBER_RO`, and can safely be used in replicas.
 
+## Alternative
+
+`GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` argument.
+
 ## Examples
 
 ```

--- a/commands/georadius_ro.md
+++ b/commands/georadius_ro.md
@@ -1,3 +1,7 @@
 Read-only variant of the `GEORADIUS` command.
 
 This command is identical to the `GEORADIUS` command, except that it doesn't support the optional `STORE` and `STOREDIST` parameters.
+
+## Alternative
+
+`GEOSEARCH` with the `BYRADIUS` argument.

--- a/commands/georadiusbymember.md
+++ b/commands/georadiusbymember.md
@@ -7,6 +7,10 @@ Please check the example below and the `GEORADIUS` documentation for more inform
 
 Note that `GEORADIUSBYMEMBER_RO` was added to provide a read-only command that can be used in replicas. See the `GEORADIUS` page for more information.
 
+## Alternative
+
+`GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` and `FROMMEMBER` arguments.
+
 ## Examples
 
 ```

--- a/commands/georadiusbymember_ro.md
+++ b/commands/georadiusbymember_ro.md
@@ -1,3 +1,7 @@
 Read-only variant of the `GEORADIUSBYMEMBER` command.
 
 This command is identical to the `GEORADIUSBYMEMBER` command, except that it doesn't support the optional `STORE` and `STOREDIST` parameters.
+
+## Alternative
+
+`GEOSEARCH` with the `BYRADIUS` and `FROMMEMBER` arguments.

--- a/commands/getset.md
+++ b/commands/getset.md
@@ -20,6 +20,10 @@ This can be done using `GETSET mycounter "0"`:
 "0"
 ```
 
+## Alternative
+
+`SET` with the `GET` argument.
+
 ## Examples
 
 ```

--- a/commands/hmset.md
+++ b/commands/hmset.md
@@ -3,6 +3,10 @@ Sets the specified fields to their respective values in the hash stored at
 This command overwrites any specified fields already existing in the hash.
 If `key` does not exist, a new key holding a hash is created.
 
+## Alternative
+
+`HSET` with multiple field-value pairs.
+
 ## Examples
 
 ```

--- a/commands/psetex.md
+++ b/commands/psetex.md
@@ -1,6 +1,10 @@
 `PSETEX` works exactly like `SETEX` with the sole difference that the expire
 time is specified in milliseconds instead of seconds.
 
+## Alternative
+
+`SET` with the `PX` argument.
+
 ## Examples
 
 ```

--- a/commands/quit.md
+++ b/commands/quit.md
@@ -5,3 +5,7 @@ client.
 **Note:** Clients should not use this command.
 Instead, clients should simply close the connection when they're not used anymore.
 Terminating a connection on the client side is preferable, as it eliminates `TIME_WAIT` lingering sockets on the server side.
+
+## Alternative
+
+Just closing the connection.

--- a/commands/rpoplpush.md
+++ b/commands/rpoplpush.md
@@ -13,6 +13,10 @@ If `source` and `destination` are the same, the operation is equivalent to
 removing the last element from the list and pushing it as first element of the
 list, so it can be considered as a list rotation command.
 
+## Alternative
+
+`LMOVE` with the `RIGHT` and `LEFT` arguments.
+
 ## Examples
 
 ```

--- a/commands/setex.md
+++ b/commands/setex.md
@@ -8,6 +8,10 @@ SET key value EX seconds
 
 An error is returned when `seconds` is invalid.
 
+## Alternative
+
+`SET` with the `EX` argument.
+
 ## Examples
 
 ```

--- a/commands/setnx.md
+++ b/commands/setnx.md
@@ -3,6 +3,10 @@ In that case, it is equal to `SET`.
 When `key` already holds a value, no operation is performed.
 `SETNX` is short for "**SET** if **N**ot e**X**ists".
 
+## Alternative
+
+`SET` with the `NX` argument.
+
 ## Examples
 
 ```

--- a/commands/slowlog-get.md
+++ b/commands/slowlog-get.md
@@ -20,3 +20,7 @@ Each entry from the slow log is comprised of the following six values:
 The entry's unique ID can be used in order to avoid processing slow log entries multiple times (for instance you may have a script sending you an email alert for every new slow log entry).
 The ID is never reset in the course of the Valkey server execution, only a server
 restart will reset it.
+
+## Alternative
+
+`COMMANDLOG GET <count> SLOW`.

--- a/commands/slowlog-help.md
+++ b/commands/slowlog-help.md
@@ -1,1 +1,5 @@
 The `SLOWLOG HELP` command returns a helpful text describing the different subcommands.
+
+## Alternative
+
+`COMMANDLOG HELP`

--- a/commands/slowlog-len.md
+++ b/commands/slowlog-len.md
@@ -4,3 +4,7 @@ A new entry is added to the slow log whenever a command exceeds the execution ti
 The maximum number of entries in the slow log is governed by the `slowlog-max-len` configuration directive.
 Once the slog log reaches its maximal size, the oldest entry is removed whenever a new entry is created.
 The slow log can be cleared with the `SLOWLOG RESET` command.
+
+## Alternative
+
+`COMMANDLOG LEN SLOW`

--- a/commands/slowlog-reset.md
+++ b/commands/slowlog-reset.md
@@ -1,3 +1,7 @@
 This command resets the slow log, clearing all entries in it.
 
 Once deleted the information is lost forever.
+
+## Alternative
+
+`COMMANDLOG RESET SLOW`

--- a/commands/slowlog.md
+++ b/commands/slowlog.md
@@ -1,3 +1,7 @@
 This is a container command for slow log management commands.
 
 To see the list of available commands you can call `SLOWLOG HELP`.
+
+## Alternative
+
+`COMMANDLOG`

--- a/commands/substr.md
+++ b/commands/substr.md
@@ -7,6 +7,10 @@ So -1 means the last character, -2 the penultimate and so forth.
 The function handles out of range requests by limiting the resulting range to
 the actual length of the string.
 
+## Alternative
+
+`GETRANGE`
+
 ## Examples
 
 ```

--- a/commands/zrangebylex.md
+++ b/commands/zrangebylex.md
@@ -47,6 +47,10 @@ comparison of the numbers. This can be used in order to implement range
 queries on 64 bit values. As in the example below, after the first 8 bytes
 we can store the value of the element we are actually indexing.
 
+## Alternative
+
+`ZRANGE` with the `BYLEX` argument.
+
 ## Examples
 
 ```

--- a/commands/zrangebyscore.md
+++ b/commands/zrangebyscore.md
@@ -39,6 +39,10 @@ ZRANGEBYSCORE zset (5 (10
 
 Will return all the elements with `5 < score < 10` (5 and 10 excluded).
 
+## Alternative
+
+`ZRANGE` with the `BYSCORE` argument.
+
 ## Examples
 
 ```

--- a/commands/zrevrange.md
+++ b/commands/zrevrange.md
@@ -4,6 +4,10 @@ Descending lexicographical order is used for elements with equal score.
 
 Apart from the reversed ordering, `ZREVRANGE` is similar to `ZRANGE`.
 
+## Alternative
+
+`ZRANGE` with the `REV` argument.
+
 ## Examples
 
 ```

--- a/commands/zrevrangebylex.md
+++ b/commands/zrevrangebylex.md
@@ -2,6 +2,10 @@ When all the elements in a sorted set are inserted with the same score, in order
 
 Apart from the reversed ordering, `ZREVRANGEBYLEX` is similar to `ZRANGEBYLEX`.
 
+## Alternative
+
+`ZRANGE` with the `REV` and `BYLEX` arguments.
+
 ## Examples
 
 ```

--- a/commands/zrevrangebyscore.md
+++ b/commands/zrevrangebyscore.md
@@ -9,6 +9,10 @@ order.
 Apart from the reversed ordering, `ZREVRANGEBYSCORE` is similar to
 `ZRANGEBYSCORE`.
 
+## Alternative
+
+`ZRANGE` with the `REV` and `BYSCORE` arguments.
+
 ## Examples
 
 ```


### PR DESCRIPTION
See valkey-io/valkey#2546. 

This moves the `replaced_by` information from the command json files in valkey-io/valkey into the docs for non-deprecated commands.