### PR TITLE
Document server_name, valkey_version, and redis_version INFO fields

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -274,8 +274,9 @@ Here is the description of fields.
 
 Here is the meaning of all fields in the **server** section:
 
-*   `redis_version`: Redis OSS version this Valkey server is compatible with
-*   `valkey_version`: Valkey version number (e.g. 7.2.5)
+*   `server_name`: The name of the server software (always `valkey` for Valkey servers). Use this field to distinguish Valkey from Redis OSS. Added in Valkey 7.2.5.
+*   `redis_version`: The Redis OSS version that this Valkey server is compatible with. This value is fixed at `7.2.4` across all Valkey releases to maintain compatibility with existing clients and tools that check this field for feature detection.
+*   `valkey_version`: The actual Valkey version number (e.g. `8.1.1`). Use this field instead of `redis_version` to check the Valkey version.
 *   `valkey_release_stage`: The status of the Valkey version: "ga" for generally available versions; "rc1", "rc2", etc. for release candidates; "dev" for development versions. Added in 8.1.
 *   `redis_git_sha1`:  Git SHA1
 *   `redis_git_dirty`: Git dirty flag

--- a/topics/redis-compatibility.md
+++ b/topics/redis-compatibility.md
@@ -19,6 +19,28 @@ Data files produced by Redis CE 7.4+ cannot be loaded by Valkey.
 
 For migration steps, refer to [Migration from Redis to Valkey](migration.md).
 
+## Protocol compatibility
+
+Valkey uses the same RESP (REdis Serialization Protocol) wire protocol as Redis, supporting both RESP2 and RESP3.
+Existing Redis client libraries (such as Jedis, redis-py, node-redis, ioredis, and go-redis) connect to Valkey without code changes.
+
+## Persistence format compatibility
+
+Valkey reads and writes the same RDB and AOF file formats as Redis OSS 7.2.
+You can copy an RDB snapshot from Redis OSS to Valkey and load it directly.
+RDB files produced by Redis CE 7.4+ are not compatible.
+
+## Configuration compatibility
+
+Valkey accepts Redis-style configuration files.
+An existing `redis.conf` can be used as-is with `valkey-server`.
+Configuration directives are the same as Redis OSS 7.2, with additional Valkey-specific options for new features.
+
+## CLI compatibility
+
+The `redis-cli` tool works with Valkey servers, and `valkey-cli` works with Redis OSS servers.
+Both tools use the same RESP protocol and command set.
+
 ## The `redis_version` and `server_name` INFO fields
 
 To maintain compatibility with existing clients and tools that check the server version, Valkey reports a fixed `redis_version` field in the [INFO](../commands/info.md) server output:

--- a/topics/redis-compatibility.md
+++ b/topics/redis-compatibility.md
@@ -1,0 +1,91 @@
+---
+title: Redis compatibility
+description: How Valkey maintains compatibility with Redis OSS
+---
+
+Valkey is a fork of Redis OSS 7.2.4 and maintains backward compatibility with Redis OSS 7.2 and all earlier open-source Redis versions.
+This page describes how Valkey handles compatibility at the protocol, API, and scripting levels.
+
+## Version compatibility
+
+Valkey 7.2.4 was forked from Redis 7.2.4.
+All commands, data structures, and behaviors present in Redis OSS 7.2.4 work the same way in Valkey.
+
+Valkey versions 8.0 and later add new features on top of this base.
+These features are Valkey-specific and are not present in Redis OSS.
+
+Redis Community Edition (CE) 7.4 and later are not open source and are not compatible with Valkey.
+Data files produced by Redis CE 7.4+ cannot be loaded by Valkey.
+
+For migration steps, refer to [Migration from Redis to Valkey](migration.md).
+
+## The `redis_version` and `server_name` INFO fields
+
+To maintain compatibility with existing clients and tools that check the server version, Valkey reports a fixed `redis_version` field in the [INFO](../commands/info.md) server output:
+
+```
+redis_version:7.2.4
+```
+
+This value does not change across Valkey releases.
+Clients and libraries that rely on `redis_version` to detect feature support continue to work without modification.
+
+The actual Valkey version is reported in a separate field:
+
+```
+server_name:valkey
+server_version:8.1.1
+```
+
+Use `server_version` to check the Valkey version.
+Use `redis_version` only for backward compatibility with Redis-era tooling.
+
+## Lua scripting compatibility
+
+Valkey supports both the `redis` and `server` namespaces in Lua scripts and functions.
+The following calls are equivalent:
+
+```lua
+-- Redis-style (backward compatible)
+redis.call('SET', 'key', 'value')
+redis.pcall('GET', 'key')
+redis.log(redis.LOG_NOTICE, 'message')
+redis.status_reply('OK')
+redis.error_reply('ERR something')
+
+-- Valkey-style
+server.call('SET', 'key', 'value')
+server.pcall('GET', 'key')
+server.log(server.LOG_NOTICE, 'message')
+server.status_reply('OK')
+server.error_reply('ERR something')
+```
+
+Existing Lua scripts that use `redis.call()` and `redis.pcall()` work without changes.
+New scripts can use either namespace.
+
+## Module API compatibility
+
+Valkey supports both the `RedisModule_` and `ValkeyModule_` prefixed APIs for modules.
+The header files `redismodule.h` and `valkeymodule.h` are both available.
+
+Modules written for Redis OSS using the `RedisModule_` API work in Valkey without modification.
+New modules can use either API prefix.
+
+For example, both of these are valid:
+
+```c
+// Redis-style (backward compatible)
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (RedisModule_Init(ctx, "mymodule", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    return REDISMODULE_OK;
+}
+
+// Valkey-style
+int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    if (ValkeyModule_Init(ctx, "mymodule", 1, VALKEYMODULE_APIVER_1) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+    return VALKEYMODULE_OK;
+}
+```


### PR DESCRIPTION
- Add `server_name` to the server section field descriptions (it was in the example output but missing from the descriptions list)
- Expand `redis_version` description to clarify it is fixed at 7.2.4 across all Valkey releases for client compatibility
- Expand `valkey_version` description to recommend using it instead of `redis_version`

Verified against `src/version.h` and the PRs referenced in the issue (valkey-io/valkey#232, valkey-io/valkey#47).

Fixes #15