### PR TITLE
Update ZRANGE WITHSCORES examples

### DIFF
--- a/commands/zrange.md
+++ b/commands/zrange.md
@@ -140,7 +140,7 @@ In RESP3, using `valkey-cli -3`, the reply is an array of 2-element arrays where
    2) (double) 1
 2) 1) "two"
    2) (double) 2
-``` 
+```
 
 This example shows how to query the sorted set by score, excluding the value `1` and up to infinity, returning only the second element of the result:
 

--- a/commands/zrange.md
+++ b/commands/zrange.md
@@ -13,7 +13,7 @@ The optional `REV` argument reverses the ordering, so elements are ordered from 
 The optional `LIMIT` argument can be used to obtain a sub-range from the matching elements (similar to _SELECT LIMIT offset, count_ in SQL).
 A negative `<count>` returns all elements from the `<offset>`. Keep in mind that if `<offset>` is large, the sorted set needs to be traversed for `<offset>` elements before getting to the elements to return, which can add up to O(N) time complexity.
 
-The optional `WITHSCORES` argument supplements the command's reply with the scores of elements returned. The returned list contains `value1,score1,...,valueN,scoreN` instead of `value1,...,valueN`. Client libraries are free to return a more appropriate data type (suggestion: an array with (value, score) arrays/tuples).
+The optional `WITHSCORES` argument supplements the command's reply with the scores of elements returned. In RESP2 the returned list contains `value1,score1,...,valueN,scoreN` instead of `value1,...,valueN`. Client libraries are free to return a more appropriate data type (suggestion: an array with (value, score) arrays/tuples).
 
 ## Index ranges
 
@@ -116,7 +116,9 @@ The binary nature of the comparison allows to use sorted sets as a general purpo
 2) "three"
 ```
 
-The following example using `WITHSCORES` shows how the command returns always an array, but this time, populated with *element_1*, *score_1*, *element_2*, *score_2*, ..., *element_N*, *score_N*.
+The following examples using `WITHSCORES` show how the response format differs by protocol version.
+
+In RESP2, the reply is a flat interleaved array of *element_1*, *score_1*, *element_2*, *score_2*, ..., *element_N*, *score_N* where scores are returned as strings:
 
 ```
 127.0.0.1:6379> ZADD myzset 1 "one" 2 "two" 3 "three"
@@ -126,6 +128,18 @@ The following example using `WITHSCORES` shows how the command returns always an
 2) "1"
 3) "two"
 4) "2"
+```
+
+In RESP3, using `valkey-cli -3`, the reply is an array of 2-element arrays where scores are returned as doubles:
+
+```
+127.0.0.1:6379> ZADD myzset 1 "one" 2 "two" 3 "three"
+(integer) 3
+127.0.0.1:6379> ZRANGE myzset 0 1 WITHSCORES
+1) 1) "one"
+   2) (double) 1
+2) 1) "two"
+   2) (double) 2
 ```
 
 This example shows how to query the sorted set by score, excluding the value `1` and up to infinity, returning only the second element of the result:

--- a/commands/zrange.md
+++ b/commands/zrange.md
@@ -140,7 +140,7 @@ In RESP3, using `valkey-cli -3`, the reply is an array of 2-element arrays where
    2) (double) 1
 2) 1) "two"
    2) (double) 2
-```
+``` 
 
 This example shows how to query the sorted set by score, excluding the value `1` and up to infinity, returning only the second element of the result:
 

--- a/resp2_replies.json
+++ b/resp2_replies.json
@@ -1673,7 +1673,7 @@
     "[Array reply](../topics/protocol.md#arrays): when the additional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist. If the _WITHSCORES_ modifier is used, the reply is a list of members and their scores from the sorted set."
   ],
   "ZRANGE": [
-    "[Array reply](../topics/protocol.md#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given."
+    "[Array reply](../topics/protocol.md#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given. When _WITHSCORES_ is used, the reply is a flat array where each member is immediately followed by its score as a [Bulk string reply](../topics/protocol.md#bulk-strings)."
   ],
   "ZRANGEBYLEX": [
     "[Array reply](../topics/protocol.md#arrays): a list of elements in the specified score range."

--- a/resp3_replies.json
+++ b/resp3_replies.json
@@ -1740,7 +1740,7 @@
     "[Array reply](../topics/protocol.md#arrays): when the additional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist. If the _WITHSCORES_ modifier is used, the reply is a list of members and their scores from the sorted set."
   ],
   "ZRANGE": [
-    "[Array reply](../topics/protocol.md#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given."
+    "[Array reply](../topics/protocol.md#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given. When _WITHSCORES_ is used, each entry is a 2-element array containing the member and its score as a [Double reply](../topics/protocol.md#doubles)."
   ],
   "ZRANGEBYLEX": [
     "[Array reply](../topics/protocol.md#arrays): a list of elements in the specified score range."


### PR DESCRIPTION
This PR updates the ZRANGE WITHSCORES response differences between RESP2 and RESP3.

It mentions RESP2 and 3 with separate examples based on #431 