### PR TITLE
Document the ACL DIGEST command

### DIFF
--- a/commands/acl-digest.md
+++ b/commands/acl-digest.md
@@ -1,0 +1,30 @@
+Return a fingerprint of the ACL rules currently in effect, as a hexadecimal string.
+The digest depends only on the rules in effect and not on the order the users were
+created in, so two servers configured alike report the same digest.
+
+The digest covers everything [`ACL LIST`](acl-list.md) reports: the user names, their
+flags, their password hashes, and their command, key and channel rules.
+Any change to any user changes the digest.
+The reply is the same size however many users are configured.
+
+This is meant for confirming which revision of an ACL a server is running.
+A client that manages users through an ACL file can read the digest before and after an
+[`ACL LOAD`](acl-load.md) to tell whether the file it wrote is the one now in effect.
+Comparing the rules themselves is impractical, because the server reports them in its
+own normalized form rather than the form they were written in, so a client would need its
+own copy of the rule parser to compare them.
+
+## Examples
+
+```
+127.0.0.1:6379> ACL DIGEST
+"24ece0a4daea0bcb936b438ae6c9f36db76f57dfc70e00def7b2c26041c49822"
+127.0.0.1:6379> ACL SETUSER alice on >alice ~key:* +get
+OK
+127.0.0.1:6379> ACL DIGEST
+"d06ec40dd1a8e30a4babea1011d4b0daf02dbdf5de95ea18768e15f346a7d385"
+127.0.0.1:6379> ACL DELUSER alice
+(integer) 1
+127.0.0.1:6379> ACL DIGEST
+"24ece0a4daea0bcb936b438ae6c9f36db76f57dfc70e00def7b2c26041c49822"
+```

--- a/resp2_replies.json
+++ b/resp2_replies.json
@@ -8,6 +8,9 @@
   "ACL DELUSER": [
     "[Integer reply](../topics/protocol.md#integers): the number of users that were deleted. This number will not always match the number of arguments since certain users may not exist."
   ],
+  "ACL DIGEST": [
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the digest of the ACL rules currently in effect, as a hexadecimal string."
+  ],
   "ACL DRYRUN": [
     "Any of the following:",
     "* [Simple string reply](../topics/protocol.md#simple-strings): `OK` on success.",

--- a/resp3_replies.json
+++ b/resp3_replies.json
@@ -8,6 +8,9 @@
   "ACL DELUSER": [
     "[Integer reply](../topics/protocol.md#integers): the number of users that were deleted. This number will not always match the number of arguments since certain users may not exist."
   ],
+  "ACL DIGEST": [
+    "[Bulk string reply](../topics/protocol.md#bulk-strings): the digest of the ACL rules currently in effect, as a hexadecimal string."
+  ],
   "ACL DRYRUN": [
     "Any of the following:",
     "* [Simple string reply](../topics/protocol.md#simple-strings): `OK` on success.",


### PR DESCRIPTION
Documentation for `ACL DIGEST`, the command added in valkey-io/valkey#4446 and requested in valkey-io/valkey#4355.

`ACL DIGEST` returns a fingerprint of the ACL rules currently in effect, as a hexadecimal string. A controller that manages users through an ACL file can read it before and after an `ACL LOAD` and tell whether the file it wrote is the one now in effect. Comparing the rules instead does not work, because the server reports them in its own normalized form rather than the form they were written in.

This adds `commands/acl-digest.md` and the matching entries in `resp2_replies.json` and `resp3_replies.json`.

It should land after or together with the server PR. Until the command JSON exists in valkey, the Makefile leaves the page out of the build, since `commands` is the intersection of the Markdown pages and the JSON files under `VALKEY_ROOT/src/commands`, so nothing breaks in the meantime.

## Checks

The example output on the page was taken from a server built from the command branch rather than written by hand.

With `VALKEY_ROOT` pointed at that branch, `make` builds `_build/man/man3/acl-digest.3valkey.gz`. The summary, complexity, ACL categories, since version and reply description all resolve, and the links to `ACL LIST` and `ACL LOAD` render as man page references.

`utils/check-links.pl` reports no broken links, and spellchecker-cli is clean against `.spellcheckerrc.yml`.
