### PR TITLE
Add C# Valkey GLIDE client definition and fix GLIDE website links

### DIFF
--- a/clients/csharp/valkey-GLIDE.json
+++ b/clients/csharp/valkey-GLIDE.json
@@ -1,6 +1,6 @@
 {
     "name": "Valkey GLIDE C#",
-    "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
+    "description": "Valkey GLIDE C# is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo": "https://github.com/valkey-io/valkey-glide-csharp",
     "website": "https://glide.valkey.io/getting-started/quickstart/?lang=c%23",
     "installation": "dotnet add package Valkey.Glide",

--- a/clients/csharp/valkey-GLIDE.json
+++ b/clients/csharp/valkey-GLIDE.json
@@ -1,0 +1,20 @@
+{
+    "name": "valkey GLIDE",
+    "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
+    "repo": "https://github.com/valkey-io/valkey-glide-csharp",
+    "website": "https://glide.valkey.io/getting-started/quickstart/?lang=csharp",
+    "installation": "dotnet add package Valkey.Glide",
+    "version": "v1.0.0",
+    "version_released": "2026-04-18",
+    "language": "csharp",
+    "license": "Apache-2.0",
+    "read_from_replica": true,
+    "smart_backoff_to_prevent_connection_storm": true,
+    "pubsub_state_restoration": true,
+    "cluster_scan": true,
+    "latency_based_read_from_replica": false,
+    "AZ_based_read_from_replica": false,
+    "client_side_caching": false,
+    "client_capa_redirect": false,
+    "persistent_connection_pool": true
+}

--- a/clients/csharp/valkey-GLIDE.json
+++ b/clients/csharp/valkey-GLIDE.json
@@ -1,5 +1,5 @@
 {
-    "name": "valkey GLIDE",
+    "name": "Valkey GLIDE C#",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo": "https://github.com/valkey-io/valkey-glide-csharp",
     "website": "https://glide.valkey.io/getting-started/quickstart/?lang=c%23",

--- a/clients/csharp/valkey-GLIDE.json
+++ b/clients/csharp/valkey-GLIDE.json
@@ -2,7 +2,7 @@
     "name": "valkey GLIDE",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo": "https://github.com/valkey-io/valkey-glide-csharp",
-    "website": "https://glide.valkey.io/getting-started/quickstart/?lang=csharp",
+    "website": "https://glide.valkey.io/getting-started/quickstart/?lang=c%23",
     "installation": "dotnet add package Valkey.Glide",
     "version": "v1.0.0",
     "version_released": "2026-04-18",

--- a/clients/go/valkey-GLIDE.json
+++ b/clients/go/valkey-GLIDE.json
@@ -1,6 +1,6 @@
 {
     "name": "Valkey GLIDE Go",
-    "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
+    "description": "Valkey GLIDE Go is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/go",
     "website": "https://glide.valkey.io/getting-started/quickstart/?lang=go",
     "installation": "go get github.com/valkey-io/valkey-glide/go",

--- a/clients/go/valkey-GLIDE.json
+++ b/clients/go/valkey-GLIDE.json
@@ -1,5 +1,5 @@
 {
-    "name": "valkey GLIDE",
+    "name": "Valkey GLIDE Go",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/go",
     "website": "https://glide.valkey.io/getting-started/quickstart/?lang=go",

--- a/clients/go/valkey-GLIDE.json
+++ b/clients/go/valkey-GLIDE.json
@@ -2,7 +2,7 @@
     "name": "valkey GLIDE",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/go",
-    "website": "https://glide.valkey.io/languages/go/",
+    "website": "https://glide.valkey.io/getting-started/quickstart/?lang=go",
     "installation": "go get github.com/valkey-io/valkey-glide/go",
     "version":"v2.1.1",
     "version_released":"2025-10-08",

--- a/clients/java/valkey-GLIDE.json
+++ b/clients/java/valkey-GLIDE.json
@@ -1,5 +1,5 @@
 {
-    "name": "valkey GLIDE",
+    "name": "Valkey GLIDE Java",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/java",
     "website": "https://glide.valkey.io/getting-started/quickstart/?lang=java",

--- a/clients/java/valkey-GLIDE.json
+++ b/clients/java/valkey-GLIDE.json
@@ -2,7 +2,7 @@
     "name": "valkey GLIDE",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/java",
-    "website": "https://glide.valkey.io/languages/java/",
+    "website": "https://glide.valkey.io/getting-started/quickstart/?lang=java",
     "installation": [
         {
             "type": "Maven",

--- a/clients/java/valkey-GLIDE.json
+++ b/clients/java/valkey-GLIDE.json
@@ -1,6 +1,6 @@
 {
     "name": "Valkey GLIDE Java",
-    "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
+    "description": "Valkey GLIDE Java is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/java",
     "website": "https://glide.valkey.io/getting-started/quickstart/?lang=java",
     "installation": [

--- a/clients/node.js/valkey-GLIDE.json
+++ b/clients/node.js/valkey-GLIDE.json
@@ -1,5 +1,5 @@
 {
-    "name": "valkey GLIDE",
+    "name": "Valkey GLIDE Node.js",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/node",
     "website": "https://glide.valkey.io/getting-started/quickstart/?lang=node",

--- a/clients/node.js/valkey-GLIDE.json
+++ b/clients/node.js/valkey-GLIDE.json
@@ -1,6 +1,6 @@
 {
     "name": "Valkey GLIDE Node.js",
-    "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
+    "description": "Valkey GLIDE Node.js is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/node",
     "website": "https://glide.valkey.io/getting-started/quickstart/?lang=node",
     "installation": "npm install @valkey/valkey-glide",

--- a/clients/node.js/valkey-GLIDE.json
+++ b/clients/node.js/valkey-GLIDE.json
@@ -2,7 +2,7 @@
     "name": "valkey GLIDE",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/node",
-    "website": "https://glide.valkey.io/languages/nodejs/",
+    "website": "https://glide.valkey.io/getting-started/quickstart/?lang=node",
     "installation": "npm install @valkey/valkey-glide",
     "version":"v2.1.1",
     "version_released":"2025-10-08",

--- a/clients/python/valkey-GLIDE.json
+++ b/clients/python/valkey-GLIDE.json
@@ -1,6 +1,6 @@
 {
     "name": "Valkey GLIDE Python",
-    "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
+    "description": "Valkey GLIDE Python is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/python",
     "website": "https://glide.valkey.io/getting-started/quickstart/?lang=python",
     "installation": "pip install valkey-glide",

--- a/clients/python/valkey-GLIDE.json
+++ b/clients/python/valkey-GLIDE.json
@@ -1,5 +1,5 @@
 {
-    "name": "valkey GLIDE",
+    "name": "Valkey GLIDE Python",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/python",
     "website": "https://glide.valkey.io/getting-started/quickstart/?lang=python",

--- a/clients/python/valkey-GLIDE.json
+++ b/clients/python/valkey-GLIDE.json
@@ -2,7 +2,7 @@
     "name": "valkey GLIDE",
     "description": "Valkey GLIDE is designed for reliability, optimized performance, and high-availability, for Valkey and Redis OSS based applications. GLIDE is a multi language client library, written in Rust with programming language bindings, such as Java, node.js and Python.",
     "repo":"https://github.com/valkey-io/valkey-glide/tree/main/python",
-    "website": "https://glide.valkey.io/languages/python/",
+    "website": "https://glide.valkey.io/getting-started/quickstart/?lang=python",
     "installation": "pip install valkey-glide",
     "version":"v2.1.1",
     "version_released":"2025-10-08",


### PR DESCRIPTION
### Summary

Add the C# Valkey GLIDE client definition to the client registry and fix broken website links for all existing GLIDE clients.

### Issue Link

:white_circle: None

### Changes

- Added `clients/csharp/valkey-GLIDE.json` with the client metadata for the [C# GLIDE client](https://github.com/valkey-io/valkey-glide-csharp) ([v1.0.0](https://github.com/valkey-io/valkey-glide-csharp/releases/tag/v1.0.0)).
- Fixed broken website links in `clients/go/valkey-GLIDE.json`, `clients/java/valkey-GLIDE.json`, `clients/node.js/valkey-GLIDE.json`, and `clients/python/valkey-GLIDE.json` — updated from the old `/languages/` URL format to the new `/getting-started/quickstart/?lang=` format.

### Implementation

The new C# JSON file follows the same schema and conventions as the existing GLIDE client definitions (e.g., `clients/java/valkey-GLIDE.json`). Key details:

- Repository: https://github.com/valkey-io/valkey-glide-csharp
- Website: https://glide.valkey.io/getting-started/quickstart/?lang=csharp
- Installation: `dotnet add package Valkey.Glide`
- License: Apache-2.0

The website link fix updates all existing GLIDE clients to use the current URL scheme:

| Client | Old URL | New URL |
|--------|---------|---------|
| Go | `glide.valkey.io/languages/go/` | `glide.valkey.io/getting-started/quickstart/?lang=go` |
| Java | `glide.valkey.io/languages/java/` | `glide.valkey.io/getting-started/quickstart/?lang=java` |
| Node.js | `glide.valkey.io/languages/nodejs/` | `glide.valkey.io/getting-started/quickstart/?lang=node` |
| Python | `glide.valkey.io/languages/python/` | `glide.valkey.io/getting-started/quickstart/?lang=python` |

### Limitations

:white_circle: None

### Testing

:white_circle: Not applicable — data-only changes (JSON files).

### Related Issues

:white_circle: None

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~Documentation is updated where applicable.~~
- [x] Destination branch is correct.