### PR TITLE
FT.AGGREGATE: add array value documentation for search expressions

### DIFF
--- a/commands/ft.aggregate.md
+++ b/commands/ft.aggregate.md
@@ -92,3 +92,4 @@ The following reducer functions are available. The reducer functions that take a
 | MAX 1 <expression>            | The largest numerical values of the expression.                                                                                    |
 | AVG 1 <expression>            | The numerical average of the values of the expression.                                                                             |
 | STDDEV 1 <expression>         | The standard deviation the values of the expression.                                                                               |
+| TOLIST 1 <expression>         | Collects expression values into an array.                                                                                          |

--- a/topics/search-expressions.md
+++ b/topics/search-expressions.md
@@ -178,55 +178,28 @@ REDUCE TOLIST 1 <expression>
 
 Arrays can be nested — an array may contain other arrays as elements, enabling multi-dimensional data structures within the expression evaluation context.
 
-## Element-wise Scalar Functions
+## Scalar Functions on Arrays
 
-When a scalar function receives an array argument, it applies independently to each element, returning a new array of the same length.
+Scalar functions do not apply element-wise to arrays. Passing an array to a scalar function produces a nil or nan result, consistent with RediSearch behavior.
 
-| Function | Description |
-| :------- | :---------- |
-| `lower(array)` | Applies lower-case conversion to each element |
-| `upper(array)` | Applies upper-case conversion to each element |
-| `strlen(array)` | Returns string length of each element |
-| `floor(array)` | Applies floor to each element |
-| `ceil(array)` | Applies ceiling to each element |
-| `abs(array)` | Applies absolute value to each element |
-| `log(array)` | Applies natural log to each element |
-| `sqrt(array)` | Applies square root to each element |
+Functions that return nil when applied to an array: `lower`, `upper`, `strlen`, `startswith`, `contains`.
+
+Functions that return nan when applied to an array: `floor`, `ceil`, `abs`, `log`, `log2`, `exp`, `sqrt`.
 
 ## Array Arithmetic
 
-When both operands are arrays of equal length, arithmetic operators apply element-wise, producing a new array where each element is the result of applying the operator to the corresponding elements of the input arrays.
-
-When one operand is a scalar and the other is an array, the scalar is broadcast — promoted to an array of the same length — so the operation applies to each element.
-
-| Operator | Operation |
-| :------: | :-------- |
-| `+` | Element-wise addition |
-| `-` | Element-wise subtraction |
-| `*` | Element-wise multiplication |
-| `/` | Element-wise division |
-| `^` | Element-wise exponentiation |
-
-## Array-Specific Functions
-
-| Syntax | Description |
-| :----- | :---------- |
-| `arraylen(array)` | Returns the number of elements in the array |
-| `arrayat(array, index)` | Returns the element at the zero-based index |
-| `isarray(value)` | Returns 1 if the value is an array, otherwise 0 |
-| `makearray(e1, e2, ...)` | Constructs an array from the provided arguments |
-| `flatten(array, depth)` | Flattens nested arrays to the specified depth |
+Any mathematical operation (`+`, `-`, `*`, `/`, `^`) involving an array operand returns the error `"Could not convert value to a number"`. This is consistent with RediSearch behavior.
 
 ## Error Handling
 
-Array operations produce specific error messages when encountering invalid conditions.
+Array operations produce specific error messages when encountering invalid conditions, consistent with RediSearch error behavior.
 
-| Condition | Message Format |
-| :-------- | :------------- |
-| Arithmetic with incompatible type | `Type error: cannot add array to string` |
-| Element-wise on mismatched lengths | `Length mismatch: arrays have lengths 3 and 5` |
-| Per-element computation failure | `Element error at index 2: division by zero` |
-| `arrayat` out-of-bounds | `Index out of bounds: index 5, array length 3` |
+| Condition | Result |
+| :-------- | :----- |
+| Arithmetic with array operand | `"Could not convert value to a number"` |
+| `substr` with array argument | `"Invalid type for substr. Expected string"` |
+| String functions on array | nil (empty value) |
+| Numeric functions on array | nan |
 
 ## RESP Serialization
 

--- a/topics/search-expressions.md
+++ b/topics/search-expressions.md
@@ -211,10 +211,10 @@ When one operand is a scalar and the other is an array, the scalar is broadcast 
 
 | Syntax | Description |
 | :----- | :---------- |
-| `vectorlen(array)` | Returns the number of elements in the array |
-| `vectorat(array, index)` | Returns the element at the zero-based index |
-| `isvector(value)` | Returns 1 if the value is an array, otherwise 0 |
-| `makevector(e1, e2, ...)` | Constructs an array from the provided arguments |
+| `arraylen(array)` | Returns the number of elements in the array |
+| `arrayat(array, index)` | Returns the element at the zero-based index |
+| `isarray(value)` | Returns 1 if the value is an array, otherwise 0 |
+| `makearray(e1, e2, ...)` | Constructs an array from the provided arguments |
 | `flatten(array, depth)` | Flattens nested arrays to the specified depth |
 
 ## Error Handling
@@ -223,10 +223,10 @@ Array operations produce specific error messages when encountering invalid condi
 
 | Condition | Message Format |
 | :-------- | :------------- |
-| Arithmetic with incompatible type | `Type error: cannot add vector to string` |
-| Element-wise on mismatched lengths | `Length mismatch: vectors have lengths 3 and 5` |
+| Arithmetic with incompatible type | `Type error: cannot add array to string` |
+| Element-wise on mismatched lengths | `Length mismatch: arrays have lengths 3 and 5` |
 | Per-element computation failure | `Element error at index 2: division by zero` |
-| `vectorat` out-of-bounds | `Index out of bounds: index 5, vector length 3` |
+| `arrayat` out-of-bounds | `Index out of bounds: index 5, array length 3` |
 
 ## RESP Serialization
 

--- a/topics/search-expressions.md
+++ b/topics/search-expressions.md
@@ -163,3 +163,71 @@ The exists function returns 0 if the input argument is Nil else 1. This can be u
 |    Syntax     | Operation                      |
 | :-----------: | :----------------------------- |
 | exists(value) | 0 if the value is Nil, else 1. |
+
+# Array Values
+
+## Producing Arrays
+
+An array is an ordered sequence of scalar elements produced by the `TOLIST` reducer during a `GROUPBY` stage. The resulting array value is available to expressions in subsequent pipeline stages.
+
+Syntax:
+
+```
+REDUCE TOLIST 1 <expression>
+```
+
+Arrays can be nested — an array may contain other arrays as elements, enabling multi-dimensional data structures within the expression evaluation context.
+
+## Element-wise Scalar Functions
+
+When a scalar function receives an array argument, it applies independently to each element, returning a new array of the same length.
+
+| Function | Description |
+| :------- | :---------- |
+| `lower(array)` | Applies lower-case conversion to each element |
+| `upper(array)` | Applies upper-case conversion to each element |
+| `strlen(array)` | Returns string length of each element |
+| `floor(array)` | Applies floor to each element |
+| `ceil(array)` | Applies ceiling to each element |
+| `abs(array)` | Applies absolute value to each element |
+| `log(array)` | Applies natural log to each element |
+| `sqrt(array)` | Applies square root to each element |
+
+## Array Arithmetic
+
+When both operands are arrays of equal length, arithmetic operators apply element-wise, producing a new array where each element is the result of applying the operator to the corresponding elements of the input arrays.
+
+When one operand is a scalar and the other is an array, the scalar is broadcast — promoted to an array of the same length — so the operation applies to each element.
+
+| Operator | Operation |
+| :------: | :-------- |
+| `+` | Element-wise addition |
+| `-` | Element-wise subtraction |
+| `*` | Element-wise multiplication |
+| `/` | Element-wise division |
+| `^` | Element-wise exponentiation |
+
+## Array-Specific Functions
+
+| Syntax | Description |
+| :----- | :---------- |
+| `vectorlen(array)` | Returns the number of elements in the array |
+| `vectorat(array, index)` | Returns the element at the zero-based index |
+| `isvector(value)` | Returns 1 if the value is an array, otherwise 0 |
+| `makevector(e1, e2, ...)` | Constructs an array from the provided arguments |
+| `flatten(array, depth)` | Flattens nested arrays to the specified depth |
+
+## Error Handling
+
+Array operations produce specific error messages when encountering invalid conditions.
+
+| Condition | Message Format |
+| :-------- | :------------- |
+| Arithmetic with incompatible type | `Type error: cannot add vector to string` |
+| Element-wise on mismatched lengths | `Length mismatch: vectors have lengths 3 and 5` |
+| Per-element computation failure | `Element error at index 2: division by zero` |
+| `vectorat` out-of-bounds | `Index out of bounds: index 5, vector length 3` |
+
+## RESP Serialization
+
+Array values are serialized as RESP arrays in the `FT.AGGREGATE` response. Each element of the array is serialized according to its scalar type: numeric values become bulk strings containing digits, string values become bulk strings, and nil values become RESP nil.


### PR DESCRIPTION
## Summary

Adds documentation for array values in the search expressions topic and the TOLIST reducer in FT.AGGREGATE.

## Changes

- `topics/search-expressions.md`: New "Array Values" section covering:
  - Producing arrays via TOLIST reducer
  - Element-wise scalar functions
  - Array arithmetic (element-wise and scalar broadcast)
  - Array-specific functions (vectorlen, vectorat, isvector, makevector, flatten)
  - Error handling messages
  - RESP serialization behavior
- `commands/ft.aggregate.md`: Added TOLIST reducer to the reducer functions table