### PR TITLE
Update ACL rules for Replication

### DIFF
--- a/topics/acl.md
+++ b/topics/acl.md
@@ -656,9 +656,12 @@ Valkey replicas require the following commands to be allowed on the primary inst
 
 * PSYNC, REPLCONF, PING
 
-For cluster deployments, Valkey 9.0 introduces the Atomic Slot Migration feature, which requires the replication user to be allowed to run `CLUSTER SYNCSLOTS`.
-No keys need to be accessed, so this translates to the following rules:
+For cluster deployments, Valkey 9.0 introduces the Atomic Slot Migration feature, which requires additional permissions:
 
-    ACL setuser replica-user on >somepassword +psync +replconf +ping +cluster|syncslots
+* CLUSTER SYNCSLOTS, @write, SELECT
+
+This translate to the following rules:
+
+    ACL setuser replica-user on >somepassword +psync +replconf +ping +cluster|syncslots +@write +select ~*
 
 Note that you don't need to configure the replicas to allow the primary to be able to execute any set of commands. The primary is always authenticated as the root user from the point of view of replicas.

--- a/topics/acl.md
+++ b/topics/acl.md
@@ -33,7 +33,7 @@ two main goals that are well served by ACLs:
 Another typical usage of ACLs is related to managed Valkey instances. Valkey is
 often provided as a managed service both by internal company teams that handle
 the Valkey infrastructure for the other internal customers they have, or is
-provided in a software-as-a-service setup by cloud providers. In both 
+provided in a software-as-a-service setup by cloud providers. In both
 setups, we want to be sure that configuration commands are excluded for the
 customers.
 
@@ -94,7 +94,7 @@ Allow and disallow certain keys and key permissions:
 * `~<pattern>`: Add a pattern of keys that can be mentioned as part of commands. For instance `~*` allows all the keys. The pattern is a glob-style pattern like the one of `KEYS`. It is possible to specify multiple patterns.
 * `%R~<pattern>`: Add the specified read key pattern. This behaves similar to the regular key pattern but only grants permission to read from keys that match the given pattern. See [key permissions](#key-permissions) for more information.
 * `%W~<pattern>`: Add the specified write key pattern. This behaves similar to the regular key pattern but only grants permission to write to keys that match the given pattern. See [key permissions](#key-permissions) for more information.
-* `%RW~<pattern>`: Alias for `~<pattern>`. 
+* `%RW~<pattern>`: Alias for `~<pattern>`.
 * `allkeys`: Alias for `~*`.
 * `resetkeys`: Flush the list of allowed keys patterns. For instance the ACL `~foo:* ~bar:* resetkeys ~objects:*`, will only allow the client to access keys that match the pattern `objects:*`.
 
@@ -290,7 +290,7 @@ The following is a list of command categories and their meanings:
 * **hyperloglog** - Data type: hyperloglog related.
 * **fast** - Fast O(1) commands. May loop on the number of arguments, but not the
   number of elements in the key.
-* **keyspace** - Writing or reading from keys, databases, or their metadata 
+* **keyspace** - Writing or reading from keys, databases, or their metadata
   in a type agnostic way. Includes `DEL`, `RESTORE`, `DUMP`, `RENAME`, `EXISTS`, `DBSIZE`,
   `KEYS`, `EXPIRE`, `TTL`, `FLUSHALL`, etc. Commands that may modify the keyspace,
   key, or metadata will also have the `write` category. Commands that only read
@@ -422,10 +422,10 @@ This is achieved through rules that define key permissions.
 The key permission rules take the form of `%(<permission>)~<pattern>`.
 Permissions are defined as individual characters that map to the following key permissions:
 
-* W (Write): The data stored within the key may be updated or deleted. 
-* R (Read): User supplied data from the key is processed, copied or returned. Note that this does not include metadata such as size information (example `STRLEN`), type information (example `TYPE`) or information about whether a value exists within a collection (example `SISMEMBER`). 
+* W (Write): The data stored within the key may be updated or deleted.
+* R (Read): User supplied data from the key is processed, copied or returned. Note that this does not include metadata such as size information (example `STRLEN`), type information (example `TYPE`) or information about whether a value exists within a collection (example `SISMEMBER`).
 
-Permissions can be composed together by specifying multiple characters. 
+Permissions can be composed together by specifying multiple characters.
 Specifying the permission as 'RW' is considered full access and is analogous to just passing in `~<pattern>`.
 
 For a concrete example, consider a user with ACL rules `+@all ~app1:* (+@read ~app2:*)`.
@@ -437,10 +437,10 @@ However, using key selectors you can define a set of ACL rules that can handle t
 The first pattern is able to match `app1:user` and the second pattern is able to match `app2:user`.
 
 Which type of permission is required for a command is documented through [key specifications](key-specs.md#logical-operation-flags).
-The type of permission is based off the keys logical operation flags. 
-The insert, update, and delete flags map to the write key permission. 
+The type of permission is based off the keys logical operation flags.
+The insert, update, and delete flags map to the write key permission.
 The access flag maps to the read key permission.
-If the key has no logical operation flags, such as `EXISTS`, the user still needs either key read or key write permissions to execute the command. 
+If the key has no logical operation flags, such as `EXISTS`, the user still needs either key read or key write permissions to execute the command.
 
 Note: Side channels to accessing user data are ignored when it comes to evaluating whether read permissions are required to execute a command.
 This means that some write commands that return metadata about the modified key only require write permission on the key to execute.
@@ -660,8 +660,9 @@ For cluster deployments, Valkey 9.0 introduces the Atomic Slot Migration feature
 
 * CLUSTER SYNCSLOTS, @write, SELECT
 
+Since `@write` also includes dangerous commands such as `FLUSHALL` and `FLUSHDB`, you will need to exclude them.
 This translate to the following rules:
 
-    ACL setuser replica-user on >somepassword +sync +psync +replconf +ping +cluster|syncslots +@write +select ~*
+    ACL setuser replica-user on >somepassword +@write ~* -@dangerous +ping +select +psync +replconf +cluster|syncslots -flushall -flushdb -restore -restore-asking
 
 Note that you don't need to configure the replicas to allow the primary to be able to execute any set of commands. The primary is always authenticated as the root user from the point of view of replicas.

--- a/topics/acl.md
+++ b/topics/acl.md
@@ -663,6 +663,6 @@ For cluster deployments, Valkey 9.0 introduces the Atomic Slot Migration feature
 Since `@write` also includes dangerous commands such as `FLUSHALL` and `FLUSHDB`, you will need to exclude them.
 This translate to the following rules:
 
-    ACL setuser replica-user on >somepassword +@write ~* -@dangerous +ping +select +psync +replconf +cluster|syncslots -flushall -flushdb -restore -restore-asking
+    ACL setuser replica-user on >somepassword +@write ~* -@dangerous +ping +select +sync +psync +replconf +cluster|syncslots -flushall -flushdb -restore -restore-asking
 
 Note that you don't need to configure the replicas to allow the primary to be able to execute any set of commands. The primary is always authenticated as the root user from the point of view of replicas.

--- a/topics/acl.md
+++ b/topics/acl.md
@@ -654,7 +654,7 @@ Sentinel does not need to access any key in the database but does use Pub/Sub, s
 
 Valkey replicas require the following commands to be allowed on the primary instance:
 
-* PSYNC, REPLCONF, PING
+* SYNC, PSYNC, REPLCONF, PING
 
 For cluster deployments, Valkey 9.0 introduces the Atomic Slot Migration feature, which requires additional permissions:
 
@@ -662,6 +662,6 @@ For cluster deployments, Valkey 9.0 introduces the Atomic Slot Migration feature
 
 This translate to the following rules:
 
-    ACL setuser replica-user on >somepassword +psync +replconf +ping +cluster|syncslots +@write +select ~*
+    ACL setuser replica-user on >somepassword +sync +psync +replconf +ping +cluster|syncslots +@write +select ~*
 
 Note that you don't need to configure the replicas to allow the primary to be able to execute any set of commands. The primary is always authenticated as the root user from the point of view of replicas.


### PR DESCRIPTION
1. Add permission for `SYNC` (required by Dual Channel Replication)
Dual Channel Replication request a full resync from primary node using `SYNC` ([replication.c#L3187](https://github.com/valkey-io/valkey/blob/unstable/src/replication.c#L3187)):

```c
static int dualChannelReplHandleReplconfReply(connection *conn, sds *err) {
// excluded for brevity
// ...
    if (connSyncWrite(conn, "SYNC\r\n", 6, server.repl_syncio_timeout * 1000) == -1) {
        dualChannelServerLog(LL_WARNING, "I/O error writing to Primary: %s", connGetLastError(conn));
        return C_ERR;
    }
    return C_OK;
}
```



2. Update the permissions required by Atomic Slot Migration. 
The set of ACL rules currently mentioned in the doc does not work if the cluster has data:

```bash
# configure replication users with the set of ACL rules as mentioned in the docs
cat <<EOF > users.acl
user _r on >hello -@all +psync +replconf +ping +cluster|syncslots
EOF
cat <<EOF > config.sh
export ADDITIONAL_OPTIONS="--aclfile /opt/valkey/users.acl --primaryuser _r --primaryauth hello --loadmodule /opt/valkey-audit/build/libvalkeyaudit.so --audit.enabled yes --audit.events all --audit.command_result_mode all"
EOF
./utils/create-cluster/create-cluster start
./utils/create-cluster/create-cluster create

# write some keys
for i in {0000..9999}; do
    valkey-cli -p 30001 -c set $i $i
done

# execute ASM
tnode="$(valkey-cli  -c -p 30001 cluster nodes | grep master|grep -v myself |head -n 1 | awk '{print $1}')"
valkey-cli -c -p 30001 cluster migrateslots slotsrange 0 0 node $tnode
```

Log output of the ASM job:
```plaintext
26589:M 13 Jul 2026 07:34:45.785 * New slot import job created: {name: b5094a3be505334c4888e62f6054456615db3d0a, operation: import, source_node_id: 73bedc79e32275057cec49e9cc5ff0386054ebd5, slots: 0-0}.
26589:M 13 Jul 2026 07:34:45.786 * Slot migration {name: b5094a3be505334c4888e62f6054456615db3d0a, operation: import, source_node_id: 73bedc79e32275057cec49e9cc5ff0386054ebd5, slots: 0-0} state transition: waiting-for-ack -> receiving-snapshot
26589:M 13 Jul 2026 07:34:45.894 # == CRITICAL == This slot-import-target is sending an error to its slot-import-source: '-NOPERM No permissions to access a key' after processing the command 'set'
26589:M 13 Jul 2026 07:34:45.894 * Slot migration {name: b5094a3be505334c4888e62f6054456615db3d0a, operation: import, source_node_id: 73bedc79e32275057cec49e9cc5ff0386054ebd5, slots: 0-0} state transition: receiving-snapshot -> cleaning-up
26589:M 13 Jul 2026 07:34:45.895 * Cleaning up slot migration {name: b5094a3be505334c4888e62f6054456615db3d0a, operation: import, source_node_id: 73bedc79e32275057cec49e9cc5ff0386054ebd5, slots: 0-0} after failed
26589:M 13 Jul 2026 07:34:45.895 * Slot migration {name: b5094a3be505334c4888e62f6054456615db3d0a, operation: import, source_node_id: 73bedc79e32275057cec49e9cc5ff0386054ebd5, slots: 0-0} state transition: cleaning-up -> failed
26589:M 13 Jul 2026 07:34:45.895 # Slot migration {name: b5094a3be505334c4888e62f6054456615db3d0a, operation: import, source_node_id: 73bedc79e32275057cec49e9cc5ff0386054ebd5, slots: 0-0} finished. State: failed, Message: Failed to process command during slot migration. Check logs for more information
```