### PR TITLE
fix(docs): correct LPOP example in lists documentation

### DIFF
--- a/topics/lists.md
+++ b/topics/lists.md
@@ -368,11 +368,11 @@ Example of rule 2:
 127.0.0.1:6379> EXISTS bikes:repairs
 (integer) 1
 127.0.0.1:6379> LPOP bikes:repairs
-"bike:3"
+"bike:1"
 127.0.0.1:6379> LPOP bikes:repairs
 "bike:2"
 127.0.0.1:6379> LPOP bikes:repairs
-"bike:1"
+"bike:3"
 127.0.0.1:6379> EXISTS bikes:repairs
 (integer) 0
 ```


### PR DESCRIPTION
LPOP removes from the head, so the expected output after RPUSH bike:1 bike:2 bike:3 should return bike:1, bike:2, bike:3 in that order, not reverse.