### PR TITLE
Document the metric "last_successful_sync_duration_ms"

### DIFF
--- a/commands/info.md
+++ b/commands/info.md
@@ -598,7 +598,7 @@ If the instance is a replica, these additional fields are provided:
 *   `master_link_status`: Status of the link (up/down)
 *   `master_last_io_seconds_ago`: Number of seconds since the last interaction
      with primary
-*   `last_successful_sync_duration_ms`: The duration of the last successful full sync in milliseconds   
+*   `last_successful_sync_duration_ms`: The duration of the last successful full sync in milliseconds, or -1  if no successful sync has occurred
 *   `master_sync_in_progress`: Indicate the primary is syncing to the replica
 *   `slave_read_repl_offset`: The read replication offset of the replica instance.
 *   `slave_repl_offset`: The replication offset of the replica instance

--- a/commands/info.md
+++ b/commands/info.md
@@ -598,6 +598,7 @@ If the instance is a replica, these additional fields are provided:
 *   `master_link_status`: Status of the link (up/down)
 *   `master_last_io_seconds_ago`: Number of seconds since the last interaction
      with primary
+*   `last_successful_sync_duration_ms`: The duration of the last successful full sync in milliseconds   
 *   `master_sync_in_progress`: Indicate the primary is syncing to the replica
 *   `slave_read_repl_offset`: The read replication offset of the replica instance.
 *   `slave_repl_offset`: The replication offset of the replica instance

--- a/commands/info.md
+++ b/commands/info.md
@@ -598,7 +598,7 @@ If the instance is a replica, these additional fields are provided:
 *   `master_link_status`: Status of the link (up/down)
 *   `master_last_io_seconds_ago`: Number of seconds since the last interaction
      with primary
-*   `last_successful_sync_duration_ms`: The duration of the last successful full sync in milliseconds, or -1  if no successful sync has occurred
+*   `last_successful_sync_duration_ms`: The duration of the last successful full sync in milliseconds, or -1 if no successful sync has occurred
 *   `master_sync_in_progress`: Indicate the primary is syncing to the replica
 *   `slave_read_repl_offset`: The read replication offset of the replica instance.
 *   `slave_repl_offset`: The replication offset of the replica instance


### PR DESCRIPTION
### What problem is it solving?

- **Spotting replication bottlenecks**: If a new replica takes forever to sync, we want to know exactly how long. It helps us debug whether we're hitting network bandwidth limits, if the replica's disk is struggling to load the RDB, or if the primary is bogged down.
- **Monitoring & Alerting**: If the time it takes to do a full sync suddenly spikes, we want our monitoring tools (like Prometheus/Grafana) to catch it. A sudden jump usually means the dataset has grown significantly or we have a network issue between regions/zones.
- **Testing config changes**: If we're testing different replication setups (like switching between disk-based and diskless replication, or turning on dual-channel replication), we need a simple way to measure if it actually speeds up the initial sync bootstrap. Having `last_successful_sync_duration_ms` in `INFO REPLICATION` gives us a direct measurement.


### How is it Measured?
- **Start Event**: The measurement starts when the replica receives a `+FULLRESYNC` reply from the primary and prepares to initiate the full resync.
- **End Event**: The measurement stops when the replica has finished loading the primary's RDB data into memory (inside the `replicaAfterLoadPrimaryRDB` function).
- **Excluded Phases**: It explicitly excludes the post-RDB-load replication streaming (backlog draining), which is an ongoing phase, to focus purely on the bootstrap duration.


### Metric Behavior
- **On Replicas**: The metric is populated with the elapsed time in milliseconds of the last completed full sync.
- **On Masters or before first Full Sync**: The metric is populated with the value of `-1`