### PR TITLE
docs: fix 'allows to build' grammar in cluster reshard note

### DIFF
--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -548,7 +548,7 @@ line like the following:
 
     valkey-cli --cluster reshard <host>:<port> --cluster-from <node-id> --cluster-to <node-id> --cluster-slots <number of slots> --cluster-yes
 
-This allows to build some automatism if you are likely to reshard often,
+This allows you to build some automatism if you are likely to reshard often,
 however currently there is no way for `valkey-cli` to automatically
 rebalance the cluster checking the distribution of keys across the cluster
 nodes and intelligently moving slots as needed. This feature will be added


### PR DESCRIPTION
Fixes #484

Fix non-idiomatic grammar in the cluster reshard automation note:

- before: "This allows to build some automatism"
- after: "This allows you to build some automatism"

Docs-only, one-line change.