### PR TITLE
Add LibreDB Studio to the GUI tools list

### DIFF
--- a/tools/gui/github.com/libredb/libredb-studio.json
+++ b/tools/gui/github.com/libredb/libredb-studio.json
@@ -1,0 +1,5 @@
+{
+    "name": "LibreDB Studio",
+    "description": "Self-hosted, browser-based database GUI with Valkey support: non-blocking SCAN key browser, INFO health and metrics, SLOWLOG and CLIENT LIST panels",
+    "homepage": "https://libredb.org"
+}


### PR DESCRIPTION
LibreDB Studio is an open source SQL IDE that runs in the browser and is self-hosted next to the database rather than installed on a laptop. It connects to Valkey through ioredis, so this adds it under tools/gui next to the other GUI clients.

Against a Valkey server it groups key prefixes into a browsable tree using a non-blocking SCAN rather than KEYS, reads health and server metrics from INFO, the slow command log from SLOWLOG GET, and connected clients from CLIENT LIST. Commands are typed and run directly, either as plain text or as a JSON command object.

One caveat so it is not a surprise later: the overview panel reads redis_version from INFO, so a Valkey 9.1.1 server displays 7.2.4, the compatibility level rather than the Valkey release. Everything else was measured against Valkey 9.1.1 and behaved the same as it does against Redis.

Source and license: https://github.com/libredb/libredb-studio, MIT.
