### PR TITLE
Clarify SAMPLES option in MEMORY USAGE docs

### DIFF
--- a/commands/memory-usage.md
+++ b/commands/memory-usage.md
@@ -4,9 +4,12 @@ require to be stored in RAM.
 The reported usage is the total of memory allocations for data and
 administrative overheads that a key and its value require.
 
-For nested data types, the optional `SAMPLES` option can be provided, where
-`count` is the number of sampled nested values. The samples are averaged to estimate the total size.
-By default, this option is set to `5`. To sample the all of the nested values, use `SAMPLES 0`.
+For aggregate data types (lists, sets, hashes, sorted sets, and streams), the
+optional `SAMPLES` option can be provided, where `count` is the number of
+sampled elements. The sampled elements are averaged to estimate the total size.
+By default, this option is set to `5`. To sample all of the elements, use
+`SAMPLES 0`. The `SAMPLES` option has no effect on strings, whose size is
+always measured exactly.
 
 ## Examples
 


### PR DESCRIPTION
## Problem

The `MEMORY USAGE` documentation describes the `SAMPLES` option in terms of
"nested data types" and "sampled nested values". As raised in #401, this term
is ambiguous: it is unclear whether "nested" means any non-string type or an
actual nested structure (e.g. Valkey JSON).

## What the code actually does

In `objectComputeSize()` (`src/object.c`), strings are measured directly with no
sampling. Only the aggregate types (list, set, hash, sorted set, stream) walk
their elements and average a sample to estimate the total size. The command
handler (`memoryCommand`) also maps `SAMPLES 0` to "sample everything"
(`if (samples == 0) samples = LLONG_MAX;`) and rejects negative values.

So "nested data types" simply means the aggregate/container types, not nested
structures.

## Fix

Replace the ambiguous wording with the explicit list of aggregate types, clarify
that `SAMPLES` counts elements, and note that it has no effect on strings. Also
fixes the grammar in "To sample the all of the nested values".

## Verification (built from `unstable`)

```
# STRING — SAMPLES accepted but has no effect (no error):
> SET s "hello world"
> MEMORY USAGE s            -> 32
> MEMORY USAGE s SAMPLES 1  -> 32
> MEMORY USAGE s SAMPLES 0  -> 32

# HASH (hashtable-encoded, uneven fields) — SAMPLES changes the estimate:
> MEMORY USAGE h2 SAMPLES 1  -> 9240
> MEMORY USAGE h2 SAMPLES 5  -> 9240
> MEMORY USAGE h2 SAMPLES 0  -> 9304   (sampling all catches the large field)

# Negative SAMPLES:
> MEMORY USAGE h2 SAMPLES -1 -> ERR syntax error
```

Fixes #401
