### PR TITLE
Fix typo in command line option for system check

### DIFF
--- a/topics/server.md
+++ b/topics/server.md
@@ -38,7 +38,7 @@ Additional options:
 **`--test-memory`** _megabytes_
 : Run a memory test and exit.
 
-**`--check-sytem`**
+**`--check-system`**
 : Output some operating system properties relevant for running Valkey and exit.
 
 **`--sentinel`**


### PR DESCRIPTION
Fix document quickstart typo