### PR TITLE
Omit alldbs rule and drop mentions of sanitize-payload user flags

### DIFF
--- a/commands/acl-getuser.md
+++ b/commands/acl-getuser.md
@@ -7,7 +7,7 @@ Command rules are always returned in the same format as the one used in the [`AC
 Before version 7.0, keys and channels were returned as an array of patterns, however in version 7.0 later they are now also returned in same format as the one used in the `ACL SETUSER` command.
 Note: This description of command rules reflects the user's effective permissions, so while it may not be identical to the set of rules used to configure the user, it is still functionally identical.
 
-Selectors are listed in the order they were applied to the user, and include information about commands, key patterns, and channel patterns.
+Selectors are listed in the order they were applied to the user, and include information about commands, key patterns, channel patterns, and database permissions.
 
 ## Examples
 
@@ -19,21 +19,24 @@ Here's an example configuration for a user
 127.0.0.1:6379> ACL GETUSER sample
 1) "flags"
 2) 1) "on"
-   2) "allkeys"
-   3) "nopass"
+   2) "nopass"
 3) "passwords"
 4) (empty array)
 5) "commands"
-6) "+@all"
+6) "-@all +get"
 7) "keys"
 8) "~*"
 9) "channels"
 10) "&*"
-11) "selectors"
-12) 1) 1) "commands"
-       6) "+SET"
-       7) "keys"
-       8) "~key2"
-       9) "channels"
-       10) "&*"
+11) "databases"
+12) "alldbs"
+13) "selectors"
+14) 1) 1) "commands"
+       2) "-@all +set"
+       3) "keys"
+       4) "~key2"
+       5) "channels"
+       6) ""
+       7) "databases"
+       8) "alldbs"
 ```

--- a/commands/acl-list.md
+++ b/commands/acl-list.md
@@ -3,6 +3,8 @@ line in the returned array defines a different user, and the format is the
 same used in the valkey.conf file or the external ACL file, so you can
 cut and paste what is returned by the ACL LIST command directly inside a
 configuration file if you wish (but make sure to check [`ACL SAVE`](acl-save.md)).
+Implicit defaults may be omitted: for example, access to all databases (`alldbs`)
+is not shown, while explicit `db=<dbid>` and `resetdbs` rules are shown.
 
 ## Examples
 

--- a/commands/acl-setuser.md
+++ b/commands/acl-setuser.md
@@ -76,7 +76,7 @@ This is a list of all the supported Valkey ACL rules:
   Multiple ids are separated by commas, e.g. `db=0,1,2`; at least one id is required.
   Clears the `alldbs` flag and any previously configured database ids on the selector.
   See [database permissions](../topics/acl.md#database-permissions) for more information.
-* `alldbs`: Allows the selector to access all databases. This is the default for new selectors.
+* `alldbs`: Allows the selector to access all databases. This is the default for new selectors and is omitted from generated ACL strings.
 * `resetdbs`: Removes all databases from the list of allowed databases and clears the `alldbs` flag.
 
 ### User management rules
@@ -107,8 +107,8 @@ Restrict a user to a subset of databases:
 127.0.0.1:6379> ACL SETUSER alice on +@all ~* db=0,1 nopass
 OK
 127.0.0.1:6379> ACL LIST
-1) "user alice on nopass sanitize-payload ~* resetchannels db=0,1 +@all"
-2) "user default on nopass ~* &* alldbs +@all"
+1) "user alice on nopass ~* resetchannels db=0,1 +@all"
+2) "user default on nopass ~* &* +@all"
 ```
 
 A later `db=` rule replaces the previous database list:
@@ -117,8 +117,8 @@ A later `db=` rule replaces the previous database list:
 127.0.0.1:6379> ACL SETUSER alice db=2,3
 OK
 127.0.0.1:6379> ACL LIST
-1) "user alice on nopass sanitize-payload ~* resetchannels db=2,3 +@all"
-2) "user default on nopass ~* &* alldbs +@all"
+1) "user alice on nopass ~* resetchannels db=2,3 +@all"
+2) "user default on nopass ~* &* +@all"
 ```
 
 Different selectors can grant access on different databases:
@@ -127,11 +127,11 @@ Different selectors can grant access on different databases:
 127.0.0.1:6379> ACL SETUSER bob on nopass (db=0,1 +@write +select ~*) (db=2,3 +@read +select ~*)
 OK
 127.0.0.1:6379> ACL LIST
-1) "user bob on nopass sanitize-payload resetchannels alldbs -@all (~* resetchannels db=0,1 -@all +@write +select) (~* resetchannels db=2,3 -@all +@read +select)"
-2) "user default on nopass sanitize-payload ~* &* alldbs +@all"
+1) "user bob on nopass resetchannels -@all (~* resetchannels db=0,1 -@all +@write +select) (~* resetchannels db=2,3 -@all +@read +select)"
+2) "user default on nopass ~* &* +@all"
 ```
 
 The `ACL LIST` output shows three sets of permissions for `bob`: the root
-permissions (`alldbs -@all`) and two selectors, one for each parenthesized rule
-set. A command is allowed when the root permissions or any selector matches it.
+permissions (`-@all`, with implicit `alldbs`) and two selectors, one for each
+parenthesized rule set. A command is allowed when the root permissions or any selector matches it.
 See [selectors](../topics/acl.md#selectors) for more information.

--- a/topics/acl.md
+++ b/topics/acl.md
@@ -50,7 +50,7 @@ and verify what the configuration of a freshly started, defaults-configured
 Valkey instance is:
 
     > ACL LIST
-    1) "user default on nopass ~* &* alldbs +@all"
+    1) "user default on nopass ~* &* +@all"
 
 The command above reports the list of users in the same format that is
 used in the Valkey configuration files, by translating the current ACLs set
@@ -60,7 +60,7 @@ The first two words in each line are "user" followed by the username. The
 next words are ACL rules that describe different things. We'll show how the rules work in detail, but for now it is enough to say that the default
 user is configured to be active (on), to require no password (nopass), to
 access every possible key (`~*`) and Pub/Sub channel (`&*`), every
-database (`alldbs`), and be able to call every possible command (`+@all`).
+database, and be able to call every possible command (`+@all`).
 
 Also, in the special case of the default user, having the *nopass* rule means
 that new connections are automatically authenticated with the default user
@@ -110,7 +110,7 @@ Allow and disallow logical databases:
   Multiple ids are separated by commas, e.g. `db=0,1,2`; at least one id is required.
   Clears the `alldbs` flag and any previously configured database ids on the selector.
   See [database permissions](#database-permissions) for more information.
-* `alldbs`: Allow the user to access all databases. This is the default for newly created selectors.
+* `alldbs`: Allow the user to access all databases. This is the default for newly created selectors and is omitted from generated ACL strings.
 * `resetdbs`: Flush the list of allowed databases and clear the `alldbs` flag. After `resetdbs`, the user (or selector) cannot access any database until additional `db=` rules or `alldbs` are added.
 
 Configure valid passwords for the user:
@@ -203,10 +203,12 @@ computers to read, while `ACL GETUSER` is more human readable.
     8) "~cached:*"
     9) "channels"
     10) ""
-    11) "selectors"
-    12) (empty array)
+    11) "databases"
+    12) "alldbs"
+    13) "selectors"
+    14) (empty array)
 
-The `ACL GETUSER` returns a field-value array that describes the user in more parsable terms. The output includes the set of flags, a list of key patterns, passwords, and so forth. The output is probably more readable if we use RESP3, so that it is returned as a map reply:
+The `ACL GETUSER` returns a field-value array that describes the user in more parsable terms. The output includes the set of flags, a list of key patterns, passwords, and so forth. New fields may be added over time. For example, Valkey 9.1 added the `databases` field. The output is probably more readable if we use RESP3, so that it is returned as a map reply:
 
     > ACL GETUSER alice
     1# "flags" => 1~ "on"
@@ -214,7 +216,8 @@ The `ACL GETUSER` returns a field-value array that describes the user in more pa
     3# "commands" => "-@all +get"
     4# "keys" => "~cached:*"
     5# "channels" => ""
-    6# "selectors" => (empty array)
+    6# "databases" => "alldbs"
+    7# "selectors" => (empty array)
 
 *Note: from now on, we'll continue using the Valkey default protocol, version 2*
 
@@ -471,8 +474,8 @@ For example, to create a user that may only operate on databases 0 and 1:
 > ACL SETUSER alice on +@all ~* db=0,1 nopass
 OK
 > ACL LIST
-1) "user alice on nopass sanitize-payload ~* resetchannels db=0,1 +@all"
-2) "user default on nopass ~* &* alldbs +@all"
+1) "user alice on nopass ~* resetchannels db=0,1 +@all"
+2) "user default on nopass ~* &* +@all"
 ```
 
 A later `db=` rule replaces the previous database list:
@@ -481,8 +484,8 @@ A later `db=` rule replaces the previous database list:
 > ACL SETUSER alice db=2,3
 OK
 > ACL LIST
-1) "user alice on nopass sanitize-payload ~* resetchannels db=2,3 +@all"
-2) "user default on nopass ~* &* alldbs +@all"
+1) "user alice on nopass ~* resetchannels db=2,3 +@all"
+2) "user default on nopass ~* &* +@all"
 ```
 
 Use `resetdbs` to remove database access from an existing user:
@@ -491,8 +494,8 @@ Use `resetdbs` to remove database access from an existing user:
 > ACL SETUSER alice resetdbs
 OK
 > ACL LIST
-1) "user alice on nopass sanitize-payload ~* resetchannels resetdbs +@all"
-2) "user default on nopass ~* &* alldbs +@all"
+1) "user alice on nopass ~* resetchannels resetdbs +@all"
+2) "user default on nopass ~* &* +@all"
 ```
 
 Database permissions can also be combined with [selectors](#selectors) so that
@@ -502,13 +505,13 @@ different rule sets apply to different databases:
 > ACL SETUSER bob on nopass (db=0,1 +@write +select ~*) (db=2,3 +@read +select ~*)
 OK
 > ACL LIST
-1) "user bob on nopass sanitize-payload resetchannels alldbs -@all (~* resetchannels db=0,1 -@all +@write +select) (~* resetchannels db=2,3 -@all +@read +select)"
-2) "user default on nopass sanitize-payload ~* &* alldbs +@all"
+1) "user bob on nopass resetchannels -@all (~* resetchannels db=0,1 -@all +@write +select) (~* resetchannels db=2,3 -@all +@read +select)"
+2) "user default on nopass ~* &* +@all"
 ```
 
 The `ACL LIST` output shows three sets of permissions for `bob`: the root
-permissions (`alldbs -@all`) and two selectors, one for each parenthesized rule
-set. A command is allowed when the root permissions or any selector matches it.
+permissions (`-@all`, with implicit `alldbs`) and two selectors, one for each
+parenthesized rule set. A command is allowed when the root permissions or any selector matches it.
 See [selectors](#selectors) for more information.
 
 ### How database permissions are evaluated


### PR DESCRIPTION
As per https://github.com/valkey-io/valkey/pull/3721 and https://github.com/valkey-io/valkey/pull/3964, omit `alldbs` rules and drop mentions of `sanitize-payload` and `skip-sanitize-payload` user flags.