### PR TITLE
Add CI guard and Makefile targets for module API reference docs

### DIFF
--- a/.github/workflows/check-modules-api-ref.yml
+++ b/.github/workflows/check-modules-api-ref.yml
@@ -1,0 +1,116 @@
+name: Check Module API Reference
+
+on:
+  push:
+    paths:
+      - 'topics/modules-api-ref.md'
+      - '.github/workflows/check-modules-api-ref.yml'
+  pull_request:
+    paths:
+      - 'topics/modules-api-ref.md'
+      - '.github/workflows/check-modules-api-ref.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: check-modules-api-ref-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify-module-api-doc:
+    name: Verify Module API Reference
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout valkey-doc
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          path: valkey-doc
+
+      - name: Determine Valkey release version
+        id: version
+        working-directory: valkey-doc
+        run: |
+          VERSION=$(grep -E '^VERSION \?=' Makefile | awk '{print $NF}')
+          echo "version=${VERSION:-unstable}" >> $GITHUB_OUTPUT
+
+      - name: Checkout valkey
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          repository: valkey-io/valkey
+          path: valkey
+          ref: ${{ steps.version.outputs.version }}
+          fetch-depth: 0
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+
+      - name: Verify topics/modules-api-ref.md matches module.c
+        working-directory: valkey-doc
+        run: |
+          DOC_FILE="topics/modules-api-ref.md"
+          VALKEY_DIR="../valkey"
+          GEN_SCRIPT="utils/generate-module-api-doc.rb"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          if [ ! -f "$VALKEY_DIR/$GEN_SCRIPT" ]; then
+            echo "::error::Generator script $VALKEY_DIR/$GEN_SCRIPT not found!"
+            exit 1
+          fi
+
+          # Delete revoked tag 8.0.8 (mistakenly tagged on unstable and revoked in 8.0.9)
+          # so generate-module-api-doc.rb does not attribute APIs to 8.0.8.
+          git -C "$VALKEY_DIR" tag -d 8.0.8 >/dev/null 2>&1 || true
+
+          TMP_FILE=$(mktemp)
+          trap 'rm -f "$TMP_FILE"' EXIT
+
+          echo "Verifying $DOC_FILE against valkey release tag/ref $VERSION..."
+          ruby "$VALKEY_DIR/$GEN_SCRIPT" > "$TMP_FILE"
+
+          if cmp -s "$DOC_FILE" "$TMP_FILE"; then
+            echo "✓ $DOC_FILE matches generated documentation from release $VERSION."
+            exit 0
+          fi
+
+          # If it doesn't match release tag, also test against unstable
+          if [ "$VERSION" != "unstable" ]; then
+            echo "$DOC_FILE did not match $VERSION. Checking against unstable branch..."
+            git -C "$VALKEY_DIR" checkout unstable >/dev/null 2>&1 || true
+            git -C "$VALKEY_DIR" tag -d 8.0.8 >/dev/null 2>&1 || true
+            ruby "$VALKEY_DIR/$GEN_SCRIPT" > "$TMP_FILE"
+            if cmp -s "$DOC_FILE" "$TMP_FILE"; then
+              echo "✓ $DOC_FILE matches generated documentation from unstable branch."
+              exit 0
+            fi
+          fi
+
+          echo "::error file=$DOC_FILE::$DOC_FILE does not match the generated documentation from module.c."
+          echo ""
+          echo "========================================================================"
+          echo "ERROR: $DOC_FILE is auto-generated from doc comments in"
+          echo "src/module.c in the valkey-io/valkey repository using $GEN_SCRIPT."
+          echo ""
+          echo "Direct/manual edits to $DOC_FILE are not accepted."
+          echo ""
+          echo "Note: $DOC_FILE is updated automatically during version releases"
+          echo "to match the release version ($VERSION). Intermediate updates from"
+          echo "unstable should not be committed ahead of a release."
+          echo ""
+          echo "To update the Module API documentation:"
+          echo "  1. Submit your doc comment updates to src/module.c in the Valkey repository:"
+          echo "     https://github.com/valkey-io/valkey"
+          echo "  2. The documentation will be automatically regenerated on the next release."
+          echo "========================================================================"
+          echo ""
+          echo "Diff between $DOC_FILE and generated doc (from $VERSION):"
+          git -C "$VALKEY_DIR" checkout "$VERSION" >/dev/null 2>&1 || true
+          git -C "$VALKEY_DIR" tag -d 8.0.8 >/dev/null 2>&1 || true
+          ruby "$VALKEY_DIR/$GEN_SCRIPT" > "$TMP_FILE"
+          diff -u "$DOC_FILE" "$TMP_FILE" || true
+
+          exit 1

--- a/Makefile
+++ b/Makefile
@@ -268,3 +268,23 @@ distclean:
 install: install-man
 
 uninstall: uninstall-man
+
+# ---- Modules API Reference ----
+
+.PHONY: generate-modules-api-ref verify-modules-api-ref
+
+generate-modules-api-ref:
+	@git -C $(VALKEY_ROOT) tag -d 8.0.8 2>/dev/null || true
+	ruby $(VALKEY_ROOT)/utils/generate-module-api-doc.rb > topics/modules-api-ref.md
+
+verify-modules-api-ref:
+	@git -C $(VALKEY_ROOT) tag -d 8.0.8 2>/dev/null || true
+	@ruby $(VALKEY_ROOT)/utils/generate-module-api-doc.rb > topics/modules-api-ref.md.tmp
+	@if ! cmp -s topics/modules-api-ref.md topics/modules-api-ref.md.tmp; then \
+		echo "ERROR: topics/modules-api-ref.md does not match generated output from $(VALKEY_ROOT)/src/module.c"; \
+		diff -u topics/modules-api-ref.md topics/modules-api-ref.md.tmp; \
+		rm -f topics/modules-api-ref.md.tmp; \
+		exit 1; \
+	fi
+	@rm -f topics/modules-api-ref.md.tmp
+	@echo "topics/modules-api-ref.md matches $(VALKEY_ROOT)/src/module.c"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ lines of three dashes (`---`). These are YAML fields of which we use only the
 `title` field (and possibly `linkTitle`). The title field is used instead of an
 H1 heading in each of the pages.
 
+#### Module API Reference
+
+The Module API reference page (`topics/modules-api-ref.md`) is **auto-generated** from doc comments in `src/module.c` in the [Valkey core repository](https://github.com/valkey-io/valkey) using `utils/generate-module-api-doc.rb`.
+
+**Do not edit `topics/modules-api-ref.md` directly.** Any modifications to the Module API documentation must be made to the doc comments in `src/module.c` in `valkey-io/valkey`.
+
+**Release-only updates**: This file is updated automatically as part of the release process when a new Valkey version is published (matching `VERSION` in `Makefile`). Do not open PRs to sync `topics/modules-api-ref.md` from `unstable` ahead of a release, as intermediate `unstable` changes will cause CI verification to fail when subsequent commits land on `unstable`.
+
+To regenerate or verify the documentation against a local Valkey checkout:
+
+```bash
+# Regenerate topics/modules-api-ref.md
+make generate-modules-api-ref VALKEY_ROOT=path/to/valkey
+
+# Verify topics/modules-api-ref.md matches src/module.c
+make verify-modules-api-ref VALKEY_ROOT=path/to/valkey
+```
+
+
 ### Clients, modules, libraries, tools
 
 We maintain links to clients, modules, libraries and tools in various languages in

--- a/topics/modules-api-ref.md
+++ b/topics/modules-api-ref.md
@@ -8333,7 +8333,7 @@ be used again.
     ValkeyModuleString *ValkeyModule_DefragValkeyModuleString(ValkeyModuleDefragCtx *ctx,
                                                               ValkeyModuleString *str);
 
-**Available since:** 7.2.5
+**Available since:** 7.2.4
 
 Defrag a `ValkeyModuleString` previously allocated by [`ValkeyModule_Alloc`](#ValkeyModule_Alloc), [`ValkeyModule_Calloc`](#ValkeyModule_Calloc), etc.
 See [`ValkeyModule_DefragAlloc()`](#ValkeyModule_DefragAlloc) for more information on how the defragmentation process


### PR DESCRIPTION
The `topics/modules-api-ref.md` page is programmatically generated from doc comments in `src/module.c` in the Valkey core repository using `utils/generate-module-api-doc.rb`. Manual edits made directly to `topics/modules-api-ref.md` are easily lost during regeneration or lead to discrepancies between the core codebase comments and the documentation.

This commit adds:

1. A GitHub Actions workflow (`.github/workflows/check-modules-api-ref.yml`) that verifies `topics/modules-api-ref.md` matches the generated output from `src/module.c` in `valkey-io/valkey` (at the release tag or unstable) whenever `topics/modules-api-ref.md` is modified in a PR.
2. Handles skipping the revoked 8.0.8 tag (which was mistakenly tagged on unstable) so unreleased APIs are not erroneously attributed to 8.0.8.
3. Makefile targets `generate-modules-api-ref` and `verify-modules-api-ref` to easily regenerate and verify the documentation locally.
4. Documentation in `README.md` explaining that `topics/modules-api-ref.md` is auto-generated and instructions on how to contribute module doc updates via `src/module.c`.

Note that we should still only do the bump on release, or the CI will have issues on unrelated PRs when the `unstable` branch incorporates new module API changes.