### PR TITLE
Update `cluster-spec.md` to mention enabling support for multi database cluster

### DIFF
--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -29,7 +29,8 @@ to force certain keys to be stored in the same hash slot. However, during
 manual resharding, multi-key operations may become unavailable for some time
 while single-key operations are always available.
 
-Starting with version 9.0, Valkey cluster supports multiple databases, similar to standalone mode but with some additional restrictions.
+Starting with version 9.0, Valkey cluster supports multiple databases, similar to standalone mode but with some additional restrictions. 
+You can enable multi-database support using the `cluster-databases` setting (default value is `1`).
 
 ## Client and Server roles in the Valkey cluster protocol
 

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -29,7 +29,7 @@ to force certain keys to be stored in the same hash slot. However, during
 manual resharding, multi-key operations may become unavailable for some time
 while single-key operations are always available.
 
-Starting with version 9.0, Valkey cluster supports multiple databases, similar to standalone mode but with some additional restrictions. 
+Starting with version 9.0, Valkey cluster supports multiple databases, similar to standalone mode but with some additional restrictions.
 You can enable multi-database support using the `cluster-databases` setting (default value is `1`).
 
 ## Client and Server roles in the Valkey cluster protocol


### PR DESCRIPTION
By default, `cluster-databases` is set to 1, meaning the multi-database feature is disabled. And currently, the docs do not mention how to enable it. 