### PR TITLE
Add Sage (Scala) client

### DIFF
--- a/clients/scala/sage.json
+++ b/clients/scala/sage.json
@@ -1,0 +1,24 @@
+{
+    "name": "sage",
+    "description": "Sage is a Redis & Valkey client for Scala 3: one client for any effect system (ZIO, Cats Effect, Kyo, Ox, Pekko), built on a from-scratch native RESP3 protocol implementation with no Java client wrapped underneath. Supports auto-pipelining, transactions, cluster, sharded pub/sub, client-side caching, replica reads, and TLS.",
+    "repo": "https://github.com/ghostdogpr/sage",
+    "installation": [
+        {
+            "type": "sbt",
+            "command": "libraryDependencies += \"com.github.ghostdogpr\" %% \"sage-client-ox\" % \"0.2.2\""
+        }
+    ],
+    "version": "v0.2.2",
+    "version_released": "2026-07-19",
+    "language": "scala",
+    "license": "Apache-2.0",
+    "read_from_replica": true,
+    "smart_backoff_to_prevent_connection_storm": true,
+    "pubsub_state_restoration": true,
+    "cluster_scan": true,
+    "latency_based_read_from_replica": false,
+    "AZ_based_read_from_replica": false,
+    "client_side_caching": true,
+    "client_capa_redirect": false,
+    "persistent_connection_pool": true
+}


### PR DESCRIPTION
Adds [Sage](https://github.com/ghostdogpr/sage), an actively maintained Apache-2.0 Redis & Valkey client for Scala 3, to the client list. Scala currently has no entry.

Sage implements the RESP3 protocol natively (no wrapped Java client) and supports Valkey 8+, cluster, transactions, sharded pub/sub, client-side caching, replica reads, and TLS. The feature flags in the JSON were checked against the current source.

Docs: https://ghostdogpr.github.io/sage/