### PR TITLE
Update sorted set docs: skiplist replaced by B+ tree

### DIFF
--- a/commands/object-encoding.md
+++ b/commands/object-encoding.md
@@ -29,7 +29,8 @@ Valkey objects can be encoded in different ways:
 
 * Sorted Sets can be encoded as:
 
-    - `skiplist`, normal sorted set encoding.
+    - `btree`, normal sorted set encoding.
+    - `skiplist`, the name used for the normal sorted set encoding before it was replaced by a B+ tree.
     - `listpack`, a space-efficient encoding used for small sorted sets.
 
 * Streams can be encoded as:

--- a/topics/sorted-sets.md
+++ b/topics/sorted-sets.md
@@ -48,7 +48,7 @@ With sorted sets it is trivial to return a list of hackers sorted by their
 birth year because actually *they are already sorted*.
 
 Implementation note: Sorted sets are implemented via a
-dual-ported data structure containing both a skip list and a hash table, so
+dual-ported data structure containing both a B+ tree and a hash table, so
 every time we add an element Valkey performs an O(log(N)) operation. That's
 good, but when we ask for sorted elements Valkey does not have to do any work at
 all, it's already sorted. Note that the `ZRANGE` order is low to high, while the `ZREVRANGE` order is high to low:

--- a/wordlist
+++ b/wordlist
@@ -104,6 +104,7 @@ breakpoint
 broadcasted
 brpop
 bt
+btree
 btree1-az
 C[1-9]
 cacert


### PR DESCRIPTION
The sorted set skiplist was replaced with a B+ tree in valkey-io/valkey#4359. Update two places in valkey-doc:

1. commands/object-encoding.md: OBJECT ENCODING now returns 'btree' for normal sorted sets. Keep 'skiplist' as a historical note following the existing zipmap precedent.

2. topics/sorted-sets.md: Replace 'skip list' with 'B+ tree' in the implementation note. The O(log N) claim remains correct.

3. wordlist: Add 'btree' so the spellcheck workflow passes.

Closes valkey-io/valkey-doc#466