### PR TITLE
Add note on RDB version import error

### DIFF
--- a/topics/migration.md
+++ b/topics/migration.md
@@ -106,6 +106,8 @@ To perform a physical migration:
 8. Stop the Redis server.
 9. Start Valkey:
    > NOTE: If you enabled AOF in your Valkey configuration, disable it on the first start. Otherwise, the copied RDB file will not be imported into Valkey.
+   
+   > NOTE: Set `rdb-version-check relaxed` for the first start to prevent "RDB format version" errors.
 
    Run the following command:
 


### PR DESCRIPTION
While migrating Redis 8.6.1 to Valkey 9.0.3 on FreeBSD 15.0-p4 amd64, I ran into the following error

```log
6431:M 07 Mar 2026 09:37:43.232 # Can't handle RDB format version 12
````

Document the simple fix.