### PR TITLE
Update cluster-migrateslots doc to mention cluster-cancelslotmigrations

### DIFF
--- a/commands/cluster-migrateslots.md
+++ b/commands/cluster-migrateslots.md
@@ -20,3 +20,5 @@ error message is returned and no slot migrations are initiated.
 
 To check on the progress of the slot migration, use the
 [`CLUSTER GETSLOTMIGRATIONS`](cluster-getslotmigrations.md) command.
+
+To cancel the slot migration jobs, use the [`CLUSTER CANCELSLOTMIGRATIONS`](cluster-cancelslotmigrations.md) command.


### PR DESCRIPTION
It would be helpful that we have this jump when reading the doc.