### PR TITLE
Improve the doc of replication backlog fields

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -579,9 +579,8 @@ Here is the meaning of all fields in the **replication** section:
 *   `master_repl_offset`: The server's current replication offset
 *   `second_repl_offset`: The offset up to which replication IDs are accepted
 *   `repl_backlog_active`: Flag indicating replication backlog is active
-*   `repl_backlog_size`: Total size in bytes of the replication backlog buffer
-*   `repl_backlog_first_byte_offset`: The primary offset of the replication
-     backlog buffer
+*   `repl_backlog_size`: The value of the replication backlog buffer `repl-backlog-size` configuration item
+*   `repl_backlog_first_byte_offset`: Replication "primary offset" of first byte in the replication backlog buffer
 *   `repl_backlog_histlen`: Size in bytes of the data in the replication backlog
      buffer
 

--- a/commands/memory-stats.md
+++ b/commands/memory-stats.md
@@ -10,8 +10,7 @@ values. The following metrics are reported:
      allocator (see [`INFO`](info.md)'s `used_memory`)
 *   `startup.allocated`: Initial amount of memory consumed by Valkey at startup
      in bytes (see `INFO`'s `used_memory_startup`)
-*   `replication.backlog`: Size in bytes of the replication backlog (see
-     `INFO`'s `repl_backlog_active`)
+*   `replication.backlog`: Memory usage by replication backlog (see `INFO`'s `mem_replication_backlog`)
 *   `clients.slaves`: The total size in bytes of all replicas overheads (output
      and query buffers, connection contexts)
 *   `clients.normal`: The total size in bytes of all clients overheads (output


### PR DESCRIPTION
The `repl_backlog_size` in `INFO REPLICATION` is actually the value
of the `repl-backlog-size` configuration item.

The `replication.backlog` in `MEMORY STATS` is the actual memory usage
of the replication backlog buffer.

In the past, they were the same because we would immediately allocate
the backlog. But after we introduce the global shared replication buffer,
now they have expiressed different meanings.