### PR TITLE
Update the possible values of `context` field in `ACL LOG` command

### DIFF
--- a/commands/acl-log.md
+++ b/commands/acl-log.md
@@ -40,7 +40,7 @@ Each log entry is composed of the following fields:
 
 1. `count`: The number of security events detected within a 60 second period that are represented by this entry.
 2. `reason`: The reason that the security events were logged. Either `command`, `key`, `channel`, or `auth`.
-3. `context`: The context that the security events were detected in. Either `toplevel`, `multi`, `lua`, or `module`.
+3. `context`: The context that the security events were detected in. Either `toplevel`, `multi`, `lua`, `script`, or `module`.
 4. `object`: The resource that the user had insufficient permissions to access. `auth` when the reason is `auth`.
 5. `username`: The username that executed the command that caused the security events or the username that had a failed authentication attempt.
 6. `age-seconds`: Age of the log entry in seconds.


### PR DESCRIPTION
In the recent valkey PR https://github.com/valkey-io/valkey/pull/2798 the possible values for the `context` field returned by the `ACL LOG` command was updated to include the new `script` value.

This commit updates the documentation of the `ACL LOG` command to reflect the recent changes.