### PR TITLE
Add GLIDE website to glide clients and update their latest versions

### DIFF
--- a/clients/go/valkey-GLIDE.json
+++ b/clients/go/valkey-GLIDE.json
@@ -2,6 +2,7 @@
     "name": "valkey GLIDE",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/go",
+    "website": "https://glide.valkey.io/languages/go/",
     "installation": "go get github.com/valkey-io/valkey-glide/go",
     "version":"v2.1.1",
     "version_released":"2025-10-08",

--- a/clients/java/valkey-GLIDE.json
+++ b/clients/java/valkey-GLIDE.json
@@ -2,6 +2,7 @@
     "name": "valkey GLIDE",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/java",
+    "website": "https://glide.valkey.io/languages/java/",
     "installation": [
         {
             "type": "Maven",

--- a/clients/node.js/valkey-GLIDE.json
+++ b/clients/node.js/valkey-GLIDE.json
@@ -2,6 +2,7 @@
     "name": "valkey GLIDE",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/node",
+    "website": "https://glide.valkey.io/languages/nodejs/",
     "installation": "npm install @valkey/valkey-glide",
     "version":"v2.1.1",
     "version_released":"2025-10-08",

--- a/clients/python/valkey-GLIDE.json
+++ b/clients/python/valkey-GLIDE.json
@@ -2,6 +2,7 @@
     "name": "valkey GLIDE",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/python",
+    "website": "https://glide.valkey.io/languages/python/",
     "installation": "pip install valkey-glide",
     "version":"v2.1.1",
     "version_released":"2025-10-08",


### PR DESCRIPTION
## Overview

* Added website links to each of the glide client. 
* Also updated GLIDE version numbers and date to the latest

Note that this requires this [PR](https://github.com/valkey-io/valkey-io.github.io/pull/418) in order to be displayed. 

## Related Issues
https://github.com/valkey-io/valkey-io.github.io/issues/416