### PR TITLE
Update valkey-go's client_capa_redirect feature

### DIFF
--- a/clients/go/valkey-go.json
+++ b/clients/go/valkey-go.json
@@ -3,8 +3,8 @@
     "description": "A fast Golang Valkey client that does auto pipelining and supports server-assisted client-side caching.",
     "repo":"https://github.com/valkey-io/valkey-go",
     "installation": "go get github.com/valkey-io/valkey-go",
-    "version": "1.0.55",
-    "version_released":"2025-02-03",
+    "version": "1.0.67",
+    "version_released":"2025-10-12",
     "language":"go",
     "license": "Apache-2.0",
     "read_from_replica": true,
@@ -14,6 +14,6 @@
     "latency_based_read_from_replica": false,
     "AZ_based_read_from_replica": true,
     "client_side_caching": true,
-    "client_capa_redirect": false,
+    "client_capa_redirect": true,
     "persistent_connection_pool": true
 }


### PR DESCRIPTION
Update the client feature table to indicate that the latest valkey-go 1.0.67 supports `Client Capa Redirect` handling.