### PR TITLE
Document HOTKEYS hot key detection command (GET/RESET)

### DIFF
--- a/commands/hotkeys-get.md
+++ b/commands/hotkeys-get.md
@@ -1,0 +1,31 @@
+Returns the hottest keys observed during the last completed detection window,
+ordered by estimated accesses per second (QPS), from highest to lowest.
+
+Hot key detection must be enabled by setting `hotkey-sampling-percentage` above
+`0`; otherwise the command returns an error.
+
+Client key accesses are sampled into a *live* window whose length is
+`hotkey-window-seconds`. When a window completes it is *frozen*, and
+`HOTKEYS GET` always reports that last completed window — never the partial,
+in-progress one. Consequently, immediately after detection is enabled (or after
+[`HOTKEYS RESET`](hotkeys-reset.md)) the command returns an empty result until
+the first window completes.
+
+Each returned entry contains:
+
+* `key`: the key name.
+* `db`: the database in which the key was accessed.
+* `qps`: the estimated accesses per second over the completed window. Because
+  counts are sampled and tracked approximately (Space-Saving), `qps` is an
+  estimate rather than an exact value. It is reconstructed by scaling the
+  sampled count by `100 / hotkey-sampling-percentage` and dividing by
+  `hotkey-window-seconds`.
+
+At most `hotkey-top-k` keys are returned.
+
+Note that `RENAME`, `MOVE`, and `SWAPDB` are not re-attributed: a tracked entry
+is keyed by (key name, database), so after one of these commands the
+accumulated counts remain under the key's previous identity until they age out.
+As these commands are not typically high-frequency, the stale entry is harmless
+— it stops accruing new hits immediately and disappears once the reporting
+window rotates (at most one `hotkey-window-seconds` later).

--- a/commands/hotkeys-get.md
+++ b/commands/hotkeys-get.md
@@ -1,8 +1,8 @@
 Returns the hottest keys observed during the last completed detection window,
 ordered by estimated accesses per second (QPS), from highest to lowest.
 
-Hot key detection must be enabled by setting `hotkey-sampling-percentage` above
-`0`; otherwise the command returns an error.
+Hot key detection must be enabled by setting `hotkey-enabled` to `yes`;
+otherwise the command returns an error.
 
 Client key accesses are sampled into a *live* window whose length is
 `hotkey-window-seconds`. When a window completes it is *frozen*, and

--- a/commands/hotkeys-get.md
+++ b/commands/hotkeys-get.md
@@ -1,8 +1,8 @@
 Returns the hottest keys observed during the last completed detection window,
 ordered by estimated accesses per second (QPS), from highest to lowest.
 
-Hot key detection must be enabled by setting `hotkey-enabled` to `yes`;
-otherwise the command returns an error.
+Hot key detection must be enabled by setting `hotkey-top-k` to a positive value
+(`0`, the default, disables it); otherwise the command returns an error.
 
 Client key accesses are sampled into a *live* window whose length is
 `hotkey-window-seconds`. When a window completes it is *frozen*, and

--- a/commands/hotkeys-get.md
+++ b/commands/hotkeys-get.md
@@ -1,8 +1,10 @@
 Returns the hottest keys observed during the last completed detection window,
 ordered by estimated accesses per second (QPS), from highest to lowest.
 
-Hot key detection must be enabled by setting `hotkeys-top-k` to a positive value
-(`0`, the default, disables it); otherwise the command returns an error.
+Hot key detection is enabled by setting `hotkeys-top-k` to a positive value
+(`0`, the default, disables it). While it is disabled the command succeeds and
+returns an empty array, so a polling client does not need to special-case the
+disabled state.
 
 Client key accesses are sampled into a *live* window whose length is
 `hotkeys-window-seconds`. When a window completes it is *frozen*, and

--- a/commands/hotkeys-get.md
+++ b/commands/hotkeys-get.md
@@ -1,11 +1,11 @@
 Returns the hottest keys observed during the last completed detection window,
 ordered by estimated accesses per second (QPS), from highest to lowest.
 
-Hot key detection must be enabled by setting `hotkey-top-k` to a positive value
+Hot key detection must be enabled by setting `hotkeys-top-k` to a positive value
 (`0`, the default, disables it); otherwise the command returns an error.
 
 Client key accesses are sampled into a *live* window whose length is
-`hotkey-window-seconds`. When a window completes it is *frozen*, and
+`hotkeys-window-seconds`. When a window completes it is *frozen*, and
 `HOTKEYS GET` always reports that last completed window — never the partial,
 in-progress one. Consequently, immediately after detection is enabled (or after
 [`HOTKEYS RESET`](hotkeys-reset.md)) the command returns an empty result until
@@ -18,15 +18,15 @@ Each returned entry contains:
 * `qps`: the estimated accesses per second over the completed window. Because
   counts are sampled and tracked approximately (Space-Saving), `qps` is an
   estimate rather than an exact value. It is reconstructed by scaling the
-  sampled count by `100 / hotkey-sampling-percentage` and dividing by the
-  duration the window actually spanned, which is `hotkey-window-seconds` plus
+  sampled count by `100 / hotkeys-sampling-percentage` and dividing by the
+  duration the window actually spanned, which is `hotkeys-window-seconds` plus
   however late the rotation ran.
 
-At most `hotkey-top-k` keys are returned.
+At most `hotkeys-top-k` keys are returned.
 
 Note that `RENAME`, `MOVE`, and `SWAPDB` are not re-attributed: a tracked entry
 is keyed by (key name, database), so after one of these commands the
 accumulated counts remain under the key's previous identity until they age out.
 As these commands are not typically high-frequency, the stale entry is harmless
 — it stops accruing new hits immediately and disappears once the reporting
-window rotates (at most one `hotkey-window-seconds` later).
+window rotates (at most one `hotkeys-window-seconds` later).

--- a/commands/hotkeys-get.md
+++ b/commands/hotkeys-get.md
@@ -18,8 +18,9 @@ Each returned entry contains:
 * `qps`: the estimated accesses per second over the completed window. Because
   counts are sampled and tracked approximately (Space-Saving), `qps` is an
   estimate rather than an exact value. It is reconstructed by scaling the
-  sampled count by `100 / hotkey-sampling-percentage` and dividing by
-  `hotkey-window-seconds`.
+  sampled count by `100 / hotkey-sampling-percentage` and dividing by the
+  duration the window actually spanned, which is `hotkey-window-seconds` plus
+  however late the rotation ran.
 
 At most `hotkey-top-k` keys are returned.
 

--- a/commands/hotkeys-help.md
+++ b/commands/hotkeys-help.md
@@ -1,0 +1,1 @@
+Returns helpful text about the [`HOTKEYS`](hotkeys.md) subcommands.

--- a/commands/hotkeys-reset.md
+++ b/commands/hotkeys-reset.md
@@ -1,8 +1,8 @@
 Clears all accumulated hot key statistics, discarding both the in-progress
 (live) window and the last completed (frozen) window.
 
-Hot key detection must be enabled by setting `hotkey-enabled` to `yes`;
-otherwise the command returns an error.
+Hot key detection must be enabled by setting `hotkey-top-k` to a positive value
+(`0`, the default, disables it); otherwise the command returns an error.
 
 After `HOTKEYS RESET`, [`HOTKEYS GET`](hotkeys-get.md) returns an empty result
 until the next window completes.

--- a/commands/hotkeys-reset.md
+++ b/commands/hotkeys-reset.md
@@ -1,8 +1,9 @@
 Clears all accumulated hot key statistics, discarding both the in-progress
 (live) window and the last completed (frozen) window.
 
-Hot key detection must be enabled by setting `hotkeys-top-k` to a positive value
-(`0`, the default, disables it); otherwise the command returns an error.
+Hot key detection is enabled by setting `hotkeys-top-k` to a positive value
+(`0`, the default, disables it). While it is disabled there is nothing to clear
+and the command succeeds as a no-op.
 
 After `HOTKEYS RESET`, [`HOTKEYS GET`](hotkeys-get.md) returns an empty result
 until the next window completes.

--- a/commands/hotkeys-reset.md
+++ b/commands/hotkeys-reset.md
@@ -1,8 +1,8 @@
 Clears all accumulated hot key statistics, discarding both the in-progress
 (live) window and the last completed (frozen) window.
 
-Hot key detection must be enabled by setting `hotkey-sampling-percentage` above
-`0`; otherwise the command returns an error.
+Hot key detection must be enabled by setting `hotkey-enabled` to `yes`;
+otherwise the command returns an error.
 
 After `HOTKEYS RESET`, [`HOTKEYS GET`](hotkeys-get.md) returns an empty result
 until the next window completes.

--- a/commands/hotkeys-reset.md
+++ b/commands/hotkeys-reset.md
@@ -1,7 +1,7 @@
 Clears all accumulated hot key statistics, discarding both the in-progress
 (live) window and the last completed (frozen) window.
 
-Hot key detection must be enabled by setting `hotkey-top-k` to a positive value
+Hot key detection must be enabled by setting `hotkeys-top-k` to a positive value
 (`0`, the default, disables it); otherwise the command returns an error.
 
 After `HOTKEYS RESET`, [`HOTKEYS GET`](hotkeys-get.md) returns an empty result

--- a/commands/hotkeys-reset.md
+++ b/commands/hotkeys-reset.md
@@ -1,0 +1,8 @@
+Clears all accumulated hot key statistics, discarding both the in-progress
+(live) window and the last completed (frozen) window.
+
+Hot key detection must be enabled by setting `hotkey-sampling-percentage` above
+`0`; otherwise the command returns an error.
+
+After `HOTKEYS RESET`, [`HOTKEYS GET`](hotkeys-get.md) returns an empty result
+until the next window completes.

--- a/commands/hotkeys.md
+++ b/commands/hotkeys.md
@@ -3,8 +3,10 @@ This is a container command for hot key detection commands.
 Hot key detection samples client key accesses and maintains an approximate
 top-K of the most frequently accessed keys using the Space-Saving algorithm
 over a fixed reporting window. It is disabled by default; enable it by setting
-the `hotkey-enabled` configuration parameter to `yes` (see also
-`hotkey-sampling-percentage`, `hotkey-top-k`, and `hotkey-window-seconds`).
+the `hotkey-top-k` configuration parameter to a positive value, which is both
+the number of keys tracked and the on/off switch — `0` (the default) disables
+detection entirely (see also `hotkey-sampling-percentage` and
+`hotkey-window-seconds`).
 
 To see the list of available subcommands, refer to
 [`HOTKEYS GET`](hotkeys-get.md) and [`HOTKEYS RESET`](hotkeys-reset.md).

--- a/commands/hotkeys.md
+++ b/commands/hotkeys.md
@@ -3,10 +3,10 @@ This is a container command for hot key detection commands.
 Hot key detection samples client key accesses and maintains an approximate
 top-K of the most frequently accessed keys using the Space-Saving algorithm
 over a fixed reporting window. It is disabled by default; enable it by setting
-the `hotkey-top-k` configuration parameter to a positive value, which is both
+the `hotkeys-top-k` configuration parameter to a positive value, which is both
 the number of keys tracked and the on/off switch — `0` (the default) disables
-detection entirely (see also `hotkey-sampling-percentage` and
-`hotkey-window-seconds`).
+detection entirely (see also `hotkeys-sampling-percentage` and
+`hotkeys-window-seconds`).
 
 To see the list of available subcommands, refer to
 [`HOTKEYS GET`](hotkeys-get.md) and [`HOTKEYS RESET`](hotkeys-reset.md).

--- a/commands/hotkeys.md
+++ b/commands/hotkeys.md
@@ -3,8 +3,8 @@ This is a container command for hot key detection commands.
 Hot key detection samples client key accesses and maintains an approximate
 top-K of the most frequently accessed keys using the Space-Saving algorithm
 over a fixed reporting window. It is disabled by default; enable it by setting
-the `hotkey-sampling-percentage` configuration parameter above `0` (see also
-`hotkey-top-k` and `hotkey-window-seconds`).
+the `hotkey-enabled` configuration parameter to `yes` (see also
+`hotkey-sampling-percentage`, `hotkey-top-k`, and `hotkey-window-seconds`).
 
 To see the list of available subcommands, refer to
 [`HOTKEYS GET`](hotkeys-get.md) and [`HOTKEYS RESET`](hotkeys-reset.md).

--- a/commands/hotkeys.md
+++ b/commands/hotkeys.md
@@ -1,0 +1,10 @@
+This is a container command for hot key detection commands.
+
+Hot key detection samples client key accesses and maintains an approximate
+top-K of the most frequently accessed keys using the Space-Saving algorithm
+over a fixed reporting window. It is disabled by default; enable it by setting
+the `hotkey-sampling-percentage` configuration parameter above `0` (see also
+`hotkey-top-k` and `hotkey-window-seconds`).
+
+To see the list of available subcommands, refer to
+[`HOTKEYS GET`](hotkeys-get.md) and [`HOTKEYS RESET`](hotkeys-reset.md).

--- a/commands/hotkeys.md
+++ b/commands/hotkeys.md
@@ -9,4 +9,5 @@ detection entirely (see also `hotkeys-sampling-percentage` and
 `hotkeys-window-seconds`).
 
 To see the list of available subcommands, refer to
-[`HOTKEYS GET`](hotkeys-get.md) and [`HOTKEYS RESET`](hotkeys-reset.md).
+[`HOTKEYS GET`](hotkeys-get.md) and [`HOTKEYS RESET`](hotkeys-reset.md), or run
+[`HOTKEYS HELP`](hotkeys-help.md).

--- a/resp2_replies.json
+++ b/resp2_replies.json
@@ -643,6 +643,13 @@
   "HMSET": [
     "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
+  "HOTKEYS": [],
+  "HOTKEYS GET": [
+    "[Array reply](../topics/protocol.md#arrays): a list of the hottest keys from the last completed detection window, ordered by estimated QPS from highest to lowest. Each element is a flat array of the field-value pairs `key`, `db`, and `qps`. An empty array when no keys were recorded in the last completed window."
+  ],
+  "HOTKEYS RESET": [
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
+  ],
   "HRANDFIELD": [
     "Any of the following:",
     "* [Nil reply](../topics/protocol.md#bulk-strings): if the key doesn't exist",

--- a/resp2_replies.json
+++ b/resp2_replies.json
@@ -645,7 +645,10 @@
   ],
   "HOTKEYS": [],
   "HOTKEYS GET": [
-    "[Array reply](../topics/protocol.md#arrays): a list of the hottest keys from the last completed detection window, ordered by estimated QPS from highest to lowest. Each element is a flat array of the field-value pairs `key`, `db`, and `qps`. An empty array when no keys were recorded in the last completed window."
+    "[Array reply](../topics/protocol.md#arrays): a list of the hottest keys from the last completed detection window, ordered by estimated QPS from highest to lowest. Each element is a flat array of the field-value pairs `key`, `db`, and `qps`. An empty array when no keys were recorded in the last completed window, or when hot key detection is disabled."
+  ],
+  "HOTKEYS HELP": [
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "HOTKEYS RESET": [
     "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."

--- a/resp3_replies.json
+++ b/resp3_replies.json
@@ -645,6 +645,13 @@
   "HMSET": [
     "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
   ],
+  "HOTKEYS": [],
+  "HOTKEYS GET": [
+    "[Array reply](../topics/protocol.md#arrays): a list of the hottest keys from the last completed detection window, ordered by estimated QPS from highest to lowest, where each element is a [Map reply](../topics/protocol.md#maps) with the fields `key`, `db`, and `qps`. An empty array when no keys were recorded in the last completed window."
+  ],
+  "HOTKEYS RESET": [
+    "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."
+  ],
   "HRANDFIELD": [
     "Any of the following:",
     "* [Null reply](../topics/protocol.md#nulls): if the key doesn't exist",

--- a/resp3_replies.json
+++ b/resp3_replies.json
@@ -647,7 +647,10 @@
   ],
   "HOTKEYS": [],
   "HOTKEYS GET": [
-    "[Array reply](../topics/protocol.md#arrays): a list of the hottest keys from the last completed detection window, ordered by estimated QPS from highest to lowest, where each element is a [Map reply](../topics/protocol.md#maps) with the fields `key`, `db`, and `qps`. An empty array when no keys were recorded in the last completed window."
+    "[Array reply](../topics/protocol.md#arrays): a list of the hottest keys from the last completed detection window, ordered by estimated QPS from highest to lowest, where each element is a [Map reply](../topics/protocol.md#maps) with the fields `key`, `db`, and `qps`. An empty array when no keys were recorded in the last completed window, or when hot key detection is disabled."
+  ],
+  "HOTKEYS HELP": [
+    "[Array reply](../topics/protocol.md#arrays): a list of sub-commands and their descriptions."
   ],
   "HOTKEYS RESET": [
     "[Simple string reply](../topics/protocol.md#simple-strings): `OK`."


### PR DESCRIPTION
# Document the HOTKEYS command (server-side hot key detection)

Documentation for the server-side hot key detection feature added in
valkey-io/valkey#3708.

Hot key detection samples client key accesses and maintains an approximate
top-K of the most frequently accessed keys (Space-Saving algorithm) over a
fixed, frozen reporting window, surfaced through a new `HOTKEYS` container
command.

## What's included

Command pages:
- `commands/hotkeys.md` — container overview: what hot key detection does,
  that it is disabled by default, and how to enable it (`hotkey-top-k` set to a
  positive value; `0` disables).
- `commands/hotkeys-get.md` — `HOTKEYS GET`: returns the hottest keys from the
  last completed window ordered by estimated QPS (descending); documents the
  `key`/`db`/`qps` fields and the QPS estimate, the frozen-window semantics
  (empty until the first window completes), the `hotkey-top-k` cap, and the
  RENAME/MOVE/SWAPDB stale-attribution behavior.
- `commands/hotkeys-reset.md` — `HOTKEYS RESET`: clears the live and frozen
  windows.

Reply metadata:
- `resp2_replies.json` / `resp3_replies.json` — reply descriptions for
  `HOTKEYS`, `HOTKEYS GET`, and `HOTKEYS RESET`. `HOTKEYS GET` returns an array
  of entries (RESP3: each entry is a map with `key`, `db`, `qps`; RESP2: the
  equivalent flat field/value array), ordered by QPS descending.

## Related
- Feature PR: valkey-io/valkey#3708
- Clears the `needs-doc-pr` label on that PR.

## Notes
The command metadata (arity, args, flags) is generated from the command JSON in
the main repo, so this PR only adds the human-readable pages and reply
descriptions.
