### PR TITLE
docs: clarify cluster-slot-stats-enabled requirement for CLUSTER SLOT-STATS

### DIFF
--- a/commands/cluster-slot-stats.md
+++ b/commands/cluster-slot-stats.md
@@ -8,6 +8,8 @@ The following statistics are supported:
 * `network-bytes-in` -- Amount of network ingress (in bytes) received for given slot.
 * `network-bytes-out` -- Amount of network egress (in bytes) sent out for given slot.
 
+**Note:** By default, only `key-count` is returned. To enable `cpu-usec`, `network-bytes-in`, and `network-bytes-out` statistics, set `cluster-slot-stats-enabled yes` in the configuration.
+
 ## Options
 
 * `ORDERBY` -- Returns an ordered slot statistics based on the specified statistic and sub-arguments to identify hot / cold slots across the cluster. Either `ASC` or `DESC` modifiers can be used. In the event of a tie in the stats, ascending slot number is used as a tie breaker.


### PR DESCRIPTION
## Summary
Adds a note to the `CLUSTER SLOT-STATS` command documentation clarifying that advanced statistics require the `cluster-slot-stats-enabled` configuration parameter.

## Problem
The current documentation lists four statistics (`key-count`, `cpu-usec`, `network-bytes-in`, `network-bytes-out`) but does not mention that, by default, only `key-count` is returned. Users may be confused when they run the command and only see `key-count` in the output, even though the documentation shows all four metrics in the examples.

## Changes
- Added one sentence note to `commands/cluster-slot-stats.md`
- No changes to examples or other documentation

## Related
This configuration parameter was introduced in Valkey 8.0.0 via PR valkey-io/valkey#720